### PR TITLE
Always runs GitHub Actions

### DIFF
--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -7,15 +7,7 @@ concurrency:
 on:
   push:
     branches:
-      - master
-      - main
-    paths:
-      - demos/**
-      - .github/workflows/**
-  pull_request:
-    paths:
-      - demos/**'
-      - .github/workflows/**
+      - "**"
 
 jobs:
   build:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -7,15 +7,7 @@ concurrency:
 on:
   push:
     branches:
-      - master
-      - main
-    paths:
-      - packages/**
-      - .github/workflows/**
-  pull_request:
-    paths:
-      - packages/**
-      - .github/workflows/**
+      - "**"
 
 jobs:
   build:


### PR DESCRIPTION
Run the actions on a push to any branch. This runs the actions more often than strictly needed, but reduces the time to wait for actions when opening a PR.