### PR TITLE
Minor Fixes

### DIFF
--- a/packages/powersync/lib/src/open_factory.dart
+++ b/packages/powersync/lib/src/open_factory.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:isolate';
+import 'dart:math';
 
 import 'package:sqlite_async/sqlite3.dart' as sqlite;
 import 'package:sqlite_async/sqlite_async.dart';
@@ -39,10 +40,39 @@ class PowerSyncOpenFactory extends DefaultSqliteOpenFactory {
   sqlite.Database open(SqliteOpenOptions options) {
     // ignore: deprecated_member_use_from_same_package
     _sqliteSetup?.setup();
-    final db = super.open(options);
+    final db = _retriedOpen(options);
     db.execute('PRAGMA recursive_triggers = TRUE');
     setupFunctions(db);
     return db;
+  }
+
+  /// When opening the powersync connection and the standard write connection
+  /// at the same time, one could fail with this error:
+  ///
+  ///     SqliteException(5): while opening the database, automatic extension loading failed: , database is locked (code 5)
+  ///
+  /// It happens before we have a chance to set the busy timeout, so we just
+  /// retry opening the database.
+  ///
+  /// Usually a delay of 1-2ms is sufficient for the next try to succeed, but
+  /// we increase the retry delay up to 16ms per retry, and a maximum of 500ms
+  /// in total.
+  sqlite.Database _retriedOpen(SqliteOpenOptions options) {
+    final stopwatch = Stopwatch()..start();
+    var retryDelay = 2;
+    while (stopwatch.elapsedMilliseconds < 500) {
+      try {
+        return super.open(options);
+      } catch (e) {
+        if (e is sqlite.SqliteException && e.resultCode == 5) {
+          sleep(Duration(milliseconds: retryDelay));
+          retryDelay = min(retryDelay * 2, 16);
+          continue;
+        }
+        rethrow;
+      }
+    }
+    throw AssertionError('Cannot reach this point');
   }
 
   void setupFunctions(sqlite.Database db) {

--- a/packages/powersync/test/offline_online_test.dart
+++ b/packages/powersync/test/offline_online_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:powersync/powersync.dart';
 import 'package:test/test.dart';
 
@@ -113,16 +115,27 @@ void main() {
         await tx.execute('DELETE FROM local_assets');
       });
 
+      final crud = (await db.getAll('SELECT data FROM ps_crud ORDER BY id'))
+          .map((d) => jsonDecode(d['data']))
+          .toList();
       expect(
-          await db.getAll('SELECT data FROM ps_crud ORDER BY id'),
+          crud,
           equals([
             {
-              'data':
-                  '{"op":"PUT","type":"customers","id":"$customerId","data":{"name":"test customer","email":"test@example.org"}}'
+              "op": "PUT",
+              "type": "customers",
+              "id": customerId,
+              "data": {"email": "test@example.org", "name": "test customer"}
             },
             {
-              'data':
-                  '{"op":"PUT","type":"assets","id":"$assetId","data":{"user_id":"$userId","customer_id":"$customerId","description":"test."}}'
+              "op": "PUT",
+              "type": "assets",
+              "id": assetId,
+              "data": {
+                "user_id": userId,
+                "customer_id": customerId,
+                "description": "test."
+              }
             }
           ]));
     });


### PR DESCRIPTION
1. Fix error occasionally occurring when calling `powersync.connect()` right when opening the database.

> SqliteException(5): while executing, database is locked, database is locked (code 5)

I haven't seen this in an actual app, but it occasionally causes tests to fail such as [this one](https://github.com/powersync-ja/powersync.dart/actions/runs/7397336788/job/20124265094).

2. Fix the "should revert" tests from #39 to do what it says.

3. Fix the "Offline-online Tests" to not depend on order of keys in the JSON output.