### PR TITLE
Handle missing camera in demo

### DIFF
--- a/demos/supabase-todolist/lib/attachments/camera_helpers.dart
+++ b/demos/supabase-todolist/lib/attachments/camera_helpers.dart
@@ -1,5 +1,6 @@
 import 'package:camera/camera.dart';
 import 'package:flutter/widgets.dart';
+import 'package:powersync_flutter_demo/powersync.dart';
 
 late final CameraDescription? camera;
 
@@ -8,8 +9,14 @@ Future<CameraDescription?> setupCamera() async {
   // can be called before `runApp()`
   WidgetsFlutterBinding.ensureInitialized();
   // Obtain a list of the available cameras on the device.
-  final cameras = await availableCameras();
-  // Get a specific camera from the list of available cameras.
-  final camera = cameras.isNotEmpty ? cameras.first : null;
-  return camera;
+  try {
+    final cameras = await availableCameras();
+    // Get a specific camera from the list of available cameras.
+    final camera = cameras.isNotEmpty ? cameras.first : null;
+    return camera;
+  } catch (e) {
+    // Camera is not supported on all platforms
+    log.warning('Failed to setup camera: $e');
+    return null;
+  }
 }

--- a/demos/supabase-todolist/lib/attachments/camera_helpers.dart
+++ b/demos/supabase-todolist/lib/attachments/camera_helpers.dart
@@ -2,8 +2,6 @@ import 'package:camera/camera.dart';
 import 'package:flutter/widgets.dart';
 import 'package:powersync_flutter_demo/powersync.dart';
 
-late final CameraDescription? camera;
-
 Future<CameraDescription?> setupCamera() async {
   // Ensure that plugin services are initialized so that `availableCameras()`
   // can be called before `runApp()`

--- a/demos/supabase-todolist/lib/attachments/photo_capture_widget.dart
+++ b/demos/supabase-todolist/lib/attachments/photo_capture_widget.dart
@@ -3,15 +3,16 @@ import 'dart:async';
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 import 'package:powersync/powersync.dart' as powersync;
-import 'package:powersync_flutter_demo/attachments/camera_helpers.dart';
 import 'package:powersync_flutter_demo/attachments/queue.dart';
 import 'package:powersync_flutter_demo/models/todo_item.dart';
 import 'package:powersync_flutter_demo/powersync.dart';
 
 class TakePhotoWidget extends StatefulWidget {
   final String todoId;
+  final CameraDescription camera;
 
-  const TakePhotoWidget({super.key, required this.todoId});
+  const TakePhotoWidget(
+      {super.key, required this.todoId, required this.camera});
 
   @override
   State<StatefulWidget> createState() {
@@ -28,7 +29,7 @@ class _TakePhotoWidgetState extends State<TakePhotoWidget> {
     super.initState();
 
     _cameraController = CameraController(
-      camera!,
+      widget.camera,
       ResolutionPreset.medium,
     );
 

--- a/demos/supabase-todolist/lib/attachments/photo_widget.dart
+++ b/demos/supabase-todolist/lib/attachments/photo_widget.dart
@@ -38,7 +38,7 @@ class _PhotoWidgetState extends State<PhotoWidget> {
 
     bool fileExists = await File(photoPath).exists();
 
-    return _ResolvedPhotoState(photoPath: null, fileExists: fileExists);
+    return _ResolvedPhotoState(photoPath: photoPath, fileExists: fileExists);
   }
 
   @override
@@ -83,7 +83,7 @@ class _PhotoWidgetState extends State<PhotoWidget> {
           }
 
           String? filePath = data.photoPath;
-          bool fileIsDownloading = data.fileExists;
+          bool fileIsDownloading = !data.fileExists;
 
           if (fileIsDownloading) {
             return const Text("Downloading...");

--- a/demos/supabase-todolist/lib/attachments/photo_widget.dart
+++ b/demos/supabase-todolist/lib/attachments/photo_widget.dart
@@ -24,29 +24,22 @@ class PhotoWidget extends StatefulWidget {
 class _ResolvedPhotoState {
   String? photoPath;
   bool fileExists;
-  CameraDescription? camera;
 
-  _ResolvedPhotoState(
-      {required this.photoPath,
-      required this.fileExists,
-      required this.camera});
+  _ResolvedPhotoState({required this.photoPath, required this.fileExists});
 }
 
 class _PhotoWidgetState extends State<PhotoWidget> {
   late String photoPath;
 
   Future<_ResolvedPhotoState> _getPhotoState(photoId) async {
-    final camera = await setupCamera();
     if (photoId == null) {
-      return _ResolvedPhotoState(
-          photoPath: null, fileExists: false, camera: camera);
+      return _ResolvedPhotoState(photoPath: null, fileExists: false);
     }
     photoPath = await attachmentQueue.getLocalUri('$photoId.jpg');
 
     bool fileExists = await File(photoPath).exists();
 
-    return _ResolvedPhotoState(
-        photoPath: null, fileExists: fileExists, camera: camera);
+    return _ResolvedPhotoState(photoPath: null, fileExists: fileExists);
   }
 
   @override
@@ -60,8 +53,11 @@ class _PhotoWidgetState extends State<PhotoWidget> {
           }
           final data = snapshot.data!;
           Widget takePhotoButton = ElevatedButton(
-            onPressed: () {
-              if (data.camera == null) {
+            onPressed: () async {
+              final camera = await setupCamera();
+              if (!mounted) return;
+
+              if (camera == null) {
                 const snackBar = SnackBar(
                   content: Text('No camera available'),
                   backgroundColor:
@@ -71,11 +67,12 @@ class _PhotoWidgetState extends State<PhotoWidget> {
                 ScaffoldMessenger.of(context).showSnackBar(snackBar);
                 return;
               }
+
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (context) => TakePhotoWidget(
-                      todoId: widget.todo.id, camera: data.camera!),
+                  builder: (context) =>
+                      TakePhotoWidget(todoId: widget.todo.id, camera: camera),
                 ),
               );
             },

--- a/demos/supabase-todolist/lib/attachments/photo_widget.dart
+++ b/demos/supabase-todolist/lib/attachments/photo_widget.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 
+import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
+import 'package:powersync_flutter_demo/attachments/camera_helpers.dart';
 import 'package:powersync_flutter_demo/attachments/photo_capture_widget.dart';
 import 'package:powersync_flutter_demo/attachments/queue.dart';
 
@@ -19,31 +21,61 @@ class PhotoWidget extends StatefulWidget {
   }
 }
 
+class _ResolvedPhotoState {
+  String? photoPath;
+  bool fileExists;
+  CameraDescription? camera;
+
+  _ResolvedPhotoState(
+      {required this.photoPath,
+      required this.fileExists,
+      required this.camera});
+}
+
 class _PhotoWidgetState extends State<PhotoWidget> {
   late String photoPath;
 
-  Future<Map<String, dynamic>> _getPhoto(photoId) async {
+  Future<_ResolvedPhotoState> _getPhotoState(photoId) async {
+    final camera = await setupCamera();
     if (photoId == null) {
-      return {"photoPath": null, "fileExists": false};
+      return _ResolvedPhotoState(
+          photoPath: null, fileExists: false, camera: camera);
     }
     photoPath = await attachmentQueue.getLocalUri('$photoId.jpg');
 
     bool fileExists = await File(photoPath).exists();
 
-    return {"photoPath": photoPath, "fileExists": fileExists};
+    return _ResolvedPhotoState(
+        photoPath: null, fileExists: fileExists, camera: camera);
   }
 
   @override
   Widget build(BuildContext context) {
     return FutureBuilder(
-        future: _getPhoto(widget.todo.photoId),
-        builder: (BuildContext context, AsyncSnapshot snapshot) {
+        future: _getPhotoState(widget.todo.photoId),
+        builder: (BuildContext context,
+            AsyncSnapshot<_ResolvedPhotoState> snapshot) {
+          if (snapshot.data == null) {
+            return Container();
+          }
+          final data = snapshot.data!;
           Widget takePhotoButton = ElevatedButton(
             onPressed: () {
+              if (data.camera == null) {
+                const snackBar = SnackBar(
+                  content: Text('No camera available'),
+                  backgroundColor:
+                      Colors.red, // Optional: to highlight it's an error
+                );
+
+                ScaffoldMessenger.of(context).showSnackBar(snackBar);
+                return;
+              }
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (context) => TakePhotoWidget(todoId: widget.todo.id),
+                  builder: (context) => TakePhotoWidget(
+                      todoId: widget.todo.id, camera: data.camera!),
                 ),
               );
             },
@@ -54,29 +86,25 @@ class _PhotoWidgetState extends State<PhotoWidget> {
             return takePhotoButton;
           }
 
-          if (snapshot.hasData) {
-            String filePath = snapshot.data['photoPath'];
-            bool fileIsDownloading = !snapshot.data['fileExists'];
+          String? filePath = data.photoPath;
+          bool fileIsDownloading = data.fileExists;
 
-            if (fileIsDownloading) {
-              return const Text("Downloading...");
-            }
-
-            File imageFile = File(filePath);
-            int lastModified = imageFile.existsSync()
-                ? imageFile.lastModifiedSync().millisecondsSinceEpoch
-                : 0;
-            Key key = ObjectKey('$filePath:$lastModified');
-
-            return Image.file(
-              key: key,
-              imageFile,
-              width: 50,
-              height: 50,
-            );
+          if (fileIsDownloading) {
+            return const Text("Downloading...");
           }
 
-          return takePhotoButton;
+          File imageFile = File(filePath!);
+          int lastModified = imageFile.existsSync()
+              ? imageFile.lastModifiedSync().millisecondsSinceEpoch
+              : 0;
+          Key key = ObjectKey('$filePath:$lastModified');
+
+          return Image.file(
+            key: key,
+            imageFile,
+            width: 50,
+            height: 50,
+          );
         });
   }
 }

--- a/demos/supabase-todolist/lib/attachments/photo_widget.dart
+++ b/demos/supabase-todolist/lib/attachments/photo_widget.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 import 'package:powersync_flutter_demo/attachments/camera_helpers.dart';
 import 'package:powersync_flutter_demo/attachments/photo_capture_widget.dart';

--- a/demos/supabase-todolist/lib/main.dart
+++ b/demos/supabase-todolist/lib/main.dart
@@ -2,7 +2,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 import 'package:powersync_flutter_demo/app_config.dart';
-import 'package:powersync_flutter_demo/attachments/camera_helpers.dart';
 import 'package:powersync_flutter_demo/attachments/queue.dart';
 import 'package:powersync_flutter_demo/models/schema.dart';
 
@@ -37,8 +36,6 @@ void main() async {
   if (AppConfig.supabaseStorageBucket.isNotEmpty) {
     initializeAttachmentQueue(db);
   }
-
-  camera = await setupCamera();
 
   final loggedIn = isLoggedIn();
   runApp(MyApp(loggedIn: loggedIn));

--- a/demos/supabase-todolist/lib/widgets/todo_item_widget.dart
+++ b/demos/supabase-todolist/lib/widgets/todo_item_widget.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:powersync_flutter_demo/app_config.dart';
-import 'package:powersync_flutter_demo/attachments/camera_helpers.dart';
 import 'package:powersync_flutter_demo/attachments/photo_widget.dart';
 import 'package:powersync_flutter_demo/attachments/queue.dart';
 
@@ -54,7 +53,7 @@ class TodoItemWidget extends StatelessWidget {
               onPressed: () async => await deleteTodo(todo),
               tooltip: 'Delete Item',
             ),
-            AppConfig.supabaseStorageBucket.isEmpty || camera == null
+            AppConfig.supabaseStorageBucket.isEmpty
                 ? Container()
                 : PhotoWidget(todo: todo),
           ],

--- a/demos/supabase-todolist/lib/widgets/todo_item_widget.dart
+++ b/demos/supabase-todolist/lib/widgets/todo_item_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:powersync_flutter_demo/app_config.dart';
+import 'package:powersync_flutter_demo/attachments/camera_helpers.dart';
 import 'package:powersync_flutter_demo/attachments/photo_widget.dart';
 import 'package:powersync_flutter_demo/attachments/queue.dart';
 
@@ -53,7 +54,7 @@ class TodoItemWidget extends StatelessWidget {
               onPressed: () async => await deleteTodo(todo),
               tooltip: 'Delete Item',
             ),
-            AppConfig.supabaseStorageBucket.isEmpty
+            AppConfig.supabaseStorageBucket.isEmpty || camera == null
                 ? Container()
                 : PhotoWidget(todo: todo),
           ],


### PR DESCRIPTION
The attachments demo uses the camera, which is only available on Android and iOS.

This changes the camera setup to only run when taking a photo, and display an error if it cannot be initialized (e.g. on desktop).

![image](https://github.com/powersync-ja/powersync.dart/assets/94081/7e12dcea-e9dc-4168-8983-63f3226a0fc4)
