### PR TITLE
Check if abort future is completed before completing it

### DIFF
--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.4.1
+  powersync: ^1.4.2
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.4.1
+  powersync: ^1.4.2
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^1.10.25
   timeago: ^3.6.0
-  powersync: ^1.4.1
+  powersync: ^1.4.2
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.2
+
+- Fix `Bad state: Future already completed` error when calling `disconnectAndClear()`.
+
 ## 1.4.1
 
 - Upgrades dependency `powersync_flutter_libs` to version `0.1.0`.

--- a/packages/powersync/lib/src/abort_controller.dart
+++ b/packages/powersync/lib/src/abort_controller.dart
@@ -17,14 +17,18 @@ class AbortController {
   /// Abort, and wait until aborting is complete.
   Future<void> abort() async {
     aborted = true;
-    _abortRequested.complete();
+    if (!_abortRequested.isCompleted) {
+      _abortRequested.complete();
+    }
 
     await _abortCompleter.future;
   }
 
   /// Signal that an abort has completed.
   void completeAbort() {
-    _abortCompleter.complete();
+    if (!_abortCompleter.isCompleted) {
+      _abortCompleter.complete();
+    }
   }
 
   /// Signal that an abort has failed.

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.4.1
+version: 1.4.2
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - keep PostgreSQL databases in sync with on-device SQLite databases.


### PR DESCRIPTION
## Description

There was an error of `Flutter Bad state: Future already completed` when calling `disconnectAndClear()` in the demo apps. This was fixed by ensuring the abort future was not completed twice. 

## Work done

- Ensure abort future is not completed before calling `.complete()`
