### PR TITLE
fix: attachment queue duplicating requests

### DIFF
--- a/demos/supabase-todolist/lib/attachments/queue.dart
+++ b/demos/supabase-todolist/lib/attachments/queue.dart
@@ -74,9 +74,9 @@ class PhotoAttachmentQueue extends AbstractAttachmentQueue {
       return results.map((row) => row['photo_id'] as String).toList();
     }).listen((ids) async {
       List<String> idsInQueue = await attachmentsService.getAttachmentIds();
-      for (String id in ids) {
-        await syncingService.reconcileId(id, idsInQueue, fileExtension);
-      }
+      List<String> relevantIds =
+          ids.where((element) => !idsInQueue.contains(element)).toList();
+      syncingService.processIds(relevantIds, fileExtension);
     });
   }
 }

--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -429,7 +429,7 @@ packages:
       path: "../../packages/powersync_attachments_helper"
       relative: true
     source: path
-    version: "0.2.1"
+    version: "0.3.0"
   realtime_client:
     dependency: transitive
     description:

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.3.0
 
 - BREAKING CHANGE: `reconcileId` has been removed in favour of `reconcileIds`. This will require a change to `watchIds` implementation which is shown in `example/getting_started.dart`
--
+- Improved queue so that uploads, downloads and deletes do not happen multiple times
 
 ## 0.2.1
 

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.0
+
+- BREAKING CHANGE: `reconcileId` has been removed in favour of `reconcileIds`. This will require a change to `watchIds` implementation which is shown in `example/getting_started.dart`
+-
+
 ## 0.2.1
 
 - Added `onUploadError` as an optional function that can be set when setting up the queue to handle upload errors

--- a/packages/powersync_attachments_helper/README.md
+++ b/packages/powersync_attachments_helper/README.md
@@ -62,7 +62,7 @@ class PhotoAttachmentQueue extends AbstractAttachmentQueue {
   // This watcher will handle adding items to the queue based on
   // a users table element receiving a photoId
   @override
-  StreamSubscription<void> watchIds() {
+  StreamSubscription<void> watchIds({String fileExtension = 'jpg'}) {
     return db.watch('''
       SELECT photo_id FROM users
       WHERE photo_id IS NOT NULL
@@ -70,9 +70,9 @@ class PhotoAttachmentQueue extends AbstractAttachmentQueue {
       return results.map((row) => row['photo_id'] as String).toList();
     }).listen((ids) async {
       List<String> idsInQueue = await attachmentsService.getAttachmentIds();
-      for (String id in ids) {
-        await syncingService.reconcileId(id, idsInQueue);
-      }
+      List<String> relevantIds =
+          ids.where((element) => !idsInQueue.contains(element)).toList();
+      syncingService.processIds(relevantIds, fileExtension);
     });
   }
 }

--- a/packages/powersync_attachments_helper/example/getting_started.dart
+++ b/packages/powersync_attachments_helper/example/getting_started.dart
@@ -52,9 +52,9 @@ class PhotoAttachmentQueue extends AbstractAttachmentQueue {
       return results.map((row) => row['photo_id'] as String).toList();
     }).listen((ids) async {
       List<String> idsInQueue = await attachmentsService.getAttachmentIds();
-      for (String id in ids) {
-        await syncingService.reconcileId(id, idsInQueue, fileExtension);
-      }
+      List<String> relevantIds =
+          ids.where((element) => !idsInQueue.contains(element)).toList();
+      syncingService.processIds(relevantIds, fileExtension);
     });
   }
 }

--- a/packages/powersync_attachments_helper/lib/src/attachments_queue.dart
+++ b/packages/powersync_attachments_helper/lib/src/attachments_queue.dart
@@ -67,9 +67,7 @@ abstract class AbstractAttachmentQueue {
     await localStorage.makeDir(await getStorageDirectory());
 
     watchIds();
-    syncingService.watchUploads();
-    syncingService.watchDownloads();
-    syncingService.watchDeletes();
+    syncingService.watchAttachments();
 
     db.statusStream.listen((status) {
       if (db.currentStatus.connected) {
@@ -79,9 +77,7 @@ abstract class AbstractAttachmentQueue {
   }
 
   _trigger() async {
-    await syncingService.runDownloads();
-    await syncingService.runDeletes();
-    await syncingService.runUploads();
+    await syncingService.runSync();
   }
 
   /// Returns the local file path for the given filename, used to store in the database.

--- a/packages/powersync_attachments_helper/lib/src/syncing_service.dart
+++ b/packages/powersync_attachments_helper/lib/src/syncing_service.dart
@@ -136,6 +136,7 @@ class SyncingService {
     log.info('Watching attachments...');
     return db.watch('''
       SELECT * FROM ${attachmentsService.table}
+      WHERE state != ${AttachmentState.archived.index}
     ''').map((results) {
       return results.map((row) => Attachment.fromRow(row));
     }).listen((attachments) async {
@@ -147,6 +148,7 @@ class SyncingService {
   Future<void> runSync() async {
     List<Attachment> attachments = await db.execute('''
       SELECT * FROM ${attachmentsService.table}
+      WHERE state != ${AttachmentState.archived.index}
     ''').then((results) {
       return results.map((row) => Attachment.fromRow(row)).toList();
     });

--- a/packages/powersync_attachments_helper/lib/src/syncing_service.dart
+++ b/packages/powersync_attachments_helper/lib/src/syncing_service.dart
@@ -19,6 +19,7 @@ class SyncingService {
       onDownloadError;
   final Future<bool> Function(Attachment attachment, Object exception)?
       onUploadError;
+  bool isProcessing = false;
 
   SyncingService(this.db, this.remoteStorage, this.localStorage,
       this.attachmentsService, this.getLocalUri,
@@ -103,139 +104,77 @@ class SyncingService {
     }
   }
 
-  /// Function to manually run downloads for attachments marked for download
-  /// in the attachment queue.
-  /// Once a an attachment marked for download is found it will initiate a
-  /// download of the file to local storage.
-  StreamSubscription<void> watchDownloads() {
-    log.info('Watching downloads...');
-    return db.watch('''
-      SELECT * FROM ${attachmentsService.table}
-      WHERE state = ${AttachmentState.queuedDownload.index}
-    ''').map((results) {
-      return results.map((row) => Attachment.fromRow(row));
-    }).listen((attachments) async {
-      for (Attachment attachment in attachments) {
+  /// Handle downloading, uploading or deleting of attachments
+  Future<void> handleSync(Iterable<Attachment> attachments) async {
+    if (isProcessing == true) {
+      return;
+    }
+
+    isProcessing = true;
+
+    for (Attachment attachment in attachments) {
+      if (AttachmentState.queuedDownload.index == attachment.state) {
         log.info('Downloading ${attachment.filename}');
         await downloadAttachment(attachment);
       }
-    });
-  }
-
-  /// Watcher for attachments marked for download in the attachment queue.
-  /// Once a an attachment marked for download is found it will initiate a
-  /// download of the file to local storage.
-  Future<void> runDownloads() async {
-    List<Attachment> attachments = await db.execute('''
-      SELECT * FROM ${attachmentsService.table}
-      WHERE state = ${AttachmentState.queuedDownload.index}
-    ''').then((results) {
-      return results.map((row) => Attachment.fromRow(row)).toList();
-    });
-
-    for (Attachment attachment in attachments) {
-      log.info('Downloading ${attachment.filename}');
-      await downloadAttachment(attachment);
-    }
-  }
-
-  /// Watcher for attachments marked for upload in the attachment queue.
-  /// Once a an attachment marked for upload is found it will initiate an
-  /// upload of the file to remote storage.
-  StreamSubscription<void> watchUploads() {
-    log.info('Watching uploads...');
-    return db.watch('''
-      SELECT * FROM ${attachmentsService.table}
-      WHERE local_uri IS NOT NULL
-      AND state = ${AttachmentState.queuedUpload.index}
-    ''').map((results) {
-      return results.map((row) => Attachment.fromRow(row));
-    }).listen((attachments) async {
-      for (Attachment attachment in attachments) {
+      if (AttachmentState.queuedUpload.index == attachment.state) {
         log.info('Uploading ${attachment.filename}');
         await uploadAttachment(attachment);
       }
-    });
-  }
-
-  /// Function to manually run uploads for attachments marked for upload
-  /// in the attachment queue.
-  /// Once a an attachment marked for deletion is found it will initiate an
-  /// upload of the file to remote storage
-  Future<void> runUploads() async {
-    List<Attachment> attachments = await db.execute('''
-      SELECT * FROM ${attachmentsService.table}
-      WHERE local_uri IS NOT NULL
-      AND state = ${AttachmentState.queuedUpload.index}
-    ''').then((results) {
-      return results.map((row) => Attachment.fromRow(row)).toList();
-    });
-
-    for (Attachment attachment in attachments) {
-      log.info('Uploading ${attachment.filename}');
-      await uploadAttachment(attachment);
-    }
-  }
-
-  /// Watcher for attachments marked for deletion in the attachment queue.
-  /// Once a an attachment marked for deletion is found it will initiate remote
-  /// and local deletions of the file.
-  StreamSubscription<void> watchDeletes() {
-    log.info('Watching deletes...');
-    return db.watch('''
-      SELECT * FROM ${attachmentsService.table}
-      WHERE state = ${AttachmentState.queuedDelete.index}
-    ''').map((results) {
-      return results.map((row) => Attachment.fromRow(row));
-    }).listen((attachments) async {
-      for (Attachment attachment in attachments) {
+      if (AttachmentState.queuedDelete.index == attachment.state) {
         log.info('Deleting ${attachment.filename}');
         await deleteAttachment(attachment);
       }
+    }
+
+    isProcessing = false;
+  }
+
+  /// Watcher for changes to attachments table
+  /// Once a change is detected it will initiate a sync of the attachments
+  StreamSubscription<void> watchAttachments() {
+    log.info('Watching attachments...');
+    return db.watch('''
+      SELECT * FROM ${attachmentsService.table}
+    ''').map((results) {
+      return results.map((row) => Attachment.fromRow(row));
+    }).listen((attachments) async {
+      await handleSync(attachments);
     });
   }
 
-  /// Function to manually run deletes for attachments marked for deletion
-  /// in the attachment queue.
-  /// Once a an attachment marked for deletion is found it will initiate remote
-  /// and local deletions of the file.
-  Future<void> runDeletes() async {
+  /// Run the sync process on all attachments
+  Future<void> runSync() async {
     List<Attachment> attachments = await db.execute('''
       SELECT * FROM ${attachmentsService.table}
-      WHERE state = ${AttachmentState.queuedDelete.index}
     ''').then((results) {
       return results.map((row) => Attachment.fromRow(row)).toList();
     });
 
-    for (Attachment attachment in attachments) {
-      log.info('Deleting ${attachment.filename}');
-      await deleteAttachment(attachment);
-    }
+    await handleSync(attachments);
   }
 
-  /// Reconcile an ID with ID's in the attachment queue.
-  /// If the ID is not in the queue, but the file exists locally then it is
-  /// in local and remote storage.
-  /// If the ID is in the queue, but the file does not exist locally then it is
-  /// marked for download.
-  reconcileId(String id, List<String> idsInQueue, String fileExtension) async {
-    bool idIsInQueue = idsInQueue.contains(id);
+  /// Process ID's to be included in the attachment queue.
+  processIds(List<String> ids, String fileExtension) async {
+    List<Attachment> attachments = List.empty(growable: true);
 
-    String path = await getLocalUri('$id.$fileExtension');
-    File file = File(path);
-    bool fileExists = await file.exists();
+    for (String id in ids) {
+      String path = await getLocalUri('$id.$fileExtension');
+      File file = File(path);
+      bool fileExists = await file.exists();
 
-    if (!idIsInQueue) {
       if (fileExists) {
         log.info('ignore file $id.$fileExtension as it already exists');
         return;
       }
+
       log.info('Adding $id to queue');
-      return await attachmentsService.saveAttachment(Attachment(
-        id: id,
-        filename: '$id.$fileExtension',
-        state: AttachmentState.queuedDownload.index,
-      ));
+      attachments.add(Attachment(
+          id: id,
+          filename: '$id.$fileExtension',
+          state: AttachmentState.queuedDownload.index));
     }
+
+    await attachmentsService.saveAttachments(attachments);
   }
 }

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.2.1
+version: 0.3.0
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:
@@ -10,14 +10,14 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.1.0
+  powersync: ^1.2.2
   logging: ^1.2.0
   sqlite_async: ^0.6.0
-  path_provider: ^2.1.1
+  path_provider: ^2.1.2
 
 dev_dependencies:
   lints: ^3.0.0
-  test: ^1.25.0
+  test: ^1.25.2
 
 platforms:
   android:


### PR DESCRIPTION
## Description
Improve attachment queue so that multiple uploads, downloads and deletes don't run simultaneously. This is related to this support query in discord https://discord.com/channels/1138230179878154300/1220388800455250082

## Work Done 
* Replaced `watchDownloads`, `watchUploads` and `watchDeletes` into a single watcher `watchAttachments` so that duplicate upload, download or delete function calls do not occur when table is updated.
* Replaced `runDownloads`, `runUploads` and `runDeletes` into a single function `runSync` so that duplicate upload, download or delete function calls do not occur when table is updated.
* Updated dependencies
* Updated docs

## How to test
* Delete the demo app from the device you are using. Make sure you have set a bucket in config.
* Install the demo app and log in
* You should see a watcher run and begin downloading images. These should happen one at a time and not be duplicated.
* Now create a new todo and attach a photo.
* The upload should only occur once.

## Videos

### Downloading
https://github.com/powersync-ja/powersync.dart/assets/46312751/273c52fa-d7a4-43cc-aec3-d6a11d3701f3

### Uploading
https://github.com/powersync-ja/powersync.dart/assets/46312751/06c75b1b-9b8d-4cfb-b4c5-568f34b9be45

### Deleting
https://github.com/powersync-ja/powersync.dart/assets/46312751/c94434f0-6d54-4618-82f1-1722c438edf6

