### PR TITLE
[Fix] Sync stream connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2024-05-30
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - [`powersync_attachments_helper` - `v0.3.0-alpha.2`](#powersync_attachments_helper---v030-alpha2)
+
+Packages with other changes:
+
+ - [`powersync` - `v1.3.0-alpha.5`](#powersync---v130-alpha5)
+
+---
+
+#### `powersync_attachments_helper` - `v0.3.0-alpha.2`
+
+ - **FIX**: reset isProcessing when exception is thrown during sync process. (#81).
+ - **FIX**: attachment queue duplicating requests (#68).
+ - **FIX**(powersync-attachements-helper): pubspec file (#29).
+ - **FEAT**(attachments): add error handlers (#65).
+ - **DOCS**: update readmes (#38).
+ - **BREAKING** **FEAT**(attachments): cater for subdirectories in storage (#78).
+
+#### `powersync` - `v1.3.0-alpha.5`
+
+ - **FIX**(powersync-attachements-helper): pubspec file (#29).
+ - **DOCS**: update readme and getting started (#51).
+
+
 ## 2024-03-05
 
 ### Changes

--- a/demos/supabase-anonymous-auth/pubspec.lock
+++ b/demos/supabase-anonymous-auth/pubspec.lock
@@ -488,10 +488,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqlite_async
-      sha256: cfe14e9b10db9f40f550125f4a8528ad5f891754a4852bf1c1622a4b0192e80c
+      sha256: "4f43be2da7957c580643302c94ae3180045facc6b5872b7e5ba5241afd82c939"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0-alpha.3"
+    version: "0.7.0-alpha.4"
   stack_trace:
     dependency: transitive
     description:

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.3.0-alpha.3
+  powersync: ^1.3.0-alpha.5
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   supabase_flutter: ^2.0.2
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.7.0-alpha.3
+  sqlite_async: ^0.7.0-alpha.4
   universal_io: ^2.2.2
 
 dev_dependencies:

--- a/demos/supabase-edge-function-auth/pubspec.lock
+++ b/demos/supabase-edge-function-auth/pubspec.lock
@@ -488,10 +488,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqlite_async
-      sha256: cfe14e9b10db9f40f550125f4a8528ad5f891754a4852bf1c1622a4b0192e80c
+      sha256: "4f43be2da7957c580643302c94ae3180045facc6b5872b7e5ba5241afd82c939"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0-alpha.3"
+    version: "0.7.0-alpha.4"
   stack_trace:
     dependency: transitive
     description:

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.3.0-alpha.3
+  powersync: ^1.3.0-alpha.5
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   supabase_flutter: ^2.0.2
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.7.0-alpha.2
+  sqlite_async: ^0.7.0-alpha.4
   universal_io: ^2.2.2
 
 dev_dependencies:

--- a/demos/supabase-simple-chat/pubspec.lock
+++ b/demos/supabase-simple-chat/pubspec.lock
@@ -544,10 +544,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite_async
-      sha256: cfe14e9b10db9f40f550125f4a8528ad5f891754a4852bf1c1622a4b0192e80c
+      sha256: "4f43be2da7957c580643302c94ae3180045facc6b5872b7e5ba5241afd82c939"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0-alpha.3"
+    version: "0.7.0-alpha.4"
   stack_trace:
     dependency: transitive
     description:

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^1.10.25
   timeago: ^3.6.0
-  powersync: ^1.3.0-alpha.3
+  powersync: ^1.3.0-alpha.5
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: app_links
-      sha256: "42dc15aecf2618ace4ffb74a2e58a50e45cd1b9f2c17c8f0cafe4c297f08c815"
+      sha256: "96e677810b83707ff5e10fac11e4839daa0ea4e0123c35864c092699165eb3db"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "6.1.1"
   archive:
     dependency: transitive
     description:
       name: archive
-      sha256: "0763b45fa9294197a2885c8567927e2830ade852e5c896fd4ab7e0e348d0f373"
+      sha256: "6bd38d335f0954f5fad9c79e614604fbf03a0e5b975923dd001b6ea965ef5b4b"
       url: "https://pub.dev"
     source: hosted
-    version: "3.5.0"
+    version: "3.6.0"
   async:
     dependency: transitive
     description:
@@ -37,26 +37,26 @@ packages:
     dependency: "direct main"
     description:
       name: camera
-      sha256: "9499cbc2e51d8eb0beadc158b288380037618ce4e30c9acbc4fae1ac3ecb5797"
+      sha256: dfa8fc5a1adaeb95e7a54d86a5bd56f4bb0e035515354c8ac6d262e35cec2ec8
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.5+9"
+    version: "0.10.6"
   camera_android:
     dependency: transitive
     description:
       name: camera_android
-      sha256: "7b0aba6398afa8475e2bc9115d976efb49cf8db781e922572d443795c04a4f4f"
+      sha256: "3af7f0b55f184d392d2eec238aaa30552ebeef2915e5e094f5488bf50d6d7ca2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.9+1"
+    version: "0.10.9+3"
   camera_avfoundation:
     dependency: transitive
     description:
       name: camera_avfoundation
-      sha256: "5d009ae48de1c8ab621b1c4496dadb6e2a83f3223b76c6e6a4a252414105f561"
+      sha256: "7d021e8cd30d9b71b8b92b4ad669e80af432d722d18d6aac338572754a786c15"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.15"
+    version: "0.9.16"
   camera_platform_interface:
     dependency: transitive
     description:
@@ -125,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: drift
-      sha256: "3b276c838ff7f8e19aac18a51f9b388715268f3534eaaf8047c8455ef3c1738d"
+      sha256: "6acedc562ffeed308049f78fb1906abad3d65714580b6745441ee6d50ec564cd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.16.0"
+    version: "2.18.0"
   fake_async:
     dependency: transitive
     description:
@@ -141,18 +141,18 @@ packages:
     dependency: transitive
     description:
       name: fetch_api
-      sha256: "74a1e426d41ed9c89353703b2d80400c5d0ecfa144b2d8a7bd8882fbc9e48787"
+      sha256: "97f46c25b480aad74f7cc2ad7ccba2c5c6f08d008e68f95c1077286ce243d0e6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "2.2.0"
   fetch_client:
     dependency: transitive
     description:
       name: fetch_client
-      sha256: "83c07b07a63526a43630572c72715707ca113a8aa3459efbc7b2d366b79402af"
+      sha256: "9666ee14536778474072245ed5cba07db81ae8eb5de3b7bf4a2d1e2c49696092"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.2"
   ffi:
     dependency: transitive
     description:
@@ -194,10 +194,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: "592dc01a18961a51c24ae5d963b724b2b7fa4a95c100fe8eb6ca8a5a4732cadf"
+      sha256: c6b0b4c05c458e1c01ad9bcc14041dd7b1f6783d487be4386f793f47a8a4d03e
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.18"
+    version: "2.0.20"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -212,18 +212,18 @@ packages:
     dependency: transitive
     description:
       name: functions_client
-      sha256: a70b0dd9a1c35d05d1141557f7e49ffe4de5f450ffde31755a9eeeadca03b8ee
+      sha256: "48659e5c6a4bbe02659102bf6406a0cf39142202deae65aacfa78688f2e68946"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   gotrue:
     dependency: transitive
     description:
       name: gotrue
-      sha256: a0eee21a7e8ec09e6bbd5c9a36e31e423827b575ba6fc2dd049805dcfaac5b02
+      sha256: aaefc58b168723f8b5ca2a70ee8c0a051cba16f112be50f41c1ff8fb96b6a6df
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.7.0"
   gtk:
     dependency: transitive
     description:
@@ -252,10 +252,10 @@ packages:
     dependency: "direct main"
     description:
       name: image
-      sha256: "4c68bfd5ae83e700b5204c1e74451e7bf3cf750e6843c6e158289cf56bda018e"
+      sha256: "2237616a36c0d69aef7549ab439b833fb7f9fb9fc861af2cc9ac3eedddd69ca8"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.7"
+    version: "4.2.0"
   js:
     dependency: transitive
     description:
@@ -372,18 +372,18 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "51f0d2c554cfbc9d6a312ab35152fc77e2f0b758ce9f1a444a3a1e5b8f3c6b7f"
+      sha256: "9c96da072b421e98183f9ea7464898428e764bc0ce5567f27ec8693442e72514"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.5"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "5a7999be66e000916500be4f15a3633ebceb8302719b47b9cc49ce924125350f"
+      sha256: f234384a3fdd67f989b4d54a5d73ca2a6c422fa55ae694381ae0f4375cd1ea16
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.4.0"
   path_provider_linux:
     dependency: transitive
     description:
@@ -436,10 +436,10 @@ packages:
     dependency: transitive
     description:
       name: postgrest
-      sha256: "9a3b590cf123f8d323b6a918702e037f037027d12a01902f9dc6ee38fdc05d6c"
+      sha256: f1f78470a74c611811132ff12acdef9c08b3ec65b61e88161a057d6cc5fbbd83
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   powersync:
     dependency: "direct main"
     description:
@@ -458,10 +458,10 @@ packages:
     dependency: transitive
     description:
       name: realtime_client
-      sha256: bb6747fe2feff7f8349d563ac9d4a8f10ac2dd809bdff1e7e319321d5ea16b49
+      sha256: cd44fa21407a2e217d674f1c1a33b36c49ad0d8aea0349bf5b66594db06c80fb
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "2.1.0"
   retry:
     dependency: transitive
     description:
@@ -490,18 +490,18 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "1ee8bf911094a1b592de7ab29add6f826a7331fb854273d55918693d5364a1f2"
+      sha256: "93d0ec9dd902d85f326068e6a899487d1f65ffcd5798721a95330b26c8131577"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.3"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      sha256: "7708d83064f38060c7b39db12aefe449cb8cdc031d6062280087bc4cdb988f5c"
+      sha256: "0a8a893bf4fd1152f93fec03a415d11c27c74454d96e2318a7ac38dd18683ab7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.5"
+    version: "2.4.0"
   shared_preferences_linux:
     dependency: transitive
     description:
@@ -567,18 +567,18 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_flutter_libs
-      sha256: fb2a106a2ea6042fe57de2c47074cc31539a941819c91e105b864744605da3f5
+      sha256: "1e62698dc1ab396152ccaf3b3990d826244e9f3c8c39b51805f209adcd6dbea3"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.21"
+    version: "0.5.22"
   sqlite_async:
     dependency: "direct main"
     description:
       name: sqlite_async
-      sha256: cfe14e9b10db9f40f550125f4a8528ad5f891754a4852bf1c1622a4b0192e80c
+      sha256: "4f43be2da7957c580643302c94ae3180045facc6b5872b7e5ba5241afd82c939"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0-alpha.3"
+    version: "0.7.0-alpha.4"
   stack_trace:
     dependency: transitive
     description:
@@ -591,10 +591,10 @@ packages:
     dependency: transitive
     description:
       name: storage_client
-      sha256: bf5589d5de61a2451edb1b8960a0e673d4bb5c42ecc4dddf7c051a93789ced34
+      sha256: e37f1b9d40f43078d12bd2d1b6b08c2c16fbdbafc58b57bc44922da6ea3f5625
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   stream_channel:
     dependency: transitive
     description:
@@ -623,18 +623,18 @@ packages:
     dependency: transitive
     description:
       name: supabase
-      sha256: "2ddedf13f6dc013084569673dff7a7d540f5eacdd5b36fede8d58322e5d79c55"
+      sha256: "4555658031af0a8b38c7375f28e4b35312291f4aab0ca504dd76661381ce134f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   supabase_flutter:
     dependency: "direct main"
     description:
       name: supabase_flutter
-      sha256: "2d9683a15098258de137cb9182e695fa2a1a0f366c7409c2a6e6d47bc5a42be3"
+      sha256: "1d6fb4ffaf50fc6f60507ab8ebf0b7dedbe6fabfbd8066db6f2a6552ddd0ea8c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.5.4"
   term_glyph:
     dependency: transitive
     description:
@@ -671,26 +671,26 @@ packages:
     dependency: transitive
     description:
       name: url_launcher
-      sha256: "0ecc004c62fd3ed36a2ffcbe0dd9700aee63bd7532d0b642a488b1ec310f492e"
+      sha256: "6ce1e04375be4eed30548f10a315826fd933c1e493206eab82eed01f438c8d2e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.5"
+    version: "6.2.6"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "360a6ed2027f18b73c8d98e159dda67a61b7f2e0f6ec26e86c3ada33b0621775"
+      sha256: ceb2625f0c24ade6ef6778d1de0b2e44f2db71fded235eb52295247feba8c5cf
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.1"
+    version: "6.3.3"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: "9149d493b075ed740901f3ee844a38a00b33116c7c5c10d7fb27df8987fb51d5"
+      sha256: "7068716403343f6ba4969b4173cbf3b84fc768042124bc2c011e5d782b24fe89"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.5"
+    version: "6.3.0"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -703,10 +703,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: b7244901ea3cf489c5335bdacda07264a6e960b1c1b1a9f91e4bc371d9e68234
+      sha256: "9a1a42d5d2d95400c795b2914c36fdcb525870c752569438e4ebb09a2b5d90de"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.2.0"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -719,10 +719,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: "3692a459204a33e04bc94f5fb91158faf4f2c8903281ddd82915adecdb1a901d"
+      sha256: "8d9e750d8c9338601e709cd0885f95825086bd8b642547f26bda435aade95d8a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -775,10 +775,10 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: "0a989dc7ca2bb51eac91e8fd00851297cfffd641aa7538b165c62637ca0eaa4a"
+      sha256: a79dbe579cb51ecd6d30b17e0cae4e0ea15e2c0e66f69ad4198f22a6789e94f4
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.0"
+    version: "5.5.1"
   xdg_directories:
     dependency: transitive
     description:
@@ -804,5 +804,5 @@ packages:
     source: hosted
     version: "2.0.0"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.0"
+  dart: ">=3.4.0 <4.0.0"
+  flutter: ">=3.22.0"

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   supabase_flutter: ^2.0.1
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.7.0-alpha.3
+  sqlite_async: ^0.7.0-alpha.4
   camera: ^0.10.5+7
   image: ^4.1.3
   universal_io: ^2.2.2

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.3.0-alpha.1
+  powersync_attachments_helper: ^0.3.0-alpha.2
 
-  powersync: ^1.3.0-alpha.3
+  powersync: ^1.3.0-alpha.5
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Add `crudThrottleTime` option to arguments when running `PowerSyncDatabase.connect` to set throttle time for crud operations.
 
+## 1.3.0-alpha.5
+
+- Update `sqlite_async.dart` dependency
+- Fix issue where sync stream connection would fail to connect https://github.com/powersync-ja/powersync.dart/issues/11
+
 ## 1.3.0-alpha.4
 
 - Merge master branch in and resolve conflicts

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 1.3.0-alpha.5
-
- - **FIX**(powersync-attachements-helper): pubspec file (#29).
- - **DOCS**: update readme and getting started (#51).
-
 ## 1.3.1
 
 - Fix "Checksum mismatch" issue when calling `PowerSyncDatabase.connect` multiple times.

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.0-alpha.5
+
+ - **FIX**(powersync-attachements-helper): pubspec file (#29).
+ - **DOCS**: update readme and getting started (#51).
+
 ## 1.3.1
 
 - Fix "Checksum mismatch" issue when calling `PowerSyncDatabase.connect` multiple times.

--- a/packages/powersync/lib/src/database/web/web_powersync_database.dart
+++ b/packages/powersync/lib/src/database/web/web_powersync_database.dart
@@ -144,9 +144,7 @@ class PowerSyncDatabaseImpl
         uploadCrud: () => connector.uploadData(this),
         updateStream: updates,
         retryDelay: Duration(seconds: 3),
-        // HTTP streaming is not supported on web with the standard http package
-        // https://github.com/dart-lang/http/issues/595
-        client: FetchClient(mode: RequestMode.cors, streamRequests: true));
+        client: FetchClient(mode: RequestMode.cors));
     sync.statusStream.listen((event) {
       setStatus(event);
     });

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  sqlite_async: ^0.7.0-alpha.3
+  sqlite_async: ^0.7.0-alpha.4
   sqlite3_flutter_libs: ^0.5.15
   meta: ^1.0.0
   http: ^1.1.0

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.3.0-alpha.4
+version: 1.3.0-alpha.5
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - keep PostgreSQL databases in sync with on-device SQLite databases.

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.3.0-alpha.2
+
+> Note: This release has breaking changes.
+
+ - **FIX**: reset isProcessing when exception is thrown during sync process. (#81).
+ - **FIX**: attachment queue duplicating requests (#68).
+ - **FIX**(powersync-attachements-helper): pubspec file (#29).
+ - **FEAT**(attachments): add error handlers (#65).
+ - **DOCS**: update readmes (#38).
+ - **BREAKING** **FEAT**(attachments): cater for subdirectories in storage (#78).
+
 ## 0.4.1
 
 - Reduce version number of `path_provider` to `2.0.13`

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.3.0-alpha.1
+version: 0.3.0-alpha.2
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.3.0-alpha.3
+  powersync: ^1.3.0-alpha.5
   logging: ^1.2.0
   sqlite3: '>2.3.0 <2.4.3'
   sqlite_async: ^0.7.0-alpha.4

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   powersync: ^1.3.0-alpha.3
   logging: ^1.2.0
   sqlite3: '>2.3.0 <2.4.3'
-  sqlite_async: ^0.7.0-alpha.3
+  sqlite_async: ^0.7.0-alpha.4
   path_provider: ^2.0.13
 
 dev_dependencies:


### PR DESCRIPTION
# Overview

## Sync Stream

A recent issue https://github.com/powersync-ja/powersync.dart/issues/11#issuecomment-2133967076 showed that under certain conditions the sync stream network request would fail in web.

We currently use the [fetch_client](https://pub.dev/packages/fetch_client) package to  bind to the JS `fetch` method. This supports streaming for request body and request responses. The streaming of request bodies requires `Chromium 105+ based browsers and requires server to use HTTP/2 or HTTP/3`. We only require streaming for request responses. This allows us to remove the `streamRequests: true` param and maintain better compatibility.

## Dependency update

This PR also updates `sqlite_async.dart` to the latest alpha version.

## Testing

This was tested in the Supabase todolist app. The sync stream connection was verified by having data sync down to the client in real time.


https://github.com/powersync-ja/powersync.dart/assets/51082125/29385a2e-9c96-422a-9d37-79ac0063ed2c



