### PR TITLE
Lower path_provider dependency version

### DIFF
--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   powersync: ^1.2.2
   logging: ^1.2.0
   sqlite_async: ^0.6.1
-  path_provider: ^2.1.2
+  path_provider: ^2.0.13
 
 dev_dependencies:
   lints: ^3.0.0


### PR DESCRIPTION
This increases compatibility with other projects.

Dependency calls were audited and this doesn't impact existing functionality.