### PR TITLE
chore(attachments): minor improvements and fix loop

### DIFF
--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -429,7 +429,7 @@ packages:
       path: "../../packages/powersync_attachments_helper"
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.3.1"
   realtime_client:
     dependency: transitive
     description:

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.1
+
+- Add periodic syncing and deleting of attachments
+- Minor improvements
+
 ## 0.3.0
 
 - BREAKING CHANGE: `reconcileId` has been removed in favour of `reconcileIds`. This will require a change to `watchIds` implementation which is shown in `example/getting_started.dart`

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 0.3.1
 
 - Add periodic syncing and deleting of attachments
-- Minor improvements
+- Remove unnecessary delete
+- Fix loop
 
 ## 0.3.0
 

--- a/packages/powersync_attachments_helper/lib/src/attachments_queue.dart
+++ b/packages/powersync_attachments_helper/lib/src/attachments_queue.dart
@@ -33,7 +33,7 @@ abstract class AbstractAttachmentQueue {
   /// Return true if you want to ignore attachment
   Future<bool> Function(Attachment attachment, Object exception)? onUploadError;
 
-  /// Interval in minutes to periodically delete archived attachments
+  /// Interval in minutes to periodically run [syncingService.startPeriodicSync]
   /// Default is 5 minutes
   int intervalInMinutes;
 

--- a/packages/powersync_attachments_helper/lib/src/attachments_queue.dart
+++ b/packages/powersync_attachments_helper/lib/src/attachments_queue.dart
@@ -33,6 +33,10 @@ abstract class AbstractAttachmentQueue {
   /// Return true if you want to ignore attachment
   Future<bool> Function(Attachment attachment, Object exception)? onUploadError;
 
+  /// Interval in minutes to periodically delete archived attachments
+  /// Default is 5 minutes
+  int intervalInMinutes;
+
   AbstractAttachmentQueue(
       {required this.db,
       required this.remoteStorage,
@@ -40,7 +44,7 @@ abstract class AbstractAttachmentQueue {
       this.attachmentsQueueTableName = defaultAttachmentsQueueTableName,
       this.onDownloadError,
       this.onUploadError,
-      performInitialSync = true}) {
+      this.intervalInMinutes = 5}) {
     attachmentsService = AttachmentsService(
         db, localStorage, attachmentDirectoryName, attachmentsQueueTableName);
     syncingService = SyncingService(
@@ -68,6 +72,7 @@ abstract class AbstractAttachmentQueue {
 
     watchIds();
     syncingService.watchAttachments();
+    syncingService.startPeriodicSync(intervalInMinutes);
 
     db.statusStream.listen((status) {
       if (db.currentStatus.connected) {

--- a/packages/powersync_attachments_helper/lib/src/attachments_service.dart
+++ b/packages/powersync_attachments_helper/lib/src/attachments_service.dart
@@ -93,10 +93,6 @@ class AttachmentsService {
       (id, filename, local_uri, media_type, size, timestamp, state) VALUES (?, ?, ?, ?, ?, ?, ?)
     ''', updatedRecords);
 
-    await db.executeBatch('''
-      DELETE FROM $table WHERE id = ?
-    ''', ids);
-
     return;
   }
 

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.3.0
+version: 0.3.1
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:
@@ -12,7 +12,7 @@ dependencies:
 
   powersync: ^1.2.2
   logging: ^1.2.0
-  sqlite_async: ^0.6.0
+  sqlite_async: ^0.6.1
   path_provider: ^2.1.2
 
 dev_dependencies:


### PR DESCRIPTION
## Description
Minor improvements based on feedack

## Work Done
* Added a scheduled sync task that runs a sync and deletes archived data
* Fixed loop to use continue instead of return
* Removed unnecessary `executeBatch` delete