### PR TITLE
Reset isProcessing when exception is thrown during sync process.

### DIFF
--- a/packages/powersync_attachments_helper/lib/src/syncing_service.dart
+++ b/packages/powersync_attachments_helper/lib/src/syncing_service.dart
@@ -107,28 +107,32 @@ class SyncingService {
 
   /// Handle downloading, uploading or deleting of attachments
   Future<void> handleSync(Iterable<Attachment> attachments) async {
-    if (isProcessing == true) {
-      return;
+      if (isProcessing == true) {
+        return;
+      }
+  
+    try {
+      isProcessing = true;
+
+      for (Attachment attachment in attachments) {
+        if (AttachmentState.queuedDownload.index == attachment.state) {
+          log.info('Downloading ${attachment.filename}');
+          await downloadAttachment(attachment);
+        }
+        if (AttachmentState.queuedUpload.index == attachment.state) {
+          log.info('Uploading ${attachment.filename}');
+          await uploadAttachment(attachment);
+        }
+        if (AttachmentState.queuedDelete.index == attachment.state) {
+          log.info('Deleting ${attachment.filename}');
+          await deleteAttachment(attachment);
+        }
+      }
+    } finally {
+      // if anything throws an exception
+      // reset the ability to sync
+      isProcessing = false;
     }
-
-    isProcessing = true;
-
-    for (Attachment attachment in attachments) {
-      if (AttachmentState.queuedDownload.index == attachment.state) {
-        log.info('Downloading ${attachment.filename}');
-        await downloadAttachment(attachment);
-      }
-      if (AttachmentState.queuedUpload.index == attachment.state) {
-        log.info('Uploading ${attachment.filename}');
-        await uploadAttachment(attachment);
-      }
-      if (AttachmentState.queuedDelete.index == attachment.state) {
-        log.info('Deleting ${attachment.filename}');
-        await deleteAttachment(attachment);
-      }
-    }
-
-    isProcessing = false;
   }
 
   /// Watcher for changes to attachments table

--- a/packages/powersync_attachments_helper/lib/src/syncing_service.dart
+++ b/packages/powersync_attachments_helper/lib/src/syncing_service.dart
@@ -128,9 +128,12 @@ class SyncingService {
           await deleteAttachment(attachment);
         }
       }
+    } catch (error) {
+      log.severe(e);
+      rethrow;
     } finally {
       // if anything throws an exception
-      // reset the ability to sync
+      // reset the ability to sync again
       isProcessing = false;
     }
   }

--- a/packages/powersync_attachments_helper/lib/src/syncing_service.dart
+++ b/packages/powersync_attachments_helper/lib/src/syncing_service.dart
@@ -129,7 +129,7 @@ class SyncingService {
         }
       }
     } catch (error) {
-      log.severe(e);
+      log.severe(error);
       rethrow;
     } finally {
       // if anything throws an exception


### PR DESCRIPTION
The `isProcessing` property needs to be reset if an error is thrown during a sync so that subsequent sync attempts can be made. If it's not reset, then it's always `true` and will never sync again until the app is closed and re-opened.