### PR TITLE
Improve connection status

### DIFF
--- a/demos/supabase-anonymous-auth/lib/widgets/status_app_bar.dart
+++ b/demos/supabase-anonymous-auth/lib/widgets/status_app_bar.dart
@@ -61,13 +61,13 @@ Widget _makeIcon(String text, IconData icon) {
 }
 
 Widget _getStatusIcon(SyncStatus status) {
-  if (status.exception != null) {
-    // The exception message is verbose, could be replaced with something
+  if (status.anyError != null) {
+    // The error message is verbose, could be replaced with something
     // more user-friendly
     if (!status.connected) {
-      return _makeIcon(status.exception!.toString(), Icons.cloud_off);
+      return _makeIcon(status.anyError!.toString(), Icons.cloud_off);
     } else {
-      return _makeIcon(status.exception!.toString(), Icons.sync_problem);
+      return _makeIcon(status.anyError!.toString(), Icons.sync_problem);
     }
   } else if (status.connecting) {
     return _makeIcon('Connecting', Icons.cloud_sync_outlined);

--- a/demos/supabase-anonymous-auth/lib/widgets/status_app_bar.dart
+++ b/demos/supabase-anonymous-auth/lib/widgets/status_app_bar.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:powersync/powersync.dart';
 import '../powersync.dart';
@@ -39,22 +40,48 @@ class _StatusAppBarState extends State<StatusAppBar> {
 
   @override
   Widget build(BuildContext context) {
-    const connectedIcon = IconButton(
-      icon: Icon(Icons.wifi),
-      tooltip: 'Connected',
-      onPressed: null,
-    );
-    const disconnectedIcon = IconButton(
-      icon: Icon(Icons.wifi_off),
-      tooltip: 'Not connected',
-      onPressed: null,
-    );
+    final statusIcon = _getStatusIcon(_connectionState);
 
     return AppBar(
       title: Text(widget.title),
       actions: <Widget>[
-        _connectionState.connected ? connectedIcon : disconnectedIcon
+        statusIcon,
+        // Make some space for the "Debug" banner, so that the status
+        // icon isn't hidden
+        if (kDebugMode) _makeIcon('Debug mode', Icons.developer_mode),
       ],
     );
+  }
+}
+
+Widget _makeIcon(String text, IconData icon) {
+  return Tooltip(
+      message: text,
+      child: SizedBox(width: 40, height: null, child: Icon(icon, size: 24)));
+}
+
+Widget _getStatusIcon(SyncStatus status) {
+  if (status.exception != null) {
+    // The exception message is verbose, could be replaced with something
+    // more user-friendly
+    if (!status.connected) {
+      return _makeIcon(status.exception!.toString(), Icons.cloud_off);
+    } else {
+      return _makeIcon(status.exception!.toString(), Icons.sync_problem);
+    }
+  } else if (status.connecting) {
+    return _makeIcon('Connecting', Icons.cloud_sync_outlined);
+  } else if (!status.connected) {
+    return _makeIcon('Not connected', Icons.cloud_off);
+  } else if (status.uploading && status.downloading) {
+    // The status changes often between downloading, uploading and both,
+    // so we use the same icon for all three
+    return _makeIcon('Uploading and downloading', Icons.cloud_sync_outlined);
+  } else if (status.uploading) {
+    return _makeIcon('Uploading', Icons.cloud_sync_outlined);
+  } else if (status.downloading) {
+    return _makeIcon('Downloading', Icons.cloud_sync_outlined);
+  } else {
+    return _makeIcon('Connected', Icons.cloud_queue);
   }
 }

--- a/demos/supabase-edge-function-auth/lib/widgets/status_app_bar.dart
+++ b/demos/supabase-edge-function-auth/lib/widgets/status_app_bar.dart
@@ -61,13 +61,13 @@ Widget _makeIcon(String text, IconData icon) {
 }
 
 Widget _getStatusIcon(SyncStatus status) {
-  if (status.exception != null) {
-    // The exception message is verbose, could be replaced with something
+  if (status.anyError != null) {
+    // The error message is verbose, could be replaced with something
     // more user-friendly
     if (!status.connected) {
-      return _makeIcon(status.exception!.toString(), Icons.cloud_off);
+      return _makeIcon(status.anyError!.toString(), Icons.cloud_off);
     } else {
-      return _makeIcon(status.exception!.toString(), Icons.sync_problem);
+      return _makeIcon(status.anyError!.toString(), Icons.sync_problem);
     }
   } else if (status.connecting) {
     return _makeIcon('Connecting', Icons.cloud_sync_outlined);

--- a/demos/supabase-edge-function-auth/lib/widgets/status_app_bar.dart
+++ b/demos/supabase-edge-function-auth/lib/widgets/status_app_bar.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:powersync/powersync.dart';
 import '../powersync.dart';
@@ -39,22 +40,48 @@ class _StatusAppBarState extends State<StatusAppBar> {
 
   @override
   Widget build(BuildContext context) {
-    const connectedIcon = IconButton(
-      icon: Icon(Icons.wifi),
-      tooltip: 'Connected',
-      onPressed: null,
-    );
-    const disconnectedIcon = IconButton(
-      icon: Icon(Icons.wifi_off),
-      tooltip: 'Not connected',
-      onPressed: null,
-    );
+    final statusIcon = _getStatusIcon(_connectionState);
 
     return AppBar(
       title: Text(widget.title),
       actions: <Widget>[
-        _connectionState.connected ? connectedIcon : disconnectedIcon
+        statusIcon,
+        // Make some space for the "Debug" banner, so that the status
+        // icon isn't hidden
+        if (kDebugMode) _makeIcon('Debug mode', Icons.developer_mode),
       ],
     );
+  }
+}
+
+Widget _makeIcon(String text, IconData icon) {
+  return Tooltip(
+      message: text,
+      child: SizedBox(width: 40, height: null, child: Icon(icon, size: 24)));
+}
+
+Widget _getStatusIcon(SyncStatus status) {
+  if (status.exception != null) {
+    // The exception message is verbose, could be replaced with something
+    // more user-friendly
+    if (!status.connected) {
+      return _makeIcon(status.exception!.toString(), Icons.cloud_off);
+    } else {
+      return _makeIcon(status.exception!.toString(), Icons.sync_problem);
+    }
+  } else if (status.connecting) {
+    return _makeIcon('Connecting', Icons.cloud_sync_outlined);
+  } else if (!status.connected) {
+    return _makeIcon('Not connected', Icons.cloud_off);
+  } else if (status.uploading && status.downloading) {
+    // The status changes often between downloading, uploading and both,
+    // so we use the same icon for all three
+    return _makeIcon('Uploading and downloading', Icons.cloud_sync_outlined);
+  } else if (status.uploading) {
+    return _makeIcon('Uploading', Icons.cloud_sync_outlined);
+  } else if (status.downloading) {
+    return _makeIcon('Downloading', Icons.cloud_sync_outlined);
+  } else {
+    return _makeIcon('Connected', Icons.cloud_queue);
   }
 }

--- a/demos/supabase-todolist/lib/models/todo_list.dart
+++ b/demos/supabase-todolist/lib/models/todo_list.dart
@@ -37,7 +37,9 @@ class TodoList {
   /// Watch all lists.
   static Stream<List<TodoList>> watchLists() {
     // This query is automatically re-run when data in "lists" or "todos" is modified.
-    return db.watch('SELECT * FROM lists ORDER BY created_at').map((results) {
+    return db
+        .watch('SELECT * FROM lists ORDER BY created_at, id')
+        .map((results) {
       return results.map(TodoList.fromRow).toList(growable: false);
     });
   }
@@ -71,7 +73,7 @@ class TodoList {
   /// Watch items within this list.
   Stream<List<TodoItem>> watchItems() {
     return db.watch(
-        'SELECT * FROM todos WHERE list_id = ? ORDER BY created_at DESC',
+        'SELECT * FROM todos WHERE list_id = ? ORDER BY created_at DESC, id',
         parameters: [id]).map((event) {
       return event.map(TodoItem.fromRow).toList(growable: false);
     });

--- a/demos/supabase-todolist/lib/widgets/status_app_bar.dart
+++ b/demos/supabase-todolist/lib/widgets/status_app_bar.dart
@@ -68,13 +68,13 @@ Widget _makeIcon(String text, IconData icon) {
 }
 
 Widget _getStatusIcon(SyncStatus status) {
-  if (status.exception != null) {
-    // The exception message is verbose, could be replaced with something
+  if (status.anyError != null) {
+    // The error message is verbose, could be replaced with something
     // more user-friendly
     if (!status.connected) {
-      return _makeIcon(status.exception!.toString(), Icons.cloud_off);
+      return _makeIcon(status.anyError!.toString(), Icons.cloud_off);
     } else {
-      return _makeIcon(status.exception!.toString(), Icons.sync_problem);
+      return _makeIcon(status.anyError!.toString(), Icons.sync_problem);
     }
   } else if (status.connecting) {
     return _makeIcon('Connecting', Icons.cloud_sync_outlined);

--- a/demos/supabase-todolist/lib/widgets/status_app_bar.dart
+++ b/demos/supabase-todolist/lib/widgets/status_app_bar.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:powersync/powersync.dart';
 import 'package:powersync_flutter_demo/widgets/fts_search_delegate.dart';
@@ -40,16 +41,7 @@ class _StatusAppBarState extends State<StatusAppBar> {
 
   @override
   Widget build(BuildContext context) {
-    const connectedIcon = IconButton(
-      icon: Icon(Icons.wifi),
-      tooltip: 'Connected',
-      onPressed: null,
-    );
-    const disconnectedIcon = IconButton(
-      icon: Icon(Icons.wifi_off),
-      tooltip: 'Not connected',
-      onPressed: null,
-    );
+    final statusIcon = _getStatusIcon(_connectionState);
 
     return AppBar(
       title: Text(widget.title),
@@ -60,8 +52,43 @@ class _StatusAppBarState extends State<StatusAppBar> {
           },
           icon: const Icon(Icons.search),
         ),
-        _connectionState.connected ? connectedIcon : disconnectedIcon
+        statusIcon,
+        // Make some space for the "Debug" banner, so that the status
+        // icon isn't hidden
+        if (kDebugMode) _makeIcon('Debug mode', Icons.developer_mode),
       ],
     );
+  }
+}
+
+Widget _makeIcon(String text, IconData icon) {
+  return Tooltip(
+      message: text,
+      child: SizedBox(width: 40, height: null, child: Icon(icon, size: 24)));
+}
+
+Widget _getStatusIcon(SyncStatus status) {
+  if (status.exception != null) {
+    // The exception message is verbose, could be replaced with something
+    // more user-friendly
+    if (!status.connected) {
+      return _makeIcon(status.exception!.toString(), Icons.cloud_off);
+    } else {
+      return _makeIcon(status.exception!.toString(), Icons.sync_problem);
+    }
+  } else if (status.connecting) {
+    return _makeIcon('Connecting', Icons.cloud_sync_outlined);
+  } else if (!status.connected) {
+    return _makeIcon('Not connected', Icons.cloud_off);
+  } else if (status.uploading && status.downloading) {
+    // The status changes often between downloading, uploading and both,
+    // so we use the same icon for all three
+    return _makeIcon('Uploading and downloading', Icons.cloud_sync_outlined);
+  } else if (status.uploading) {
+    return _makeIcon('Uploading', Icons.cloud_sync_outlined);
+  } else if (status.downloading) {
+    return _makeIcon('Downloading', Icons.cloud_sync_outlined);
+  } else {
+    return _makeIcon('Connected', Icons.cloud_queue);
   }
 }

--- a/packages/powersync/lib/src/powersync_database.dart
+++ b/packages/powersync/lib/src/powersync_database.dart
@@ -42,8 +42,11 @@ class PowerSyncDatabase with SqliteQueries implements SqliteConnection {
   final SqliteDatabase database;
 
   /// Current connection status.
-  SyncStatus currentStatus =
-      const SyncStatus(connected: false, lastSyncedAt: null);
+  SyncStatus currentStatus = const SyncStatus(
+      connected: false,
+      uploading: false,
+      downloading: false,
+      lastSyncedAt: null);
 
   /// Use this stream to subscribe to connection status updates.
   late final Stream<SyncStatus> statusStream;
@@ -201,7 +204,10 @@ class PowerSyncDatabase with SqliteQueries implements SqliteConnection {
           _setStatus(status);
         } else if (action == 'close') {
           _setStatus(SyncStatus(
-              connected: false, lastSyncedAt: currentStatus.lastSyncedAt));
+              connected: false,
+              downloading: false,
+              uploading: false,
+              lastSyncedAt: currentStatus.lastSyncedAt));
           rPort.close();
           updateSubscription?.cancel();
         } else if (action == 'log') {
@@ -232,6 +238,11 @@ class PowerSyncDatabase with SqliteQueries implements SqliteConnection {
       _disconnecter?.completeAbort();
       _disconnecter = null;
       rPort.close();
+      _setStatus(SyncStatus(
+          connected: false,
+          lastSyncedAt: currentStatus.lastSyncedAt,
+          downloading: false,
+          uploading: false));
     }
 
     var exitPort = ReceivePort();

--- a/packages/powersync/lib/src/powersync_database.dart
+++ b/packages/powersync/lib/src/powersync_database.dart
@@ -42,11 +42,7 @@ class PowerSyncDatabase with SqliteQueries implements SqliteConnection {
   final SqliteDatabase database;
 
   /// Current connection status.
-  SyncStatus currentStatus = const SyncStatus(
-      connected: false,
-      uploading: false,
-      downloading: false,
-      lastSyncedAt: null);
+  SyncStatus currentStatus = const SyncStatus();
 
   /// Use this stream to subscribe to connection status updates.
   late final Stream<SyncStatus> statusStream;
@@ -203,11 +199,8 @@ class PowerSyncDatabase with SqliteQueries implements SqliteConnection {
           final SyncStatus status = data[1];
           _setStatus(status);
         } else if (action == 'close') {
-          _setStatus(SyncStatus(
-              connected: false,
-              downloading: false,
-              uploading: false,
-              lastSyncedAt: currentStatus.lastSyncedAt));
+          // Clear status apart from lastSyncedAt
+          _setStatus(SyncStatus(lastSyncedAt: currentStatus.lastSyncedAt));
           rPort.close();
           updateSubscription?.cancel();
         } else if (action == 'log') {
@@ -238,11 +231,8 @@ class PowerSyncDatabase with SqliteQueries implements SqliteConnection {
       _disconnecter?.completeAbort();
       _disconnecter = null;
       rPort.close();
-      _setStatus(SyncStatus(
-          connected: false,
-          lastSyncedAt: currentStatus.lastSyncedAt,
-          downloading: false,
-          uploading: false));
+      // Clear status apart from lastSyncedAt
+      _setStatus(SyncStatus(lastSyncedAt: currentStatus.lastSyncedAt));
     }
 
     var exitPort = ReceivePort();

--- a/packages/powersync/lib/src/streaming_sync.dart
+++ b/packages/powersync/lib/src/streaming_sync.dart
@@ -35,11 +35,7 @@ class StreamingSyncImplementation {
 
   final Duration retryDelay;
 
-  SyncStatus lastStatus = SyncStatus(
-      connected: false,
-      lastSyncedAt: null,
-      downloading: false,
-      uploading: false);
+  SyncStatus lastStatus = const SyncStatus();
 
   StreamingSyncImplementation(
       {required this.adapter,
@@ -150,6 +146,8 @@ class StreamingSyncImplementation {
     return body['data']['write_checkpoint'] as String;
   }
 
+  /// Update sync status based on any non-null parameters.
+  /// To clear errors, use [_noError] instead of null.
   void _updateStatus(
       {DateTime? lastSyncedAt,
       bool? connected,

--- a/packages/powersync/lib/src/streaming_sync.dart
+++ b/packages/powersync/lib/src/streaming_sync.dart
@@ -353,7 +353,7 @@ HttpException getError(http.Response response) {
   try {
     final body = response.body;
     final decoded = convert.jsonDecode(body);
-    final details = decoded['error']?['details']?[0] ?? body;
+    final details = stringOrFirst(decoded['error']?['details']) ?? body;
     final message = '${response.reasonPhrase ?? "Request failed"}: $details';
     return HttpException(message, uri: response.request?.url);
   } on Error catch (_) {
@@ -366,11 +366,23 @@ Future<HttpException> getStreamedError(http.StreamedResponse response) async {
   try {
     final body = await response.stream.bytesToString();
     final decoded = convert.jsonDecode(body);
-    final details = decoded['error']?['details']?[0] ?? body;
+    final details = stringOrFirst(decoded['error']?['details']) ?? body;
     final message = '${response.reasonPhrase ?? "Request failed"}: $details';
     return HttpException(message, uri: response.request?.url);
   } on Error catch (_) {
     return HttpException(response.reasonPhrase ?? "Request failed",
         uri: response.request?.url);
+  }
+}
+
+String? stringOrFirst(Object? details) {
+  if (details == null) {
+    return null;
+  } else if (details is String) {
+    return details;
+  } else if (details is List<String>) {
+    return details[0];
+  } else {
+    return null;
   }
 }

--- a/packages/powersync/lib/src/streaming_sync.dart
+++ b/packages/powersync/lib/src/streaming_sync.dart
@@ -380,7 +380,7 @@ String? stringOrFirst(Object? details) {
     return null;
   } else if (details is String) {
     return details;
-  } else if (details is List<String>) {
+  } else if (details is List && details[0] is String) {
     return details[0];
   } else {
     return null;

--- a/packages/powersync/lib/src/sync_status.dart
+++ b/packages/powersync/lib/src/sync_status.dart
@@ -55,19 +55,9 @@ class SyncStatus {
         other.lastSyncedAt == lastSyncedAt);
   }
 
-  // Get the current [downloadError] or [uploadError] as an Exception;
-  Exception? get exception {
-    if (downloadError is Exception) {
-      return downloadError as Exception;
-    } else if (downloadError != null) {
-      return Exception('Download error: $downloadError');
-    } else if (uploadError is Exception) {
-      return uploadError as Exception;
-    } else if (uploadError != null) {
-      return Exception('Upload error: $uploadError');
-    } else {
-      return null;
-    }
+  /// Get the current [downloadError] or [uploadError].
+  Object? get anyError {
+    return downloadError ?? uploadError;
   }
 
   @override
@@ -78,7 +68,7 @@ class SyncStatus {
 
   @override
   String toString() {
-    return "SyncStatus<connected: $connected downloading: $downloading uploading: $uploading lastSyncedAt: $lastSyncedAt error: $exception>";
+    return "SyncStatus<connected: $connected downloading: $downloading uploading: $uploading lastSyncedAt: $lastSyncedAt error: $anyError>";
   }
 }
 

--- a/packages/powersync/lib/src/sync_status.dart
+++ b/packages/powersync/lib/src/sync_status.dart
@@ -68,7 +68,7 @@ class SyncStatus {
 
   @override
   String toString() {
-    return "SyncStatus<connected: $connected downloading: $downloading uploading: $uploading lastSyncedAt: $lastSyncedAt error: $anyError>";
+    return "SyncStatus<connected: $connected connecting: $connecting downloading: $downloading uploading: $uploading lastSyncedAt: $lastSyncedAt error: $anyError>";
   }
 }
 

--- a/packages/powersync/lib/src/sync_status.dart
+++ b/packages/powersync/lib/src/sync_status.dart
@@ -2,27 +2,72 @@ class SyncStatus {
   /// true if currently connected
   final bool connected;
 
+  /// true if currently connected
+  final bool connecting;
+
+  /// true if downloading changes
+  final bool downloading;
+
+  /// true if uploading changes
+  final bool uploading;
+
   /// Time that a last sync has fully completed, if any
   /// Currently this is reset to null after a restart
   final DateTime? lastSyncedAt;
 
-  const SyncStatus({required this.connected, required this.lastSyncedAt});
+  /// Error during uploading.
+  /// Cleared on the next successful upload.
+  final Object? uploadError;
+
+  /// Error during downloading (including connecting).
+  /// Cleared on the next successful data download.
+  final Object? downloadError;
+
+  const SyncStatus(
+      {this.connected = false,
+      this.connecting = false,
+      this.lastSyncedAt,
+      this.downloading = false,
+      this.uploading = false,
+      this.downloadError,
+      this.uploadError});
 
   @override
   bool operator ==(Object other) {
     return (other is SyncStatus &&
         other.connected == connected &&
+        other.downloading == downloading &&
+        other.uploading == uploading &&
+        other.connecting == connecting &&
+        other.downloadError == downloadError &&
+        other.uploadError == uploadError &&
         other.lastSyncedAt == lastSyncedAt);
+  }
+
+  // Get the current [downloadError] or [uploadError] as an Exception;
+  Exception? get exception {
+    if (downloadError is Exception) {
+      return downloadError as Exception;
+    } else if (downloadError != null) {
+      return Exception('Download error: $downloadError');
+    } else if (uploadError is Exception) {
+      return uploadError as Exception;
+    } else if (uploadError != null) {
+      return Exception('Upload error: $uploadError');
+    } else {
+      return null;
+    }
   }
 
   @override
   int get hashCode {
-    return Object.hash(connected, lastSyncedAt);
+    return Object.hash(connected, downloading, uploading, connecting,
+        uploadError, downloadError, lastSyncedAt);
   }
 
   @override
   String toString() {
-    return "SyncStatus<connected: $connected lastSyncedAt: $lastSyncedAt>";
+    return "SyncStatus<connected: $connected downloading: $downloading uploading: $uploading lastSyncedAt: $lastSyncedAt error: $exception>";
   }
 }
 

--- a/packages/powersync/lib/src/sync_status.dart
+++ b/packages/powersync/lib/src/sync_status.dart
@@ -1,25 +1,36 @@
 class SyncStatus {
-  /// true if currently connected
+  /// true if currently connected.
+  ///
+  /// This means the PowerSync connection is ready to download, and
+  /// [PowerSyncBackendConnector.uploadData] may be called for any local changes.
   final bool connected;
 
-  /// true if currently connected
+  /// true if the PowerSync connection is busy connecting.
+  ///
+  /// During this stage, [PowerSyncBackendConnector.uploadData] may already be called,
+  /// called, and [uploading] may be true.
   final bool connecting;
 
-  /// true if downloading changes
+  /// true if actively downloading changes.
+  ///
+  /// This is only true when [connected] is also true.
   final bool downloading;
 
   /// true if uploading changes
   final bool uploading;
 
-  /// Time that a last sync has fully completed, if any
-  /// Currently this is reset to null after a restart
+  /// Time that a last sync has fully completed, if any.
+  ///
+  /// Currently this is reset to null after a restart.
   final DateTime? lastSyncedAt;
 
   /// Error during uploading.
+  ///
   /// Cleared on the next successful upload.
   final Object? uploadError;
 
   /// Error during downloading (including connecting).
+  ///
   /// Cleared on the next successful data download.
   final Object? downloadError;
 


### PR DESCRIPTION
Changes to SyncStatus:
 * Fix `connected` not updating when calling `powersync.disconnect()`.
 * Add `connecting`, `downloading` and `uploading` flags.
 * Add `downloadError`, `uploadError` and a combined `exception` field.

The demo now uses these to provide more fine-grained connectivity status.

![image](https://github.com/powersync-ja/powersync.dart/assets/94081/7d10c850-623b-459b-9028-ba0bdf4f8fbe)

Also includes a minor fix for error parsing that would only return the first character of the error message in some cases.