### PR TITLE
Upgrade powersync-sqlite-core to version 0.1.7 for Android

### DIFF
--- a/demos/supabase-anonymous-auth/pubspec.lock
+++ b/demos/supabase-anonymous-auth/pubspec.lock
@@ -333,7 +333,7 @@ packages:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.1.0"
   realtime_client:
     dependency: transitive
     description:

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.2.0
+  powersync: ^1.4.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.lock
+++ b/demos/supabase-edge-function-auth/pubspec.lock
@@ -333,7 +333,7 @@ packages:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.1.0"
   realtime_client:
     dependency: transitive
     description:

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.2.0
+  powersync: ^1.4.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.lock
+++ b/demos/supabase-simple-chat/pubspec.lock
@@ -365,7 +365,7 @@ packages:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.1.0"
   realtime_client:
     dependency: transitive
     description:

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^1.10.25
   timeago: ^3.6.0
-  powersync: ^1.2.0
+  powersync: ^1.4.1
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -420,7 +420,7 @@ packages:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.1.0"
   realtime_client:
     dependency: transitive
     description:

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.1.4
-  powersync: ^1.2.0
+  powersync_attachments_helper: ^0.4.1
+  powersync: ^1.4.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.1
+
+- Upgrades dependency `powersync_flutter_libs` to version `0.1.0`.
+
 ## 1.4.0
 
 - Introduces the use of the `powersync-sqlite-core` native extension.

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
 
   sqlite_async: ^0.6.1
   sqlite3_flutter_libs: ^0.5.23
-  powersync_flutter_libs: ^0.0.1
+  powersync_flutter_libs: ^0.1.0
   http: ^1.1.0
   uuid: ^4.2.0
   async: ^2.10.0

--- a/packages/powersync_flutter_libs/CHANGELOG.md
+++ b/packages/powersync_flutter_libs/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0
+
+- Upgrade `powersync-sqlite-core` on Android to version 0.1.7 which lowers the minSDK to API 21
+
 ## 0.0.1
 
 - Load the powersync extension binaries on Android, iOS, macOS, Windows and Linux

--- a/packages/powersync_flutter_libs/android/build.gradle
+++ b/packages/powersync_flutter_libs/android/build.gradle
@@ -50,5 +50,5 @@ android {
 }
 
 dependencies {
-    implementation 'co.powersync:powersync-sqlite-core:0.1.6'
+    implementation 'co.powersync:powersync-sqlite-core:0.1.7'
 }

--- a/packages/powersync_flutter_libs/pubspec.yaml
+++ b/packages/powersync_flutter_libs/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_flutter_libs
 description: PowerSync core binaries for the PowerSync Flutter SDK. Needs to be included for Flutter apps.
-version: 0.0.1
+version: 0.1.0
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 


### PR DESCRIPTION
## Work done

The work was verified by running it on an android emulator (API 21), ensuring the extension loads and `db.get('select powersync_rs_version()')` returns version 0.1.7.

- Upgrade powersync-sqlite-core to version 0.1.7 for Android
- Upgrade `powersync_flutter_libs` to version 0.1.0
- Bump `powersync` to version 1.4.1