### PR TITLE
[Chore] Fix Pana Score Checks

### DIFF
--- a/packages/powersync_flutter_libs/example/README.md
+++ b/packages/powersync_flutter_libs/example/README.md
@@ -1,0 +1,1 @@
+This example is only included for Pana package score checks. This package should automatically apply native binaries if installed.

--- a/packages/powersync_flutter_libs/lib/powersync_flutter_libs.dart
+++ b/packages/powersync_flutter_libs/lib/powersync_flutter_libs.dart
@@ -1,1 +1,4 @@
+/// PowerSync Flutter Libs.
+///
+/// This provides binary files for the [PowerSync SQLite Rust Core](https://github.com/powersync-ja/powersync-sqlite-core)
 library powersync_flutter_libs;


### PR DESCRIPTION
# Description

Currently some of the CI checks for Dart package scores are failing. See [reference](https://github.com/powersync-ja/powersync.dart/actions/runs/9717540494/job/26823430677?pr=108).

This PR adds an example and some documentation comments to `powersync_flutter_libs` to bring the score value up to the required score threshold. 

This example is based off [this](https://github.com/simolus3/sqlite3.dart/blob/main/sqlite3_flutter_libs/example/README.md).