### PR TITLE
Fix reverting failed deletes

### DIFF
--- a/packages/powersync/lib/src/schema_logic.dart
+++ b/packages/powersync/lib/src/schema_logic.dart
@@ -53,6 +53,15 @@ FOR EACH ROW
 BEGIN
   DELETE FROM $internalNameE WHERE id = OLD.id;
   INSERT INTO ps_crud(tx_id, data) SELECT current_tx, json_object('op', 'DELETE', 'type', ${quoteString(type)}, 'id', OLD.id) FROM ps_tx WHERE id = 1;
+  INSERT INTO ps_oplog(bucket, op_id, op, row_type, row_id, hash, superseded)
+    SELECT '\$local',
+           1,
+           'REMOVE',
+           ${quoteString(type)},
+           OLD.id,
+           0,
+           0;
+  INSERT OR REPLACE INTO ps_buckets(name, pending_delete, last_op, target_op) VALUES('\$local', 1, 0, $maxOpId);
 END""",
     """
 CREATE TRIGGER ${quoteIdentifier('ps_view_insert_$viewName')}


### PR DESCRIPTION
If a row is modified locally, and the upload batch is completed without the update is not applied on the server (e.g. due to validation or RLS error), the client needs to revert the local update.

This was correctly implemented for INSERT and UPDATE statements, but not for DELETE. The row would remain deleted on the client, instead of re-creating the row after syncing. This fixes the issue by handling deletes in the same way as inserts and updates - storing a marker record in `ps_oplog` until the next sync completes.