### PR TITLE
powersync v1.2.0

### DIFF
--- a/demos/supabase-anonymous-auth/pubspec.lock
+++ b/demos/supabase-anonymous-auth/pubspec.lock
@@ -310,7 +310,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.1.1"
+    version: "1.2.0"
   realtime_client:
     dependency: transitive
     description:

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.1.0
+  powersync: ^1.2.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.lock
+++ b/demos/supabase-edge-function-auth/pubspec.lock
@@ -310,7 +310,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.1.1"
+    version: "1.2.0"
   realtime_client:
     dependency: transitive
     description:

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.1.0
+  powersync: ^1.2.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.lock
+++ b/demos/supabase-simple-chat/pubspec.lock
@@ -326,7 +326,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.1.1"
+    version: "1.2.0"
   realtime_client:
     dependency: transitive
     description:

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^1.10.25
   timeago: ^3.6.0
-  powersync: ^1.1.0
+  powersync: ^1.2.0
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -414,7 +414,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.1.1"
+    version: "1.2.0"
   powersync_attachments_helper:
     dependency: "direct main"
     description:

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   powersync_attachments_helper: ^0.1.4
 
-  powersync: ^1.1.0
+  powersync: ^1.2.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,7 +1,21 @@
+## 1.2.0
+
+This release improves the default log output and errors to better assist in debugging.
+
+Breaking changes:
+
+- `PowerSyncCredentials` constructor is no longer const, and the `endpoint` URL is validated in the constructor.
+- Different error and exception classes are now used by the library, including `CredentialsException`, `SyncResponseException` and `PowerSyncProtocolException`, instead of more generic `AssertionError` and `HttpException`.
+
+Other changes:
+
+- The library now logs to the console in debug builds by default. To get the old behavior, use `logger: attachedLogger` in the `PowerSyncDatabase` constructor.
+- Log messages have been improved to better explain the sync process and errors.
+
 ## 1.1.1
 
-- Fix error occasionally occurring when calling powersync.connect() right when opening the database.
-- Update getting started docs
+- Fix error occasionally occurring when calling `powersync.connect()` right when opening the database.
+- Update getting started docs.
 
 ## 1.1.0
 
@@ -25,7 +39,7 @@
 - Improve HTTP error messages.
 - Enable SQLite recursive triggers.
 - Support overriding view names.
-- *Breaking change:* Validate schema definitions for duplicates.
+- _Breaking change:_ Validate schema definitions for duplicates.
   Remove `id` column and indexes from any tables in the schema if present.
 
 ## 0.4.1
@@ -79,9 +93,9 @@ Breaking changes:
 
 - `TableUpdate` renamed to `UpdateNotification`.
 - `PowerSyncDatabase.connectionFactory()` renamed to `PowerSyncDatabase.isolateConnectionFactory()`,
-   and should only be used to pass the connection to a different isolate.
+  and should only be used to pass the connection to a different isolate.
 - All tables apart from `ps_crud` are dropped and re-created when upgrading to this version.
-   This will not result in any data loss, but a full re-sync is required.
+  This will not result in any data loss, but a full re-sync is required.
 
 Fixes:
 

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.1.1
+version: 1.2.0
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - keep PostgreSQL databases in sync with on-device SQLite databases.


### PR DESCRIPTION
This release improves the default log output and errors to better assist in debugging.

Breaking changes:

- `PowerSyncCredentials` constructor is no longer const, and the `endpoint` URL is validated in the constructor.
- Different error and exception classes are now used by the library, including `CredentialsException`, `SyncResponseException` and `PowerSyncProtocolException`, instead of more generic `AssertionError` and `HttpException`.

Other changes:

- The library now logs to the console in debug builds by default. To get the old behavior, use `logger: attachedLogger` in the `PowerSyncDatabase` constructor.
- Log messages have been improved to better explain the sync process and errors.


See #53 for details.