### PR TITLE
[Alpha Fix] Disconnect and clear bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2024-03-05
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`powersync` - `v1.3.0-alpha.3`](#powersync---v130-alpha3)
+ - [`powersync_attachments_helper` - `v0.3.0-alpha.2`](#powersync_attachments_helper---v030-alpha2)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `powersync_attachments_helper` - `v0.3.0-alpha.2`
+
+---
+
+#### `powersync` - `v1.3.0-alpha.3`
+
+ - Fixed issue where disconnectAndClear would prevent subsequent sync connection on native platforms and would fail to clear the database on web.
+
+
 ## 2024-02-15
 
 ### Changes

--- a/demos/supabase-anonymous-auth/pubspec.lock
+++ b/demos/supabase-anonymous-auth/pubspec.lock
@@ -342,7 +342,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.3.0-alpha.1"
+    version: "1.3.0-alpha.2"
   realtime_client:
     dependency: transitive
     description:
@@ -464,10 +464,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqlite_async
-      sha256: "91f454cddc85617bea2c7c1544ff386887d0d2cf0ecdb3599015c05cc141ff4d"
+      sha256: "7a68036b2fc2fae5fc0efbc6bd436deb79e39090282348d979e6a7c38c8d067e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0-alpha.1"
+    version: "0.7.0-alpha.2"
   stack_trace:
     dependency: transitive
     description:

--- a/demos/supabase-anonymous-auth/pubspec.lock
+++ b/demos/supabase-anonymous-auth/pubspec.lock
@@ -156,10 +156,10 @@ packages:
     dependency: transitive
     description:
       name: gotrue
-      sha256: f40610bacf1074723354b0856a4f586508ffb075b799f72466f34e843133deb9
+      sha256: "1bf6354278a98b8a1867263e94921da8a239de07e9babceab2b4e80af651a098"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.5.1"
   gtk:
     dependency: transitive
     description:
@@ -332,10 +332,10 @@ packages:
     dependency: transitive
     description:
       name: postgrest
-      sha256: "748ebffffb60b4eaa270955dcf3742a19a2b315344c41ff1b4a0ebcd322b5181"
+      sha256: "9a3b590cf123f8d323b6a918702e037f037027d12a01902f9dc6ee38fdc05d6c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   powersync:
     dependency: "direct main"
     description:
@@ -347,10 +347,10 @@ packages:
     dependency: transitive
     description:
       name: realtime_client
-      sha256: "5831636c19802ba936093a35a7c5b745b130e268fa052e84b4b5290139d2ae03"
+      sha256: "41d6c5e0327d6c270b98b79bfed672928244af60e2856770f3eff697f9efe459"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   retry:
     dependency: transitive
     description:
@@ -411,10 +411,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: "7b15ffb9387ea3e237bb7a66b8a23d2147663d391cafc5c8f37b2e7b4bde5d21"
+      sha256: d762709c2bbe80626ecc819143013cc820fa49ca5e363620ee20a8b15a3e3daf
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.1"
   shared_preferences_windows:
     dependency: transitive
     description:
@@ -504,18 +504,18 @@ packages:
     dependency: transitive
     description:
       name: supabase
-      sha256: "4bce9c49f264f4cd44b4ffc895647af2dca0c40125c169045be9f708fd2a2a40"
+      sha256: f431753d2a4cb9dacd72c7378154f806c2b2cef23859bd9cee1add23821e874d
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.7"
+    version: "2.0.8"
   supabase_flutter:
     dependency: "direct main"
     description:
       name: supabase_flutter
-      sha256: "5ef71289c380b6429216e941c69971c75eaab50d67fd7b540f6c1f6ebfc00ed7"
+      sha256: "30e966b89ee61dc9de845e2d7e1c60967b3189c410d105c6d42f09b6259f4cb6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.3.4"
   term_glyph:
     dependency: transitive
     description:
@@ -592,18 +592,18 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
-      sha256: a932c3a8082e118f80a475ce692fde89dc20fddb24c57360b96bc56f7035de1f
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: fff0932192afeedf63cdd50ecbb1bc825d31aed259f02bb8dba0f3b729a5e88b
+      sha256: "7fd2f55fe86cea2897b963e864dc01a7eb0719ecc65fcef4c1cc3d686d718bb2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.0"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -670,4 +670,4 @@ packages:
     version: "2.0.0"
 sdks:
   dart: ">=3.2.3 <4.0.0"
-  flutter: ">=3.16.0"
+  flutter: ">=3.13.0"

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.3.0-alpha.2
+  powersync: ^1.3.0-alpha.3
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   supabase_flutter: ^2.0.2
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.7.0-alpha.1
+  sqlite_async: ^0.7.0-alpha.2
   universal_io: ^2.2.2
 
 dev_dependencies:

--- a/demos/supabase-edge-function-auth/lib/widgets/login_page.dart
+++ b/demos/supabase-edge-function-auth/lib/widgets/login_page.dart
@@ -34,7 +34,7 @@ class _LoginPageState extends State<LoginPage> {
       await Supabase.instance.client.auth.signInWithPassword(
           email: _usernameController.text, password: _passwordController.text);
 
-      if (mounted) {
+      if (context.mounted) {
         Navigator.of(context).pushReplacement(MaterialPageRoute(
           builder: (context) => homePage,
         ));

--- a/demos/supabase-edge-function-auth/lib/widgets/signup_page.dart
+++ b/demos/supabase-edge-function-auth/lib/widgets/signup_page.dart
@@ -34,7 +34,7 @@ class _SignupPageState extends State<SignupPage> {
       final response = await Supabase.instance.client.auth.signUp(
           email: _usernameController.text, password: _passwordController.text);
 
-      if (mounted) {
+      if (context.mounted) {
         if (response.session != null) {
           Navigator.of(context).pushReplacement(MaterialPageRoute(
             builder: (context) => homePage,

--- a/demos/supabase-edge-function-auth/pubspec.lock
+++ b/demos/supabase-edge-function-auth/pubspec.lock
@@ -342,7 +342,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.3.0-alpha.1"
+    version: "1.3.0-alpha.2"
   realtime_client:
     dependency: transitive
     description:
@@ -464,10 +464,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqlite_async
-      sha256: "91f454cddc85617bea2c7c1544ff386887d0d2cf0ecdb3599015c05cc141ff4d"
+      sha256: "7a68036b2fc2fae5fc0efbc6bd436deb79e39090282348d979e6a7c38c8d067e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0-alpha.1"
+    version: "0.7.0-alpha.2"
   stack_trace:
     dependency: transitive
     description:

--- a/demos/supabase-edge-function-auth/pubspec.lock
+++ b/demos/supabase-edge-function-auth/pubspec.lock
@@ -156,10 +156,10 @@ packages:
     dependency: transitive
     description:
       name: gotrue
-      sha256: f40610bacf1074723354b0856a4f586508ffb075b799f72466f34e843133deb9
+      sha256: "1bf6354278a98b8a1867263e94921da8a239de07e9babceab2b4e80af651a098"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.5.1"
   gtk:
     dependency: transitive
     description:
@@ -332,10 +332,10 @@ packages:
     dependency: transitive
     description:
       name: postgrest
-      sha256: "748ebffffb60b4eaa270955dcf3742a19a2b315344c41ff1b4a0ebcd322b5181"
+      sha256: "9a3b590cf123f8d323b6a918702e037f037027d12a01902f9dc6ee38fdc05d6c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   powersync:
     dependency: "direct main"
     description:
@@ -347,10 +347,10 @@ packages:
     dependency: transitive
     description:
       name: realtime_client
-      sha256: "5831636c19802ba936093a35a7c5b745b130e268fa052e84b4b5290139d2ae03"
+      sha256: "41d6c5e0327d6c270b98b79bfed672928244af60e2856770f3eff697f9efe459"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   retry:
     dependency: transitive
     description:
@@ -411,10 +411,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: "7b15ffb9387ea3e237bb7a66b8a23d2147663d391cafc5c8f37b2e7b4bde5d21"
+      sha256: d762709c2bbe80626ecc819143013cc820fa49ca5e363620ee20a8b15a3e3daf
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.1"
   shared_preferences_windows:
     dependency: transitive
     description:
@@ -504,18 +504,18 @@ packages:
     dependency: transitive
     description:
       name: supabase
-      sha256: "4bce9c49f264f4cd44b4ffc895647af2dca0c40125c169045be9f708fd2a2a40"
+      sha256: f431753d2a4cb9dacd72c7378154f806c2b2cef23859bd9cee1add23821e874d
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.7"
+    version: "2.0.8"
   supabase_flutter:
     dependency: "direct main"
     description:
       name: supabase_flutter
-      sha256: "5ef71289c380b6429216e941c69971c75eaab50d67fd7b540f6c1f6ebfc00ed7"
+      sha256: "30e966b89ee61dc9de845e2d7e1c60967b3189c410d105c6d42f09b6259f4cb6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.3.4"
   term_glyph:
     dependency: transitive
     description:
@@ -592,18 +592,18 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
-      sha256: a932c3a8082e118f80a475ce692fde89dc20fddb24c57360b96bc56f7035de1f
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: fff0932192afeedf63cdd50ecbb1bc825d31aed259f02bb8dba0f3b729a5e88b
+      sha256: "7fd2f55fe86cea2897b963e864dc01a7eb0719ecc65fcef4c1cc3d686d718bb2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.0"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -670,4 +670,4 @@ packages:
     version: "2.0.0"
 sdks:
   dart: ">=3.2.3 <4.0.0"
-  flutter: ">=3.16.0"
+  flutter: ">=3.13.0"

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.3.0-alpha.2
+  powersync: ^1.3.0-alpha.3
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   supabase_flutter: ^2.0.2
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.7.0-alpha.1
+  sqlite_async: ^0.7.0-alpha.2
   universal_io: ^2.2.2
 
 dev_dependencies:

--- a/demos/supabase-simple-chat/lib/pages/login_page.dart
+++ b/demos/supabase-simple-chat/lib/pages/login_page.dart
@@ -37,7 +37,7 @@ class LoginPageState extends State<LoginPage> {
     } catch (_) {
       context.showErrorSnackBar(message: unexpectedErrorMessage);
     }
-    if (mounted) {
+    if (context.mounted) {
       setState(() {
         _isLoading = true;
       });

--- a/demos/supabase-simple-chat/pubspec.lock
+++ b/demos/supabase-simple-chat/pubspec.lock
@@ -443,10 +443,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: "7b15ffb9387ea3e237bb7a66b8a23d2147663d391cafc5c8f37b2e7b4bde5d21"
+      sha256: d762709c2bbe80626ecc819143013cc820fa49ca5e363620ee20a8b15a3e3daf
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.1"
   shared_preferences_windows:
     dependency: transitive
     description:
@@ -656,18 +656,18 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
-      sha256: a932c3a8082e118f80a475ce692fde89dc20fddb24c57360b96bc56f7035de1f
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: fff0932192afeedf63cdd50ecbb1bc825d31aed259f02bb8dba0f3b729a5e88b
+      sha256: "7fd2f55fe86cea2897b963e864dc01a7eb0719ecc65fcef4c1cc3d686d718bb2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.0"
   url_launcher_windows:
     dependency: transitive
     description:

--- a/demos/supabase-simple-chat/pubspec.lock
+++ b/demos/supabase-simple-chat/pubspec.lock
@@ -374,7 +374,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.3.0-alpha.1"
+    version: "1.3.0-alpha.2"
   realtime_client:
     dependency: transitive
     description:

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^1.10.25
   timeago: ^3.6.0
-  powersync: ^1.3.0-alpha.2
+  powersync: ^1.3.0-alpha.3
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist/ios/Runner.xcodeproj/project.pbxproj
+++ b/demos/supabase-todolist/ios/Runner.xcodeproj/project.pbxproj
@@ -155,7 +155,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/demos/supabase-todolist/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/demos/supabase-todolist/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/demos/supabase-todolist/lib/attachments/photo_widget.dart
+++ b/demos/supabase-todolist/lib/attachments/photo_widget.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:powersync_attachments_helper/powersync_attachments_helper.dart';
 import 'package:powersync_flutter_demo/attachments/camera_helpers.dart';
 import 'package:powersync_flutter_demo/attachments/photo_capture_widget.dart';
 import 'package:powersync_flutter_demo/attachments/queue.dart';
@@ -23,8 +24,10 @@ class PhotoWidget extends StatefulWidget {
 class _ResolvedPhotoState {
   String? photoPath;
   bool fileExists;
+  Attachment? attachment;
 
-  _ResolvedPhotoState({required this.photoPath, required this.fileExists});
+  _ResolvedPhotoState(
+      {required this.photoPath, required this.fileExists, this.attachment});
 }
 
 class _PhotoWidgetState extends State<PhotoWidget> {
@@ -38,7 +41,17 @@ class _PhotoWidgetState extends State<PhotoWidget> {
 
     bool fileExists = await File(photoPath).exists();
 
-    return _ResolvedPhotoState(photoPath: photoPath, fileExists: fileExists);
+    final row = await attachmentQueue.db
+        .getOptional('SELECT * FROM attachments_queue WHERE id = ?', [photoId]);
+
+    if (row != null) {
+      Attachment attachment = Attachment.fromRow(row);
+      return _ResolvedPhotoState(
+          photoPath: photoPath, fileExists: fileExists, attachment: attachment);
+    }
+
+    return _ResolvedPhotoState(
+        photoPath: photoPath, fileExists: fileExists, attachment: null);
   }
 
   @override
@@ -54,7 +67,7 @@ class _PhotoWidgetState extends State<PhotoWidget> {
           Widget takePhotoButton = ElevatedButton(
             onPressed: () async {
               final camera = await setupCamera();
-              if (!mounted) return;
+              if (!context.mounted) return;
 
               if (camera == null) {
                 const snackBar = SnackBar(
@@ -84,6 +97,20 @@ class _PhotoWidgetState extends State<PhotoWidget> {
 
           String? filePath = data.photoPath;
           bool fileIsDownloading = !data.fileExists;
+          bool fileArchived =
+              data.attachment?.state == AttachmentState.archived.index;
+
+          if (fileArchived) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const Text("Unavailable"),
+                const SizedBox(height: 8),
+                takePhotoButton
+              ],
+            );
+          }
 
           if (fileIsDownloading) {
             return const Text("Downloading...");

--- a/demos/supabase-todolist/lib/attachments/queue.dart
+++ b/demos/supabase-todolist/lib/attachments/queue.dart
@@ -11,9 +11,21 @@ import 'package:powersync_flutter_demo/models/schema.dart';
 late final PhotoAttachmentQueue attachmentQueue;
 final remoteStorage = SupabaseStorageAdapter();
 
+/// Function to handle errors when downloading attachments
+/// Return false if you want to archive the attachment
+Future<bool> onDownloadError(Attachment attachment, Object exception) async {
+  if (exception.toString().contains('Object not found')) {
+    return false;
+  }
+  return true;
+}
+
 class PhotoAttachmentQueue extends AbstractAttachmentQueue {
   PhotoAttachmentQueue(db, remoteStorage)
-      : super(db: db, remoteStorage: remoteStorage);
+      : super(
+            db: db,
+            remoteStorage: remoteStorage,
+            onDownloadError: onDownloadError);
 
   @override
   init() async {

--- a/demos/supabase-todolist/lib/widgets/lists_page.dart
+++ b/demos/supabase-todolist/lib/widgets/lists_page.dart
@@ -61,7 +61,7 @@ class _ListsWidgetState extends State<ListsWidget> {
     super.initState();
     final stream = TodoList.watchListsWithStats();
     _subscription = stream.listen((data) {
-      if (!mounted) {
+      if (!context.mounted) {
         return;
       }
       setState(() {

--- a/demos/supabase-todolist/lib/widgets/login_page.dart
+++ b/demos/supabase-todolist/lib/widgets/login_page.dart
@@ -34,7 +34,7 @@ class _LoginPageState extends State<LoginPage> {
       await Supabase.instance.client.auth.signInWithPassword(
           email: _usernameController.text, password: _passwordController.text);
 
-      if (mounted) {
+      if (context.mounted) {
         Navigator.of(context).pushReplacement(MaterialPageRoute(
           builder: (context) => listsPage,
         ));

--- a/demos/supabase-todolist/lib/widgets/query_widget.dart
+++ b/demos/supabase-todolist/lib/widgets/query_widget.dart
@@ -46,7 +46,7 @@ class QueryWidgetState extends State<QueryWidget> {
     _subscription?.cancel();
     final stream = db.watch(_query);
     _subscription = stream.listen((data) {
-      if (!mounted) {
+      if (!context.mounted) {
         return;
       }
       setState(() {

--- a/demos/supabase-todolist/lib/widgets/signup_page.dart
+++ b/demos/supabase-todolist/lib/widgets/signup_page.dart
@@ -34,7 +34,7 @@ class _SignupPageState extends State<SignupPage> {
       final response = await Supabase.instance.client.auth.signUp(
           email: _usernameController.text, password: _passwordController.text);
 
-      if (mounted) {
+      if (context.mounted) {
         if (response.session != null) {
           Navigator.of(context).pushReplacement(MaterialPageRoute(
             builder: (context) => homePage,

--- a/demos/supabase-todolist/lib/widgets/todo_list_page.dart
+++ b/demos/supabase-todolist/lib/widgets/todo_list_page.dart
@@ -62,7 +62,7 @@ class TodoListWidgetState extends State<TodoListWidget> {
     super.initState();
     final stream = widget.list.watchItems();
     _subscription = stream.listen((data) {
-      if (!mounted) {
+      if (!context.mounted) {
         return;
       }
       setState(() {

--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -430,7 +430,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.3.0-alpha.1"
+    version: "1.3.0-alpha.2"
   powersync_attachments_helper:
     dependency: "direct main"
     description:
@@ -559,10 +559,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqlite_async
-      sha256: "91f454cddc85617bea2c7c1544ff386887d0d2cf0ecdb3599015c05cc141ff4d"
+      sha256: "7a68036b2fc2fae5fc0efbc6bd436deb79e39090282348d979e6a7c38c8d067e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0-alpha.1"
+    version: "0.7.0-alpha.2"
   stack_trace:
     dependency: transitive
     description:

--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: fedaadfa3a6996f75211d835aaeb8fede285dae94262485698afd832371b9a5e
+      sha256: "2f9d2cbccb76127ba28528cb3ae2c2326a122446a83de5a056aaa3880d3882c5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3+8"
+    version: "0.3.3+7"
   crypto:
     dependency: transitive
     description:
@@ -220,10 +220,10 @@ packages:
     dependency: transitive
     description:
       name: gotrue
-      sha256: f40610bacf1074723354b0856a4f586508ffb075b799f72466f34e843133deb9
+      sha256: "1bf6354278a98b8a1867263e94921da8a239de07e9babceab2b4e80af651a098"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.5.1"
   gtk:
     dependency: transitive
     description:
@@ -420,10 +420,10 @@ packages:
     dependency: transitive
     description:
       name: postgrest
-      sha256: "748ebffffb60b4eaa270955dcf3742a19a2b315344c41ff1b4a0ebcd322b5181"
+      sha256: "9a3b590cf123f8d323b6a918702e037f037027d12a01902f9dc6ee38fdc05d6c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   powersync:
     dependency: "direct main"
     description:
@@ -442,10 +442,10 @@ packages:
     dependency: transitive
     description:
       name: realtime_client
-      sha256: "5831636c19802ba936093a35a7c5b745b130e268fa052e84b4b5290139d2ae03"
+      sha256: "41d6c5e0327d6c270b98b79bfed672928244af60e2856770f3eff697f9efe459"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   retry:
     dependency: transitive
     description:
@@ -506,10 +506,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: "7b15ffb9387ea3e237bb7a66b8a23d2147663d391cafc5c8f37b2e7b4bde5d21"
+      sha256: d762709c2bbe80626ecc819143013cc820fa49ca5e363620ee20a8b15a3e3daf
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.1"
   shared_preferences_windows:
     dependency: transitive
     description:
@@ -607,18 +607,18 @@ packages:
     dependency: transitive
     description:
       name: supabase
-      sha256: "4bce9c49f264f4cd44b4ffc895647af2dca0c40125c169045be9f708fd2a2a40"
+      sha256: f431753d2a4cb9dacd72c7378154f806c2b2cef23859bd9cee1add23821e874d
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.7"
+    version: "2.0.8"
   supabase_flutter:
     dependency: "direct main"
     description:
       name: supabase_flutter
-      sha256: "5ef71289c380b6429216e941c69971c75eaab50d67fd7b540f6c1f6ebfc00ed7"
+      sha256: "30e966b89ee61dc9de845e2d7e1c60967b3189c410d105c6d42f09b6259f4cb6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.3.4"
   term_glyph:
     dependency: transitive
     description:
@@ -695,18 +695,18 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
-      sha256: a932c3a8082e118f80a475ce692fde89dc20fddb24c57360b96bc56f7035de1f
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: fff0932192afeedf63cdd50ecbb1bc825d31aed259f02bb8dba0f3b729a5e88b
+      sha256: "7fd2f55fe86cea2897b963e864dc01a7eb0719ecc65fcef4c1cc3d686d718bb2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.0"
   url_launcher_windows:
     dependency: transitive
     description:

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   powersync_attachments_helper: ^0.3.0-alpha.1
 
-  powersync: ^1.3.0-alpha.2
+  powersync: ^1.3.0-alpha.3
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   supabase_flutter: ^2.0.1
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.7.0-alpha.1
+  sqlite_async: ^0.7.0-alpha.2
   camera: ^0.10.5+7
   image: ^4.1.3
   universal_io: ^2.2.2

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0-alpha.3
+
+ - Fixed issue where disconnectAndClear would prevent subsequent sync connection on native platforms and would fail to clear the database on web.
+
 ## 1.3.0-alpha.2
 
  - **FIX**(powersync-attachements-helper): pubspec file (#29).

--- a/packages/powersync/lib/src/database/native/native_powersync_database.dart
+++ b/packages/powersync/lib/src/database/native/native_powersync_database.dart
@@ -332,7 +332,7 @@ Future<void> _powerSyncDatabaseIsolate(
         updateStream: updateController.stream,
         retryDelay: args.retryDelay,
         client: http.Client());
-    sync.streamingSync(null);
+    sync.streamingSync();
     sync.statusStream.listen((event) {
       sPort.send(['status', event]);
     });

--- a/packages/powersync/lib/src/database/native/native_powersync_database.dart
+++ b/packages/powersync/lib/src/database/native/native_powersync_database.dart
@@ -332,7 +332,7 @@ Future<void> _powerSyncDatabaseIsolate(
         updateStream: updateController.stream,
         retryDelay: args.retryDelay,
         client: http.Client());
-    sync.streamingSync();
+    sync.streamingSync(null);
     sync.statusStream.listen((event) {
       sPort.send(['status', event]);
     });

--- a/packages/powersync/lib/src/database/powersync_db_mixin.dart
+++ b/packages/powersync/lib/src/database/powersync_db_mixin.dart
@@ -44,6 +44,8 @@ mixin PowerSyncDatabaseMixin implements SqliteConnection {
   StreamController<SyncStatus> statusStreamController =
       StreamController<SyncStatus>.broadcast();
 
+  @override
+
   /// Broadcast stream that is notified of any table updates.
   ///
   /// Unlike in [SqliteDatabase.updates], the tables reported here are the

--- a/packages/powersync/lib/src/database/web/web_powersync_database.dart
+++ b/packages/powersync/lib/src/database/web/web_powersync_database.dart
@@ -144,7 +144,7 @@ class PowerSyncDatabaseImpl
     sync.statusStream.listen((event) {
       setStatus(event);
     });
-    sync.streamingSync(disconnecter);
+    sync.streamingSync(abortController: disconnecter);
   }
 
   /// Takes a read lock, without starting a transaction.

--- a/packages/powersync/lib/src/database/web/web_powersync_database.dart
+++ b/packages/powersync/lib/src/database/web/web_powersync_database.dart
@@ -124,8 +124,7 @@ class PowerSyncDatabaseImpl
 
     // Disconnect if connected
     await disconnect();
-    final disconnector = AbortController();
-    disconnecter = disconnector;
+    disconnecter = AbortController();
 
     await isInitialized;
 
@@ -145,7 +144,7 @@ class PowerSyncDatabaseImpl
     sync.statusStream.listen((event) {
       setStatus(event);
     });
-    sync.streamingSync();
+    sync.streamingSync(disconnecter);
   }
 
   /// Takes a read lock, without starting a transaction.

--- a/packages/powersync/lib/src/streaming_sync.dart
+++ b/packages/powersync/lib/src/streaming_sync.dart
@@ -49,7 +49,7 @@ class StreamingSyncImplementation {
     statusStream = _statusStreamController.stream;
   }
 
-  Future<void> streamingSync(AbortController? abortController) async {
+  Future<void> streamingSync({AbortController? abortController}) async {
     crudLoop();
     var invalidCredentials = false;
     while (true) {
@@ -65,7 +65,7 @@ class StreamingSyncImplementation {
           await invalidCredentialsCallback!();
           invalidCredentials = false;
         }
-        await streamingSyncIteration(abortController);
+        await streamingSyncIteration(abortController: abortController);
         // Continue immediately
       } catch (e, stacktrace) {
         final message = _syncErrorMessage(e);
@@ -178,7 +178,8 @@ class StreamingSyncImplementation {
     _statusStreamController.add(newStatus);
   }
 
-  Future<bool> streamingSyncIteration(AbortController? abortController) async {
+  Future<bool> streamingSyncIteration(
+      {AbortController? abortController}) async {
     adapter.startSession();
     final bucketEntries = await adapter.getBucketStates();
 

--- a/packages/powersync/lib/src/streaming_sync.dart
+++ b/packages/powersync/lib/src/streaming_sync.dart
@@ -54,6 +54,7 @@ class StreamingSyncImplementation {
     var invalidCredentials = false;
     while (true) {
       if (abortController?.aborted == true) {
+        abortController!.completeAbort();
         return;
       }
       _updateStatus(connecting: true);

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.3.0-alpha.2
+version: 1.3.0-alpha.3
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - keep PostgreSQL databases in sync with on-device SQLite databases.

--- a/packages/powersync/test/disconnect_test.dart
+++ b/packages/powersync/test/disconnect_test.dart
@@ -16,8 +16,6 @@ void main() {
     });
 
     test('Multiple calls to disconnect', () async {
-      // Start with "offline-only" schema.
-      // This does not record any operations to the crud queue.
       final db = await testUtils.setupPowerSync(path: path, schema: testSchema);
 
       credentialsCallback() async {
@@ -43,8 +41,6 @@ void main() {
     });
 
     test('disconnectAndClear clears DB', () async {
-      // Start with "offline-only" schema.
-      // This does not record any operations to the crud queue.
       final db = await testUtils.setupPowerSync(path: path, schema: testSchema);
 
       await db.execute(

--- a/packages/powersync/test/disconnect_test.dart
+++ b/packages/powersync/test/disconnect_test.dart
@@ -1,0 +1,64 @@
+import 'package:powersync/powersync.dart';
+import 'package:test/test.dart';
+import 'streaming_sync_test.dart';
+import 'utils/test_utils_impl.dart';
+import 'watch_test.dart';
+
+final testUtils = TestUtils();
+
+void main() {
+  group('Disconnect Tests', () {
+    late String path;
+
+    setUp(() async {
+      path = testUtils.dbPath();
+      await testUtils.cleanDb(path: path);
+    });
+
+    test('Multiple calls to disconnect', () async {
+      // Start with "offline-only" schema.
+      // This does not record any operations to the crud queue.
+      final db = await testUtils.setupPowerSync(path: path, schema: testSchema);
+
+      credentialsCallback() async {
+        // A blank endpoint will fail, but that's okay for this test
+        final endpoint = '';
+        return PowerSyncCredentials(
+            endpoint: endpoint,
+            token: 'token',
+            userId: 'u1',
+            expiresAt: DateTime.now());
+      }
+
+      db.retryDelay = Duration(milliseconds: 5000);
+      var connector = TestConnector(credentialsCallback);
+      await db.connect(connector: connector);
+
+      // Call disconnect multiple times, each Future should resolve
+      final disconnect1 = db.disconnect();
+      final disconnect2 = db.disconnect();
+
+      await expectLater(disconnect1, completes);
+      await expectLater(disconnect2, completes);
+    });
+
+    test('disconnectAndClear clears DB', () async {
+      // Start with "offline-only" schema.
+      // This does not record any operations to the crud queue.
+      final db = await testUtils.setupPowerSync(path: path, schema: testSchema);
+
+      await db.execute(
+          'INSERT INTO customers (id, name, email) VALUES(uuid(), ?, ?)',
+          ['Steven', 'steven@journeyapps.com']);
+
+      final getCustomersQuery = 'SELECT * from customers';
+      final initialCustomers = await db.getAll(getCustomersQuery);
+      expect(initialCustomers.length, equals(1));
+
+      await db.disconnectAndClear();
+
+      final finalCustomers = await db.getAll(getCustomersQuery);
+      expect(finalCustomers.length, equals(0));
+    });
+  });
+}

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 - Added initial support for Web platform.
 
+## 0.2.1
+
+- Added `onUploadError` as an optional function that can be set when setting up the queue to handle upload errors
+- Added `onDownloadError` as an optional function that can be set when setting up the queue to handle upload errors
+
 ## 0.2.0
 
 - Potentially BREAKING CHANGE for users who rely on multiple attachment queues.
-  Moved away from randomly generating queue table name in favour of  a user creating a queue and table using a name of their choosing.
+  Moved away from randomly generating queue table name in favour of a user creating a queue and table using a name of their choosing.
 
 ## 0.1.5
 

--- a/packages/powersync_attachments_helper/lib/src/attachments_queue.dart
+++ b/packages/powersync_attachments_helper/lib/src/attachments_queue.dart
@@ -24,16 +24,28 @@ abstract class AbstractAttachmentQueue {
   final LocalStorageAdapter localStorage = LocalStorageAdapter();
   String attachmentsQueueTableName;
 
+  /// Function to handle errors when downloading attachments
+  /// Return true if you want to ignore attachment
+  Future<bool> Function(Attachment attachment, Object exception)?
+      onDownloadError;
+
+  /// Function to handle errors when uploading attachments
+  /// Return true if you want to ignore attachment
+  Future<bool> Function(Attachment attachment, Object exception)? onUploadError;
+
   AbstractAttachmentQueue(
       {required this.db,
       required this.remoteStorage,
       this.attachmentDirectoryName = 'attachments',
       this.attachmentsQueueTableName = defaultAttachmentsQueueTableName,
+      this.onDownloadError,
+      this.onUploadError,
       performInitialSync = true}) {
     attachmentsService = AttachmentsService(
         db, localStorage, attachmentDirectoryName, attachmentsQueueTableName);
     syncingService = SyncingService(
-        db, remoteStorage, localStorage, attachmentsService, getLocalUri);
+        db, remoteStorage, localStorage, attachmentsService, getLocalUri,
+        onDownloadError: onDownloadError, onUploadError: onUploadError);
   }
 
   /// Create watcher to get list of ID's from a table to be used for syncing in the attachment queue.

--- a/packages/powersync_attachments_helper/lib/src/attachments_queue_table.dart
+++ b/packages/powersync_attachments_helper/lib/src/attachments_queue_table.dart
@@ -64,11 +64,8 @@ class Attachment {
 /// 1. Attachment to be uploaded
 /// 2. Attachment to be downloaded
 /// 3. Attachment to be deleted
-enum AttachmentState {
-  queuedUpload,
-  queuedDownload,
-  queuedDelete,
-}
+/// 4. Attachment to be archived
+enum AttachmentState { queuedUpload, queuedDownload, queuedDelete, archived }
 
 class AttachmentsQueueTable extends Table {
   AttachmentsQueueTable(

--- a/packages/powersync_attachments_helper/lib/src/attachments_service.dart
+++ b/packages/powersync_attachments_helper/lib/src/attachments_service.dart
@@ -23,6 +23,11 @@ class AttachmentsService {
   Future<void> deleteAttachment(String id) async =>
       db.execute('DELETE FROM $table WHERE id = ?', [id]);
 
+  ///Set the state of the attachment to ignore.
+  Future<void> ignoreAttachment(String id) async => db.execute(
+      'UPDATE $table SET state = ${AttachmentState.archived.index} WHERE id = ?',
+      [id]);
+
   /// Get the attachment from the attachment queue using an ID.
   Future<Attachment?> getAttachment(String id) async =>
       db.getOptional('SELECT * FROM $table WHERE id = ?', [id]).then((row) {

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   powersync: ^1.3.0-alpha.2
   logging: ^1.2.0
   sqlite3: ^2.3.0
-  sqlite_async: ^0.7.0-alpha.1
+  sqlite_async: ^0.7.0-alpha.2
   path_provider: ^2.1.1
 
 dev_dependencies:

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.3.0-alpha.2
+  powersync: ^1.3.0-alpha.3
   logging: ^1.2.0
   sqlite3: ^2.3.0
   sqlite_async: ^0.7.0-alpha.2

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -245,10 +245,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:


### PR DESCRIPTION
# Description

This fixes multiple issues regarding disconnecting and clearing the database.

This also updates the `alpha-release` branch with changes from `master`

## Native
For native platforms this fixes an issue where after calling `disconnect` the PowerSync client would fail to re-establish a valid streaming connection.

This is fixed by updating `sqlite_async` to `0.7.0-alpha.2`

## Web
For web this fixes an issue where if calling `disconnect`(or `disconnectAndClear`) multiple times, the abort controller was not cleared, which would attempt to abort twice - which throws an exception. 

If `disconnect` was called first, say from an authentication provider listener such as in [here](https://github.com/powersync-ja/powersync.dart/blob/92896fe7bdcecf7d4123f7d64e4d5cc5122cd8c9/demos/supabase-todolist/lib/powersync.dart#L184) then `disconnectAndClear` was called thereafter, the `disconnectAndClear` function would throw an exception before actually clearing the database.

This PR properly aborts the web streaming sync connection and awaits for the abort process to complete.

