### PR TITLE
chore: remove versioning from melos release workflow

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -21,6 +21,5 @@ jobs:
           channel: 'stable'
       - uses: bluefireteam/melos-action@v3
         with:
-          run-versioning: true
           publish-dry-run: true
           create-pr: true


### PR DESCRIPTION
## Description
Since we don't use conventional commits versioning using melos won't help so all we want is it to create a PR to publish