### PR TITLE
Upgrade sqlite_async

### DIFF
--- a/demos/supabase-anonymous-auth/pubspec.lock
+++ b/demos/supabase-anonymous-auth/pubspec.lock
@@ -318,7 +318,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.4.2"
+    version: "1.5.0"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
@@ -439,19 +439,18 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_flutter_libs
-      sha256: "9f89a7e7dc36eac2035808427eba1c3fbd79e59c3a22093d8dace6d36b1fe89e"
+      sha256: "62bbb4073edbcdf53f40c80775f33eea01d301b7b81417e5b3fb7395416258c1"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.23"
+    version: "0.5.24"
   sqlite_async:
     dependency: "direct main"
     description:
-      path: "."
-      ref: "fix/update-sqlite3-return-value-error"
-      resolved-ref: b8a45a149418749f46cda5eef53c9e10efaf05d0
-      url: "git@github.com:powersync-ja/sqlite_async.dart.git"
-    source: git
-    version: "0.6.2"
+      name: sqlite_async
+      sha256: "7c121bd76b9063cd8189ce54512f243709c88addeced0f3d027eea5db64d3220"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0"
   stack_trace:
     dependency: transitive
     description:
@@ -592,10 +591,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: cd210a09f7c18cbe5a02511718e0334de6559871052c90a90c0cca46a4aa81c8
+      sha256: "814e9e88f21a176ae1359149021870e87f7cddaf633ab678a5d2b0bff7fd1ba8"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.3"
+    version: "4.4.0"
   vector_math:
     dependency: transitive
     description:

--- a/demos/supabase-anonymous-auth/pubspec.lock
+++ b/demos/supabase-anonymous-auth/pubspec.lock
@@ -152,14 +152,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   jwt_decode:
     dependency: transitive
     description:
@@ -172,26 +164,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -228,10 +220,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -326,7 +318,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.4.1"
+    version: "1.4.2"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
@@ -439,10 +431,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "072128763f1547e3e9b4735ce846bfd226d68019ccda54db4cd427b12dfdedc9"
+      sha256: "6d17989c0b06a5870b2190d391925186f944cb943e5262d0d3f778fcfca3bc6e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.4"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
@@ -454,11 +446,12 @@ packages:
   sqlite_async:
     dependency: "direct main"
     description:
-      name: sqlite_async
-      sha256: "139c8f1085132d0941b925efacb4fa0fed9ee40d624739cc26a051dbc36bf727"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.1"
+      path: "."
+      ref: "fix/update-sqlite3-return-value-error"
+      resolved-ref: b8a45a149418749f46cda5eef53c9e10efaf05d0
+      url: "git@github.com:powersync-ja/sqlite_async.dart.git"
+    source: git
+    version: "0.6.2"
   stack_trace:
     dependency: transitive
     description:
@@ -519,10 +512,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
@@ -615,10 +608,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   web:
     dependency: transitive
     description:
@@ -660,5 +653,5 @@ packages:
     source: hosted
     version: "2.0.0"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.13.0"
+  dart: ">=3.4.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -16,7 +16,10 @@ dependencies:
   supabase_flutter: ^2.0.2
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.6.0
+  sqlite_async:
+    git:
+      url: git@github.com:powersync-ja/sqlite_async.dart.git
+      ref: fix/update-sqlite3-return-value-error
 
 dev_dependencies:
   flutter_test:

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -5,21 +5,18 @@ publish_to: "none"
 version: 1.0.1
 
 environment:
-  sdk: ^3.2.0
+  sdk: ^3.4.0
 
 dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.4.2
+  powersync: ^1.5.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async:
-    git:
-      url: git@github.com:powersync-ja/sqlite_async.dart.git
-      ref: fix/update-sqlite3-return-value-error
+  sqlite_async: ^0.7.0
 
 dev_dependencies:
   flutter_test:

--- a/demos/supabase-edge-function-auth/pubspec.lock
+++ b/demos/supabase-edge-function-auth/pubspec.lock
@@ -318,7 +318,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.4.2"
+    version: "1.5.0"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
@@ -439,19 +439,18 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_flutter_libs
-      sha256: "9f89a7e7dc36eac2035808427eba1c3fbd79e59c3a22093d8dace6d36b1fe89e"
+      sha256: "62bbb4073edbcdf53f40c80775f33eea01d301b7b81417e5b3fb7395416258c1"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.23"
+    version: "0.5.24"
   sqlite_async:
     dependency: "direct main"
     description:
-      path: "."
-      ref: "fix/update-sqlite3-return-value-error"
-      resolved-ref: b8a45a149418749f46cda5eef53c9e10efaf05d0
-      url: "git@github.com:powersync-ja/sqlite_async.dart.git"
-    source: git
-    version: "0.6.2"
+      name: sqlite_async
+      sha256: "7c121bd76b9063cd8189ce54512f243709c88addeced0f3d027eea5db64d3220"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0"
   stack_trace:
     dependency: transitive
     description:
@@ -592,10 +591,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: cd210a09f7c18cbe5a02511718e0334de6559871052c90a90c0cca46a4aa81c8
+      sha256: "814e9e88f21a176ae1359149021870e87f7cddaf633ab678a5d2b0bff7fd1ba8"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.3"
+    version: "4.4.0"
   vector_math:
     dependency: transitive
     description:

--- a/demos/supabase-edge-function-auth/pubspec.lock
+++ b/demos/supabase-edge-function-auth/pubspec.lock
@@ -152,14 +152,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   jwt_decode:
     dependency: transitive
     description:
@@ -172,26 +164,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -228,10 +220,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -326,7 +318,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.4.1"
+    version: "1.4.2"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
@@ -439,10 +431,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "072128763f1547e3e9b4735ce846bfd226d68019ccda54db4cd427b12dfdedc9"
+      sha256: "6d17989c0b06a5870b2190d391925186f944cb943e5262d0d3f778fcfca3bc6e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.4"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
@@ -454,11 +446,12 @@ packages:
   sqlite_async:
     dependency: "direct main"
     description:
-      name: sqlite_async
-      sha256: "139c8f1085132d0941b925efacb4fa0fed9ee40d624739cc26a051dbc36bf727"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.1"
+      path: "."
+      ref: "fix/update-sqlite3-return-value-error"
+      resolved-ref: b8a45a149418749f46cda5eef53c9e10efaf05d0
+      url: "git@github.com:powersync-ja/sqlite_async.dart.git"
+    source: git
+    version: "0.6.2"
   stack_trace:
     dependency: transitive
     description:
@@ -519,10 +512,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
@@ -615,10 +608,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   web:
     dependency: transitive
     description:
@@ -660,5 +653,5 @@ packages:
     source: hosted
     version: "2.0.0"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.13.0"
+  dart: ">=3.4.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -16,7 +16,10 @@ dependencies:
   supabase_flutter: ^2.0.2
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.6.0
+  sqlite_async:
+    git:
+      url: git@github.com:powersync-ja/sqlite_async.dart.git
+      ref: fix/update-sqlite3-return-value-error
 
 dev_dependencies:
   flutter_test:

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -5,21 +5,18 @@ publish_to: "none"
 version: 1.0.1
 
 environment:
-  sdk: ^3.2.0
+  sdk: ^3.4.0
 
 dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.4.2
+  powersync: ^1.5.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async:
-    git:
-      url: git@github.com:powersync-ja/sqlite_async.dart.git
-      ref: fix/update-sqlite3-return-value-error
+  sqlite_async: ^0.7.0
 
 dev_dependencies:
   flutter_test:

--- a/demos/supabase-simple-chat/pubspec.lock
+++ b/demos/supabase-simple-chat/pubspec.lock
@@ -204,26 +204,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -260,10 +260,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -358,7 +358,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.4.1"
+    version: "1.4.2"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
@@ -495,10 +495,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "072128763f1547e3e9b4735ce846bfd226d68019ccda54db4cd427b12dfdedc9"
+      sha256: "6d17989c0b06a5870b2190d391925186f944cb943e5262d0d3f778fcfca3bc6e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.4"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
@@ -510,11 +510,12 @@ packages:
   sqlite_async:
     dependency: transitive
     description:
-      name: sqlite_async
-      sha256: "139c8f1085132d0941b925efacb4fa0fed9ee40d624739cc26a051dbc36bf727"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.1"
+      path: "."
+      ref: "fix/update-sqlite3-return-value-error"
+      resolved-ref: b8a45a149418749f46cda5eef53c9e10efaf05d0
+      url: "git@github.com:powersync-ja/sqlite_async.dart.git"
+    source: git
+    version: "0.6.2"
   stack_trace:
     dependency: transitive
     description:
@@ -575,10 +576,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   timeago:
     dependency: "direct main"
     description:
@@ -679,10 +680,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   web:
     dependency: transitive
     description:
@@ -756,5 +757,5 @@ packages:
     source: hosted
     version: "1.1.1"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.16.6"
+  dart: ">=3.4.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/demos/supabase-simple-chat/pubspec.lock
+++ b/demos/supabase-simple-chat/pubspec.lock
@@ -358,7 +358,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.4.2"
+    version: "1.5.0"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
@@ -503,19 +503,18 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_flutter_libs
-      sha256: "9f89a7e7dc36eac2035808427eba1c3fbd79e59c3a22093d8dace6d36b1fe89e"
+      sha256: "62bbb4073edbcdf53f40c80775f33eea01d301b7b81417e5b3fb7395416258c1"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.23"
+    version: "0.5.24"
   sqlite_async:
     dependency: transitive
     description:
-      path: "."
-      ref: "fix/update-sqlite3-return-value-error"
-      resolved-ref: b8a45a149418749f46cda5eef53c9e10efaf05d0
-      url: "git@github.com:powersync-ja/sqlite_async.dart.git"
-    source: git
-    version: "0.6.2"
+      name: sqlite_async
+      sha256: "7c121bd76b9063cd8189ce54512f243709c88addeced0f3d027eea5db64d3220"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0"
   stack_trace:
     dependency: transitive
     description:
@@ -664,10 +663,10 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: cd210a09f7c18cbe5a02511718e0334de6559871052c90a90c0cca46a4aa81c8
+      sha256: "814e9e88f21a176ae1359149021870e87f7cddaf633ab678a5d2b0bff7fd1ba8"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.3"
+    version: "4.4.0"
   vector_math:
     dependency: transitive
     description:

--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: "0763b45fa9294197a2885c8567927e2830ade852e5c896fd4ab7e0e348d0f373"
+      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
       url: "https://pub.dev"
     source: hosted
-    version: "3.5.0"
+    version: "3.6.1"
   async:
     dependency: transitive
     description:
@@ -37,18 +37,18 @@ packages:
     dependency: "direct main"
     description:
       name: camera
-      sha256: "9499cbc2e51d8eb0beadc158b288380037618ce4e30c9acbc4fae1ac3ecb5797"
+      sha256: dfa8fc5a1adaeb95e7a54d86a5bd56f4bb0e035515354c8ac6d262e35cec2ec8
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.5+9"
+    version: "0.10.6"
   camera_android:
     dependency: transitive
     description:
       name: camera_android
-      sha256: "7b0aba6398afa8475e2bc9115d976efb49cf8db781e922572d443795c04a4f4f"
+      sha256: "4ef97ae90dab306a4ed8d5eee14c85fd8daf403ae22488b5617c848774396d72"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.9+1"
+    version: "0.10.9+6"
   camera_avfoundation:
     dependency: transitive
     description:
@@ -162,10 +162,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: "8cf40eebf5dec866a6d1956ad7b4f7016e6c0cc69847ab946833b7d43743809f"
+      sha256: c6b0b4c05c458e1c01ad9bcc14041dd7b1f6783d487be4386f793f47a8a4d03e
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.19"
+    version: "2.0.20"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -220,10 +220,10 @@ packages:
     dependency: "direct main"
     description:
       name: image
-      sha256: "4c68bfd5ae83e700b5204c1e74451e7bf3cf750e6843c6e158289cf56bda018e"
+      sha256: "2237616a36c0d69aef7549ab439b833fb7f9fb9fc861af2cc9ac3eedddd69ca8"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.7"
+    version: "4.2.0"
   jwt_decode:
     dependency: transitive
     description:
@@ -398,14 +398,14 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.4.2"
+    version: "1.5.0"
   powersync_attachments_helper:
     dependency: "direct main"
     description:
       path: "../../packages/powersync_attachments_helper"
       relative: true
     source: path
-    version: "0.4.1"
+    version: "0.5.0"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
@@ -526,19 +526,18 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_flutter_libs
-      sha256: "9f89a7e7dc36eac2035808427eba1c3fbd79e59c3a22093d8dace6d36b1fe89e"
+      sha256: "62bbb4073edbcdf53f40c80775f33eea01d301b7b81417e5b3fb7395416258c1"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.23"
+    version: "0.5.24"
   sqlite_async:
     dependency: "direct main"
     description:
-      path: "."
-      ref: "fix/update-sqlite3-return-value-error"
-      resolved-ref: b8a45a149418749f46cda5eef53c9e10efaf05d0
-      url: "git@github.com:powersync-ja/sqlite_async.dart.git"
-    source: git
-    version: "0.6.2"
+      name: sqlite_async
+      sha256: "7c121bd76b9063cd8189ce54512f243709c88addeced0f3d027eea5db64d3220"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0"
   stack_trace:
     dependency: transitive
     description:
@@ -757,4 +756,4 @@ packages:
     version: "2.0.0"
 sdks:
   dart: ">=3.4.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.22.0"

--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -224,14 +224,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.7"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.1"
   jwt_decode:
     dependency: transitive
     description:
@@ -244,26 +236,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -300,10 +292,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -406,7 +398,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.4.1"
+    version: "1.4.2"
   powersync_attachments_helper:
     dependency: "direct main"
     description:
@@ -526,10 +518,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "1abbeb84bf2b1a10e5e1138c913123c8aa9d83cd64e5f9a0dd847b3c83063202"
+      sha256: "6d17989c0b06a5870b2190d391925186f944cb943e5262d0d3f778fcfca3bc6e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.4"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
@@ -541,11 +533,12 @@ packages:
   sqlite_async:
     dependency: "direct main"
     description:
-      name: sqlite_async
-      sha256: "139c8f1085132d0941b925efacb4fa0fed9ee40d624739cc26a051dbc36bf727"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.1"
+      path: "."
+      ref: "fix/update-sqlite3-return-value-error"
+      resolved-ref: b8a45a149418749f46cda5eef53c9e10efaf05d0
+      url: "git@github.com:powersync-ja/sqlite_async.dart.git"
+    source: git
+    version: "0.6.2"
   stack_trace:
     dependency: transitive
     description:
@@ -614,10 +607,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
@@ -710,10 +703,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   web:
     dependency: transitive
     description:
@@ -763,5 +756,5 @@ packages:
     source: hosted
     version: "2.0.0"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"
   flutter: ">=3.19.0"

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -5,21 +5,18 @@ publish_to: "none"
 version: 1.0.1
 
 environment:
-  sdk: ^3.2.0
+  sdk: ^3.4.0
 
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.4.1
-  powersync: ^1.4.1
+  powersync_attachments_helper: ^0.5.0
+  powersync: ^1.5.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async:
-    git:
-      url: git@github.com:powersync-ja/sqlite_async.dart.git
-      ref: fix/update-sqlite3-return-value-error
+  sqlite_async: ^0.7.0
   camera: ^0.10.5+7
   image: ^4.1.3
 

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -16,7 +16,10 @@ dependencies:
   supabase_flutter: ^2.0.1
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.6.0
+  sqlite_async:
+    git:
+      url: git@github.com:powersync-ja/sqlite_async.dart.git
+      ref: fix/update-sqlite3-return-value-error
   camera: ^0.10.5+7
   image: ^4.1.3
 

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.5.0
+
+- Upgrade minimum Dart SDK constraint to `3.4.0`.
+- Upgrade `sqlite_async` to version 0.7.0 which updates all Database types to use a `CommonDatabase` interface.
+
 ## 1.4.2
 
 - Fix `Bad state: Future already completed` error when calling `disconnectAndClear()`.

--- a/packages/powersync/lib/src/bucket_storage.dart
+++ b/packages/powersync/lib/src/bucket_storage.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:collection/collection.dart';
 import 'package:sqlite_async/mutex.dart';
 import 'package:sqlite_async/sqlite3.dart' as sqlite;
+import 'package:sqlite_async/sqlite3_common.dart';
 
 import 'crud.dart';
 import 'database_utils.dart';
@@ -13,13 +14,13 @@ import 'sync_types.dart';
 const compactOperationInterval = 1000;
 
 class BucketStorage {
-  final sqlite.Database _internalDb;
+  final CommonDatabase _internalDb;
   final Mutex mutex;
   bool _hasCompletedSync = false;
   bool _pendingBucketDeletes = false;
   int _compactCounter = compactOperationInterval;
 
-  BucketStorage(sqlite.Database db, {required this.mutex}) : _internalDb = db {
+  BucketStorage(CommonDatabase db, {required this.mutex}) : _internalDb = db {
     _init();
   }
 
@@ -64,7 +65,7 @@ class BucketStorage {
     _compactCounter += count;
   }
 
-  void _updateBucket2(sqlite.Database db, String json) {
+  void _updateBucket2(CommonDatabase db, String json) {
     db.execute('INSERT INTO powersync_operations(op, data) VALUES(?, ?)',
         ['save', json]);
   }
@@ -301,7 +302,7 @@ class BucketStorage {
   /// is assumed that multiple functions on this instance won't be called
   /// concurrently.
   Future<T> writeTransaction<T>(
-      FutureOr<T> Function(sqlite.Database tx) callback,
+      FutureOr<T> Function(CommonDatabase tx) callback,
       {Duration? lockTimeout}) async {
     return mutex.lock(() async {
       final r = await asyncDirectTransaction(_internalDb, callback);

--- a/packages/powersync/lib/src/database_utils.dart
+++ b/packages/powersync/lib/src/database_utils.dart
@@ -1,9 +1,10 @@
 import 'dart:async';
 
 import 'package:sqlite_async/sqlite3.dart' as sqlite;
+import 'package:sqlite_async/sqlite3_common.dart';
 
-Future<T> asyncDirectTransaction<T>(sqlite.Database db,
-    FutureOr<T> Function(sqlite.Database db) callback) async {
+Future<T> asyncDirectTransaction<T>(
+    CommonDatabase db, FutureOr<T> Function(CommonDatabase db) callback) async {
   for (var i = 50; i >= 0; i--) {
     try {
       db.execute('BEGIN IMMEDIATE');

--- a/packages/powersync/lib/src/open_factory.dart
+++ b/packages/powersync/lib/src/open_factory.dart
@@ -7,6 +7,7 @@ import 'dart:math';
 import 'package:powersync/sqlite3.dart';
 import 'package:powersync/src/exceptions.dart';
 import 'package:sqlite_async/sqlite3.dart' as sqlite;
+import 'package:sqlite_async/sqlite3_common.dart';
 import 'package:sqlite_async/sqlite_async.dart';
 
 /// Advanced: Define custom setup for each SQLite connection.
@@ -37,13 +38,13 @@ class PowerSyncOpenFactory extends DefaultSqliteOpenFactory {
       : _sqliteSetup = sqliteSetup;
 
   @override
-  sqlite.Database open(SqliteOpenOptions options) {
+  Future<CommonDatabase> open(SqliteOpenOptions options) async {
     // ignore: deprecated_member_use_from_same_package
     _sqliteSetup?.setup();
 
     enableExtension();
 
-    final db = _retriedOpen(options);
+    final db = await _retriedOpen(options);
     db.execute('PRAGMA recursive_triggers = TRUE');
     setupFunctions(db);
     return db;
@@ -60,7 +61,7 @@ class PowerSyncOpenFactory extends DefaultSqliteOpenFactory {
   /// Usually a delay of 1-2ms is sufficient for the next try to succeed, but
   /// we increase the retry delay up to 16ms per retry, and a maximum of 500ms
   /// in total.
-  sqlite.Database _retriedOpen(SqliteOpenOptions options) {
+  FutureOr<CommonDatabase> _retriedOpen(SqliteOpenOptions options) async {
     final stopwatch = Stopwatch()..start();
     var retryDelay = 2;
     while (stopwatch.elapsedMilliseconds < 500) {
@@ -95,7 +96,7 @@ class PowerSyncOpenFactory extends DefaultSqliteOpenFactory {
         : DynamicLibrary.open(getLibraryForPlatform());
   }
 
-  void setupFunctions(sqlite.Database db) {
+  void setupFunctions(CommonDatabase db) {
     db.createFunction(
       functionName: 'powersync_sleep',
       argumentCount: const sqlite.AllowedArgumentCount(1),

--- a/packages/powersync/lib/src/open_factory.dart
+++ b/packages/powersync/lib/src/open_factory.dart
@@ -38,13 +38,13 @@ class PowerSyncOpenFactory extends DefaultSqliteOpenFactory {
       : _sqliteSetup = sqliteSetup;
 
   @override
-  Future<CommonDatabase> open(SqliteOpenOptions options) async {
+  CommonDatabase open(SqliteOpenOptions options) {
     // ignore: deprecated_member_use_from_same_package
     _sqliteSetup?.setup();
 
     enableExtension();
 
-    final db = await _retriedOpen(options);
+    final db = _retriedOpen(options);
     db.execute('PRAGMA recursive_triggers = TRUE');
     setupFunctions(db);
     return db;
@@ -61,7 +61,7 @@ class PowerSyncOpenFactory extends DefaultSqliteOpenFactory {
   /// Usually a delay of 1-2ms is sufficient for the next try to succeed, but
   /// we increase the retry delay up to 16ms per retry, and a maximum of 500ms
   /// in total.
-  FutureOr<CommonDatabase> _retriedOpen(SqliteOpenOptions options) async {
+  CommonDatabase _retriedOpen(SqliteOpenOptions options) {
     final stopwatch = Stopwatch()..start();
     var retryDelay = 2;
     while (stopwatch.elapsedMilliseconds < 500) {

--- a/packages/powersync/lib/src/powersync_database.dart
+++ b/packages/powersync/lib/src/powersync_database.dart
@@ -581,7 +581,7 @@ Future<void> _powerSyncDatabaseIsolate(
   }
 
   runZonedGuarded(() async {
-    db = await args.dbRef.openFactory
+    db = args.dbRef.openFactory
         .open(SqliteOpenOptions(primaryConnection: false, readOnly: false));
 
     final storage = BucketStorage(db!, mutex: mutex);

--- a/packages/powersync/lib/src/powersync_database.dart
+++ b/packages/powersync/lib/src/powersync_database.dart
@@ -3,8 +3,7 @@ import 'dart:isolate';
 
 import 'package:logging/logging.dart';
 import 'package:powersync/src/log_internal.dart';
-import 'package:sqlite_async/mutex.dart';
-import 'package:sqlite_async/sqlite3.dart' as sqlite;
+import 'package:sqlite_async/sqlite3_common.dart';
 import 'package:sqlite_async/sqlite_async.dart';
 
 import 'abort_controller.dart';
@@ -531,7 +530,7 @@ Future<void> _powerSyncDatabaseIsolate(
   StreamController updateController = StreamController.broadcast();
   final upstreamDbClient = args.dbRef.upstreamPort.open();
 
-  sqlite.Database? db;
+  CommonDatabase? db;
   final mutex = args.dbRef.mutex.open();
 
   rPort.listen((message) async {

--- a/packages/powersync/lib/src/schema_logic.dart
+++ b/packages/powersync/lib/src/schema_logic.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:sqlite_async/sqlite3.dart' as sqlite;
+import 'package:sqlite_async/sqlite3_common.dart';
 import 'package:sqlite_async/sqlite_async.dart';
 
 import 'schema.dart';
@@ -10,7 +10,7 @@ const String maxOpId = '9223372036854775807';
 final invalidSqliteCharacters = RegExp(r'''["'%,\.#\s\[\]]''');
 
 /// Sync the schema to the local database.
-void updateSchema(sqlite.Database db, Schema schema) {
+void updateSchema(CommonDatabase db, Schema schema) {
   db.execute('SELECT powersync_replace_schema(?)', [jsonEncode(schema)]);
 }
 

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,19 +1,16 @@
 name: powersync
-version: 1.4.2
+version: 1.5.0
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - keep PostgreSQL databases in sync with on-device SQLite databases.
 environment:
-  sdk: ^3.2.3
+  sdk: ^3.4.0
 dependencies:
   # Needed because of sqlite3_flutter_libs
   flutter:
     sdk: flutter
 
-  sqlite_async:
-    git:
-      url: git@github.com:powersync-ja/sqlite_async.dart.git
-      ref: fix/update-sqlite3-return-value-error
+  sqlite_async: ^0.7.0
   sqlite3_flutter_libs: ^0.5.23
   powersync_flutter_libs: ^0.1.0
   http: ^1.1.0

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -10,7 +10,10 @@ dependencies:
   flutter:
     sdk: flutter
 
-  sqlite_async: ^0.6.1
+  sqlite_async:
+    git:
+      url: git@github.com:powersync-ja/sqlite_async.dart.git
+      ref: fix/update-sqlite3-return-value-error
   sqlite3_flutter_libs: ^0.5.23
   powersync_flutter_libs: ^0.1.0
   http: ^1.1.0

--- a/packages/powersync/test/bucket_storage_test.dart
+++ b/packages/powersync/test/bucket_storage_test.dart
@@ -3,6 +3,7 @@ import 'package:powersync/src/bucket_storage.dart';
 import 'package:powersync/src/sync_types.dart';
 import 'package:sqlite_async/sqlite3.dart' as sqlite;
 import 'package:sqlite_async/mutex.dart';
+import 'package:sqlite_async/sqlite3_common.dart';
 import 'package:test/test.dart';
 
 import 'util.dart';
@@ -40,7 +41,7 @@ const removeAsset1_5 = OplogEntry(
 void main() {
   group('Bucket Storage Tests', () {
     late PowerSyncDatabase powersync;
-    late sqlite.Database db;
+    late CommonDatabase db;
     late BucketStorage bucketStorage;
     late String path;
 

--- a/packages/powersync/test/util.dart
+++ b/packages/powersync/test/util.dart
@@ -7,6 +7,7 @@ import 'package:powersync/powersync.dart';
 import 'package:powersync/sqlite3.dart' as sqlite;
 import 'package:powersync/sqlite_async.dart';
 import 'package:sqlite3/open.dart' as sqlite_open;
+import 'package:sqlite_async/sqlite3_common.dart';
 import 'package:test_api/src/backend/invoker.dart';
 
 const schema = Schema([
@@ -31,7 +32,7 @@ class TestOpenFactory extends PowerSyncOpenFactory {
   TestOpenFactory({required super.path});
 
   @override
-  sqlite.Database open(SqliteOpenOptions options) {
+  Future<CommonDatabase> open(SqliteOpenOptions options) async {
     sqlite_open.open.overrideFor(sqlite_open.OperatingSystem.linux, () {
       return DynamicLibrary.open('libsqlite3.so.0');
     });

--- a/packages/powersync/test/util.dart
+++ b/packages/powersync/test/util.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 
 import 'package:logging/logging.dart';
 import 'package:powersync/powersync.dart';
-import 'package:powersync/sqlite3.dart' as sqlite;
 import 'package:powersync/sqlite_async.dart';
 import 'package:sqlite3/open.dart' as sqlite_open;
 import 'package:sqlite_async/sqlite3_common.dart';

--- a/packages/powersync/test/util.dart
+++ b/packages/powersync/test/util.dart
@@ -32,7 +32,7 @@ class TestOpenFactory extends PowerSyncOpenFactory {
   TestOpenFactory({required super.path});
 
   @override
-  Future<CommonDatabase> open(SqliteOpenOptions options) async {
+  CommonDatabase open(SqliteOpenOptions options) {
     sqlite_open.open.overrideFor(sqlite_open.OperatingSystem.linux, () {
       return DynamicLibrary.open('libsqlite3.so.0');
     });
@@ -79,7 +79,7 @@ Future<PowerSyncDatabase> setupPowerSync(
   return db;
 }
 
-Future<sqlite.Database> setupSqlite(
+Future<CommonDatabase> setupSqlite(
     {required PowerSyncDatabase powersync}) async {
   await powersync.initialize();
 

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.0
+
+- Upgrade minimum Dart SDK constraint to `3.4.0`.
+- Upgrade `sqlite_async` to version 0.7.0.
+
 ## 0.4.1
 
 - Reduce version number of `path_provider` to `2.0.13`
@@ -30,7 +35,7 @@
 ## 0.2.0
 
 - Potentially BREAKING CHANGE for users who rely on multiple attachment queues.
-  Moved away from randomly generating queue table name in favour of  a user creating a queue and table using a name of their choosing.
+  Moved away from randomly generating queue table name in favour of a user creating a queue and table using a name of their choosing.
 
 ## 0.1.5
 

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -12,7 +12,10 @@ dependencies:
 
   powersync: ^1.2.2
   logging: ^1.2.0
-  sqlite_async: ^0.6.1
+  sqlite_async:
+    git:
+      url: git@github.com:powersync-ja/sqlite_async.dart.git
+      ref: fix/update-sqlite3-return-value-error
   path_provider: ^2.0.13
 
 dev_dependencies:

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,21 +1,18 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.4.1
+version: 0.5.0
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:
-  sdk: ^3.2.0
+  sdk: ^3.4.0
 
 dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.2.2
+  powersync: ^1.5.0
   logging: ^1.2.0
-  sqlite_async:
-    git:
-      url: git@github.com:powersync-ja/sqlite_async.dart.git
-      ref: fix/update-sqlite3-return-value-error
+  sqlite_async: ^0.7.0
   path_provider: ^2.0.13
 
 dev_dependencies:


### PR DESCRIPTION
## Description

This upgrades `sqlite_async` to version 0.7.0 which requires the minimum dart SDK version 3.4.0 and fixes the `Invalid argument(s): argument value for 'return_value' is null` error when closing the database connection.
This also updates all the Database types to a `CommonDatabase` type.