### PR TITLE
chore: automate publishing

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,23 @@
+name: Prepare release
+on:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  prepare-release:
+    name: Prepare release
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    if: contains(github.event.head_commit.message, 'chore(release)') == false
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+      - uses: bluefireteam/melos-action@v3
+        with:
+          run-versioning: true
+          publish-dry-run: true
+          create-pr: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Publish packages
+on:
+  push:
+    branches:
+        - master
+        - main
+
+jobs:
+ publish-packages:
+   name: Publish packages
+   permissions:
+     contents: write
+     id-token: write # Required for authentication using OIDC
+   runs-on: [ ubuntu-latest ]
+   if: contains(github.event.head_commit.message, 'chore(release)')
+   steps:
+     - uses: actions/checkout@v3
+     - uses: subosito/flutter-action@v2
+     - uses: bluefireteam/melos-action@v3
+       with:
+         publish: true

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -2,7 +2,7 @@ name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
 version: 0.1.0
 homepage: https://www.powersync.com/
-repository: https://github.com/powersync-ja/powersync-dart/packages/powersync_attachments_helper.dart
+repository: https://github.com/powersync-ja/powersync-dart/packages/powersync_attachments_helper
 
 environment:
   sdk: ^3.2.3


### PR DESCRIPTION
## Description
Create automated publishing based on merges to main

## Work Done
* Added prepare_realease action which versions and creates PR with title `chore(release): ...` for publishing
* Added a publish action which publishes to pub.dev whenever a PR with `chore(release): ...` is merged to main
* Fixed github repo reference