### PR TITLE
Improved error logging

### DIFF
--- a/demos/supabase-anonymous-auth/lib/main.dart
+++ b/demos/supabase-anonymous-auth/lib/main.dart
@@ -7,7 +7,6 @@ import './widgets/home_page.dart';
 import './widgets/status_app_bar.dart';
 
 void main() async {
-  // Log info from PowerSync
   Logger.root.level = Level.INFO;
   Logger.root.onRecord.listen((record) {
     if (kDebugMode) {

--- a/demos/supabase-edge-function-auth/lib/main.dart
+++ b/demos/supabase-edge-function-auth/lib/main.dart
@@ -9,7 +9,6 @@ import './widgets/signup_page.dart';
 import './widgets/status_app_bar.dart';
 
 void main() async {
-  // Log info from PowerSync
   Logger.root.level = Level.INFO;
   Logger.root.onRecord.listen((record) {
     if (kDebugMode) {

--- a/demos/supabase-todolist/lib/main.dart
+++ b/demos/supabase-todolist/lib/main.dart
@@ -13,7 +13,6 @@ import './widgets/signup_page.dart';
 import './widgets/status_app_bar.dart';
 
 void main() async {
-  // Log info from PowerSync
   Logger.root.level = Level.INFO;
   Logger.root.onRecord.listen((record) {
     if (kDebugMode) {

--- a/demos/supabase-todolist/lib/powersync.dart
+++ b/demos/supabase-todolist/lib/powersync.dart
@@ -151,7 +151,8 @@ Future<String> getDatabasePath() async {
 
 Future<void> openDatabase() async {
   // Open the local database
-  db = PowerSyncDatabase(schema: schema, path: await getDatabasePath());
+  db = PowerSyncDatabase(
+      schema: schema, path: await getDatabasePath(), logger: attachedLogger);
   await db.initialize();
 
   await loadSupabase();

--- a/packages/powersync/lib/powersync.dart
+++ b/packages/powersync/lib/powersync.dart
@@ -3,11 +3,12 @@
 /// Use [PowerSyncDatabase] to open a database.
 library;
 
-export 'src/powersync_database.dart';
-export 'src/schema.dart';
 export 'src/connector.dart';
 export 'src/crud.dart';
+export 'src/exceptions.dart';
+export 'src/log.dart';
+export 'src/open_factory.dart';
+export 'src/powersync_database.dart';
+export 'src/schema.dart';
 export 'src/sync_status.dart';
 export 'src/uuid.dart';
-export 'src/open_factory.dart';
-export 'src/log.dart' show attachedLogger, autoLogger, debugLogger;

--- a/packages/powersync/lib/powersync.dart
+++ b/packages/powersync/lib/powersync.dart
@@ -10,3 +10,4 @@ export 'src/crud.dart';
 export 'src/sync_status.dart';
 export 'src/uuid.dart';
 export 'src/open_factory.dart';
+export 'src/log.dart' show attachedLogger, autoLogger, debugLogger;

--- a/packages/powersync/lib/src/bucket_storage.dart
+++ b/packages/powersync/lib/src/bucket_storage.dart
@@ -345,7 +345,7 @@ class BucketStorage {
                 SET last_applied_op = last_op
                 WHERE last_applied_op != last_op""");
 
-      log.fine('Updated local database');
+      isolateLogger.fine('Updated local database');
       return true;
     });
   }
@@ -407,7 +407,7 @@ class BucketStorage {
     final invalidBuckets = db.select(
         "SELECT name, target_op, last_op, last_applied_op FROM ps_buckets WHERE target_op > last_op AND (name = '\$local' OR pending_delete = 0)");
     if (invalidBuckets.isNotEmpty) {
-      log.fine('Cannot update local database: $invalidBuckets');
+      isolateLogger.fine('Cannot update local database: $invalidBuckets');
       return false;
     }
     // This is specifically relevant for when data is added to crud before another batch is completed.
@@ -505,7 +505,7 @@ class BucketStorage {
           BucketChecksum(bucket: checksum.bucket, checksum: 0, count: 0);
       // Note: Count is informational only.
       if (local.checksum != checksum.checksum) {
-        log.warning(
+        isolateLogger.warning(
             'Checksum mismatch for ${checksum.bucket}: local ${local.checksum} != remote ${checksum.checksum}');
         failedChecksums.add(checksum.bucket);
       }

--- a/packages/powersync/lib/src/bucket_storage.dart
+++ b/packages/powersync/lib/src/bucket_storage.dart
@@ -2,12 +2,12 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:collection/collection.dart';
+import 'package:powersync/src/log_internal.dart';
 import 'package:sqlite_async/mutex.dart';
 import 'package:sqlite_async/sqlite3.dart' as sqlite;
 
 import 'crud.dart';
 import 'database_utils.dart';
-import 'log.dart';
 import 'schema_logic.dart';
 import 'sync_types.dart';
 import 'uuid.dart';

--- a/packages/powersync/lib/src/bucket_storage.dart
+++ b/packages/powersync/lib/src/bucket_storage.dart
@@ -345,7 +345,7 @@ class BucketStorage {
                 SET last_applied_op = last_op
                 WHERE last_applied_op != last_op""");
 
-      isolateLogger.fine('Updated local database');
+      isolateLogger.fine('Applied checkpoint ${checkpoint.lastOpId}');
       return true;
     });
   }
@@ -407,7 +407,11 @@ class BucketStorage {
     final invalidBuckets = db.select(
         "SELECT name, target_op, last_op, last_applied_op FROM ps_buckets WHERE target_op > last_op AND (name = '\$local' OR pending_delete = 0)");
     if (invalidBuckets.isNotEmpty) {
-      isolateLogger.fine('Cannot update local database: $invalidBuckets');
+      if (invalidBuckets.first['name'] == '\$local') {
+        isolateLogger.fine('Waiting for local changes to be acknowledged');
+      } else {
+        isolateLogger.fine('Waiting for more data: $invalidBuckets');
+      }
       return false;
     }
     // This is specifically relevant for when data is added to crud before another batch is completed.
@@ -506,7 +510,7 @@ class BucketStorage {
       // Note: Count is informational only.
       if (local.checksum != checksum.checksum) {
         isolateLogger.warning(
-            'Checksum mismatch for ${checksum.bucket}: local ${local.checksum} != remote ${checksum.checksum}');
+            'Checksum mismatch for ${checksum.bucket}: local ${local.checksum} != remote ${checksum.checksum}. Likely due to sync rule changes.');
         failedChecksums.add(checksum.bucket);
       }
     }

--- a/packages/powersync/lib/src/connector.dart
+++ b/packages/powersync/lib/src/connector.dart
@@ -87,11 +87,13 @@ class PowerSyncCredentials {
   /// When the token expires. Only use for debugging purposes.
   final DateTime? expiresAt;
 
-  const PowerSyncCredentials(
+  PowerSyncCredentials(
       {required this.endpoint,
       required this.token,
       this.userId,
-      this.expiresAt});
+      this.expiresAt}) {
+    _validateEndpoint();
+  }
 
   factory PowerSyncCredentials.fromJson(Map<String, dynamic> parsed) {
     String token = parsed['token'];
@@ -132,6 +134,15 @@ class PowerSyncCredentials {
   /// Resolve an endpoint path against the endpoint URI.
   Uri endpointUri(String path) {
     return Uri.parse(endpoint).resolve(path);
+  }
+
+  _validateEndpoint() {
+    final parsed = Uri.parse(endpoint);
+    if ((!parsed.isScheme('http') && !parsed.isScheme('https')) ||
+        parsed.host.isEmpty) {
+      throw ArgumentError.value(
+          endpoint, 'PowerSync endpoint must be a valid URL');
+    }
   }
 }
 

--- a/packages/powersync/lib/src/exceptions.dart
+++ b/packages/powersync/lib/src/exceptions.dart
@@ -1,0 +1,90 @@
+import 'dart:async';
+import 'dart:convert' as convert;
+
+import 'package:http/http.dart' as http;
+
+/// This indicates an error with configured credentials.
+class CredentialsException implements Exception {
+  String message;
+
+  CredentialsException(this.message);
+
+  @override
+  toString() {
+    return 'CredentialsException: $message';
+  }
+}
+
+/// An internal protocol exception.
+///
+/// This indicates that the server sent an invalid response.
+class PowerSyncProtocolException implements Exception {
+  String message;
+
+  PowerSyncProtocolException(this.message);
+
+  @override
+  toString() {
+    return 'SyncProtocolException: $message';
+  }
+}
+
+/// An error that received from the sync service.
+///
+/// Examples include authorization errors (401) and temporary service issues (503).
+class SyncResponseException implements Exception {
+  /// Parse an error response from the PowerSync service
+  static Future<SyncResponseException> fromStreamedResponse(
+      http.StreamedResponse response) async {
+    try {
+      final body = await response.stream.bytesToString();
+      final decoded = convert.jsonDecode(body);
+      final details = _stringOrFirst(decoded['error']?['details']) ?? body;
+      final message = '${response.reasonPhrase ?? "Request failed"}: $details';
+      return SyncResponseException(response.statusCode, message);
+    } on Error catch (_) {
+      return SyncResponseException(
+        response.statusCode,
+        response.reasonPhrase ?? "Request failed",
+      );
+    }
+  }
+
+  /// Parse an error response from the PowerSync service
+  static SyncResponseException fromResponse(http.Response response) {
+    try {
+      final body = response.body;
+      final decoded = convert.jsonDecode(body);
+      final details = _stringOrFirst(decoded['error']?['details']) ?? body;
+      final message = '${response.reasonPhrase ?? "Request failed"}: $details';
+      return SyncResponseException(response.statusCode, message);
+    } on Error catch (_) {
+      return SyncResponseException(
+        response.statusCode,
+        response.reasonPhrase ?? "Request failed",
+      );
+    }
+  }
+
+  int statusCode;
+  String description;
+
+  SyncResponseException(this.statusCode, this.description);
+
+  @override
+  toString() {
+    return 'SyncResponseException: $statusCode $description';
+  }
+}
+
+String? _stringOrFirst(Object? details) {
+  if (details == null) {
+    return null;
+  } else if (details is String) {
+    return details;
+  } else if (details is List && details[0] is String) {
+    return details[0];
+  } else {
+    return null;
+  }
+}

--- a/packages/powersync/lib/src/log.dart
+++ b/packages/powersync/lib/src/log.dart
@@ -1,14 +1,5 @@
 import 'package:logging/logging.dart';
-
-// Duplicate from package:flutter/foundation.dart, so we don't need to depend on Flutter
-const bool kReleaseMode = bool.fromEnvironment('dart.vm.product');
-const bool kProfileMode = bool.fromEnvironment('dart.vm.profile');
-const bool kDebugMode = !kReleaseMode && !kProfileMode;
-
-// Implementation note: The loggers here are only initialized if used - it adds
-// no overhead when not used in the client app.
-
-final isolateLogger = Logger.detached('PowerSync');
+import 'package:powersync/src/log_internal.dart';
 
 /// Logger that outputs to the console in debug mode, and nothing
 /// in release and profile modes.

--- a/packages/powersync/lib/src/log.dart
+++ b/packages/powersync/lib/src/log.dart
@@ -1,3 +1,8 @@
 import 'package:logging/logging.dart';
 
+// Duplicate from package:flutter/foundation.dart, so we don't need to depend on Flutter
+const bool kReleaseMode = bool.fromEnvironment('dart.vm.product');
+const bool kProfileMode = bool.fromEnvironment('dart.vm.profile');
+const bool kDebugMode = !kReleaseMode && !kProfileMode;
+
 final isolateLogger = Logger.detached('PowerSync');

--- a/packages/powersync/lib/src/log.dart
+++ b/packages/powersync/lib/src/log.dart
@@ -5,4 +5,46 @@ const bool kReleaseMode = bool.fromEnvironment('dart.vm.product');
 const bool kProfileMode = bool.fromEnvironment('dart.vm.profile');
 const bool kDebugMode = !kReleaseMode && !kProfileMode;
 
+// Implementation note: The loggers here are only initialized if used - it adds
+// no overhead when not used in the client app.
+
 final isolateLogger = Logger.detached('PowerSync');
+
+/// Logger that outputs to the console in debug mode, and nothing
+/// in release and profile modes.
+final Logger autoLogger = _makeAutoLogger();
+
+/// Logger that always outputs debug info to the console.
+final Logger debugLogger = _makeDebugLogger();
+
+/// Standard logger. Does not automatically log to the console,
+/// use the `Logger.root.onRecord` stream to get log messages.
+final Logger attachedLogger = Logger('PowerSync');
+
+Logger _makeDebugLogger() {
+  // Use a detached logger to log directly to the console
+  final logger = Logger.detached('PowerSync');
+  logger.level = Level.FINE;
+  logger.onRecord.listen((record) {
+    print(
+        '[${record.loggerName}] ${record.level.name}: ${record.time}: ${record.message}');
+
+    if (record.error != null) {
+      print(record.error);
+    }
+    if (record.stackTrace != null) {
+      print(record.stackTrace);
+    }
+  });
+  return logger;
+}
+
+Logger _makeAutoLogger() {
+  if (kDebugMode) {
+    return _makeDebugLogger();
+  } else {
+    final logger = Logger.detached('PowerSync');
+    logger.level = Level.OFF;
+    return logger;
+  }
+}

--- a/packages/powersync/lib/src/log.dart
+++ b/packages/powersync/lib/src/log.dart
@@ -1,3 +1,3 @@
 import 'package:logging/logging.dart';
 
-final log = Logger('PowerSync');
+final isolateLogger = Logger.detached('PowerSync');

--- a/packages/powersync/lib/src/log_internal.dart
+++ b/packages/powersync/lib/src/log_internal.dart
@@ -1,0 +1,11 @@
+import 'package:logging/logging.dart';
+
+// Duplicate from package:flutter/foundation.dart, so we don't need to depend on Flutter
+const bool kReleaseMode = bool.fromEnvironment('dart.vm.product');
+const bool kProfileMode = bool.fromEnvironment('dart.vm.profile');
+const bool kDebugMode = !kReleaseMode && !kProfileMode;
+
+// Implementation note: The loggers here are only initialized if used - it adds
+// no overhead when not used in the client app.
+
+final isolateLogger = Logger.detached('PowerSync');

--- a/packages/powersync/lib/src/powersync_database.dart
+++ b/packages/powersync/lib/src/powersync_database.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:isolate';
 
 import 'package:logging/logging.dart';
+import 'package:powersync/src/log_internal.dart';
 import 'package:sqlite_async/sqlite3.dart' as sqlite;
 import 'package:sqlite_async/sqlite_async.dart';
 

--- a/packages/powersync/lib/src/powersync_database.dart
+++ b/packages/powersync/lib/src/powersync_database.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:isolate';
 
-import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:sqlite_async/sqlite3.dart' as sqlite;
 import 'package:sqlite_async/sqlite_async.dart';
@@ -125,6 +124,7 @@ class PowerSyncDatabase with SqliteQueries implements SqliteConnection {
     if (log == LogType.debug || log == LogType.auto) {
       // Use a detached logger to log directly to the console
       logger = Logger.detached('PowerSync');
+
       final debug = log == LogType.debug || kDebugMode;
       if (debug) {
         logger.level = Level.FINE;

--- a/packages/powersync/lib/src/streaming_sync.dart
+++ b/packages/powersync/lib/src/streaming_sync.dart
@@ -64,7 +64,7 @@ class StreamingSyncImplementation {
         // Continue immediately
       } catch (e, stacktrace) {
         final message = _syncErrorMessage(e);
-        log.warning('Sync error: $message', e, stacktrace);
+        isolateLogger.warning('Sync error: $message', e, stacktrace);
         invalidCredentials = true;
 
         _updateStatus(
@@ -96,7 +96,7 @@ class StreamingSyncImplementation {
           break;
         }
       } catch (e, stacktrace) {
-        log.warning('Data upload error', e, stacktrace);
+        isolateLogger.warning('Data upload error', e, stacktrace);
         _updateStatus(uploading: false, uploadError: e);
         await Future.delayed(retryDelay);
       }

--- a/packages/powersync/test/bucket_storage_test.dart
+++ b/packages/powersync/test/bucket_storage_test.dart
@@ -38,8 +38,6 @@ const removeAsset1_5 = OplogEntry(
     opId: '5', op: OpType.remove, rowType: 'assets', rowId: 'O1', checksum: 5);
 
 void main() {
-  setupLogger();
-
   group('Bucket Storage Tests', () {
     late PowerSyncDatabase powersync;
     late sqlite.Database db;

--- a/packages/powersync/test/crud_test.dart
+++ b/packages/powersync/test/crud_test.dart
@@ -7,8 +7,6 @@ import 'util.dart';
 const testId = "2290de4f-0488-4e50-abed-f8e8eb1d0b42";
 
 void main() {
-  setupLogger();
-
   group('CRUD Tests', () {
     late PowerSyncDatabase powersync;
     late String path;

--- a/packages/powersync/test/offline_online_test.dart
+++ b/packages/powersync/test/offline_online_test.dart
@@ -68,8 +68,6 @@ Schema makeSchema(bool online) {
 }
 
 void main() {
-  setupLogger();
-
   group('Offline-online Tests', () {
     late String path;
 

--- a/packages/powersync/test/performance_test.dart
+++ b/packages/powersync/test/performance_test.dart
@@ -18,8 +18,6 @@ const pschema = Schema([
 ]);
 
 void main() {
-  setupLogger();
-
   group('Performance Tests', () {
     late String path;
 

--- a/packages/powersync/test/powersync_test.dart
+++ b/packages/powersync/test/powersync_test.dart
@@ -8,8 +8,6 @@ import 'package:sqlite_async/sqlite3.dart' as sqlite;
 import 'util.dart';
 
 void main() {
-  setupLogger();
-
   group('Basic Tests', () {
     late String path;
 

--- a/packages/powersync/test/stream_test.dart
+++ b/packages/powersync/test/stream_test.dart
@@ -6,11 +6,7 @@ import 'package:http/http.dart';
 import 'package:powersync/src/stream_utils.dart';
 import 'package:test/test.dart';
 
-import 'util.dart';
-
 void main() {
-  setupLogger();
-
   group('Stream Tests', () {
     setUp(() async {});
 

--- a/packages/powersync/test/streaming_sync_test.dart
+++ b/packages/powersync/test/streaming_sync_test.dart
@@ -23,8 +23,6 @@ class TestConnector extends PowerSyncBackendConnector {
 }
 
 void main() {
-  setupLogger();
-
   group('Streaming Sync Test', () {
     late String path;
 

--- a/packages/powersync/test/util.dart
+++ b/packages/powersync/test/util.dart
@@ -42,7 +42,7 @@ class TestOpenFactory extends PowerSyncOpenFactory {
 Future<PowerSyncDatabase> setupPowerSync(
     {required String path, Schema? schema}) async {
   final db = PowerSyncDatabase.withFactory(TestOpenFactory(path: path),
-      schema: schema ?? defaultSchema);
+      schema: schema ?? defaultSchema, log: LogType.logger);
   return db;
 }
 

--- a/packages/powersync/test/util.dart
+++ b/packages/powersync/test/util.dart
@@ -4,9 +4,9 @@ import 'dart:io';
 
 import 'package:logging/logging.dart';
 import 'package:powersync/powersync.dart';
+import 'package:powersync/sqlite3.dart' as sqlite;
 import 'package:powersync/sqlite_async.dart';
 import 'package:sqlite3/open.dart' as sqlite_open;
-import 'package:powersync/sqlite3.dart' as sqlite;
 import 'package:test_api/src/backend/invoker.dart';
 
 const schema = Schema([
@@ -42,7 +42,7 @@ class TestOpenFactory extends PowerSyncOpenFactory {
 Future<PowerSyncDatabase> setupPowerSync(
     {required String path, Schema? schema}) async {
   final db = PowerSyncDatabase.withFactory(TestOpenFactory(path: path),
-      schema: schema ?? defaultSchema, log: LogType.logger);
+      schema: schema ?? defaultSchema, logger: testLogger);
   return db;
 }
 
@@ -82,9 +82,12 @@ String dbPath() {
   return dbName;
 }
 
-setupLogger() {
-  Logger.root.level = Level.ALL;
-  Logger.root.onRecord.listen((record) {
+final testLogger = _makeTestLogger();
+
+Logger _makeTestLogger() {
+  final logger = Logger.detached('PowerSync Tests');
+  logger.level = Level.ALL;
+  logger.onRecord.listen((record) {
     print(
         '[${record.loggerName}] ${record.level.name}: ${record.time}: ${record.message}');
     if (record.error != null) {
@@ -104,4 +107,5 @@ setupLogger() {
       uncaughtError();
     }
   });
+  return logger;
 }

--- a/packages/powersync/test/watch_test.dart
+++ b/packages/powersync/test/watch_test.dart
@@ -25,8 +25,6 @@ const testSchema = Schema([
 ]);
 
 void main() {
-  setupLogger();
-
   group('Query Watch Tests', () {
     late String path;
 


### PR DESCRIPTION
This changes the logging behavior to log to console in debug mode by default, instead of logging to the root Logger.

Additionally, error messages are somewhat improved for cases where the error itself is not logged.

To get the old logging behavior back for full control over logging, use `logger: attachedLogger` in the PowerSyncDatabase constructor.

Breaking changes:
1. Exceptions are different in certain conditions.
2. Default logging behavior changed as described above.
3. PowerSyncCredentials does not have a const constructor anymore, and now validates the endpoint URI.

Despite these being breaking changes, I believe it will make debugging significantly easier for new apps, and not impact existing apps significantly.

The example apps still contain the same log handling code, since there are other places in the examples also using the logger. However, it is not required to get debug output for the powersync lib anymore.