### PR TITLE
Override default macOS sqlite db for tests

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -31,7 +31,7 @@ scripts:
 
   test:
     description: Run tests in a specific package.
-    run: dart test
+    run: flutter test
     exec:
       concurrency: 1
     packageFilters:

--- a/packages/powersync/lib/src/open_factory.dart
+++ b/packages/powersync/lib/src/open_factory.dart
@@ -79,14 +79,18 @@ class PowerSyncOpenFactory extends DefaultSqliteOpenFactory {
   }
 
   void enableExtension() {
-    var powersyncLib = Platform.isIOS || Platform.isMacOS
-        ? DynamicLibrary.process()
-        : DynamicLibrary.open(getLibraryForPlatform());
-    if (Platform.environment.containsKey('FLUTTER_TEST')) {
-      powersyncLib = DynamicLibrary.open(getLibraryForPlatform());
-    }
+    var powersyncLib = _getDynamicLibraryForPlatform();
     sqlite.sqlite3.ensureExtensionLoaded(
         SqliteExtension.inLibrary(powersyncLib, 'sqlite3_powersync_init'));
+  }
+
+  DynamicLibrary _getDynamicLibraryForPlatform() {
+    if (Platform.environment.containsKey('FLUTTER_TEST')) {
+      return DynamicLibrary.open(getLibraryForPlatform());
+    }
+    return (Platform.isIOS || Platform.isMacOS)
+        ? DynamicLibrary.process()
+        : DynamicLibrary.open(getLibraryForPlatform());
   }
 
   void setupFunctions(sqlite.Database db) {

--- a/packages/powersync/lib/src/open_factory.dart
+++ b/packages/powersync/lib/src/open_factory.dart
@@ -82,6 +82,9 @@ class PowerSyncOpenFactory extends DefaultSqliteOpenFactory {
     var powersyncLib = Platform.isIOS || Platform.isMacOS
         ? DynamicLibrary.process()
         : DynamicLibrary.open(getLibraryForPlatform());
+    if (Platform.environment.containsKey('FLUTTER_TEST')) {
+      powersyncLib = DynamicLibrary.open(getLibraryForPlatform());
+    }
     sqlite.sqlite3.ensureExtensionLoaded(
         SqliteExtension.inLibrary(powersyncLib, 'sqlite3_powersync_init'));
   }

--- a/packages/powersync/lib/src/open_factory.dart
+++ b/packages/powersync/lib/src/open_factory.dart
@@ -84,7 +84,9 @@ class PowerSyncOpenFactory extends DefaultSqliteOpenFactory {
         SqliteExtension.inLibrary(powersyncLib, 'sqlite3_powersync_init'));
   }
 
+  /// Returns the dynamic library for the current platform.
   DynamicLibrary _getDynamicLibraryForPlatform() {
+    /// When running tests, we need to load the library for all platforms.
     if (Platform.environment.containsKey('FLUTTER_TEST')) {
       return DynamicLibrary.open(getLibraryForPlatform());
     }

--- a/packages/powersync/test/util.dart
+++ b/packages/powersync/test/util.dart
@@ -35,6 +35,9 @@ class TestOpenFactory extends PowerSyncOpenFactory {
     sqlite_open.open.overrideFor(sqlite_open.OperatingSystem.linux, () {
       return DynamicLibrary.open('libsqlite3.so.0');
     });
+    sqlite_open.open.overrideFor(sqlite_open.OperatingSystem.macOS, () {
+      return DynamicLibrary.open('libsqlite3.dylib');
+    });
     return super.open(options);
   }
 


### PR DESCRIPTION
## Description 

Override the default macOS SQLite binary when running tests as it does not allow extension loading. This allows the extension to be loaded when running tests on macOS.

This requires the sqlite binary and extension binary to be placed in the root folder for testing.

## Work done

- Override the default macOS SQLite loaded for tests.
- Load the dynamic library for all platforms.