### PR TITLE
Close http connections immediately on disconnect

### DIFF
--- a/packages/powersync/lib/src/streaming_sync.dart
+++ b/packages/powersync/lib/src/streaming_sync.dart
@@ -117,7 +117,8 @@ class StreamingSyncImplementation {
               downloadError: e);
 
           // On error, wait a little before retrying
-          await Future.delayed(retryDelay);
+          // When aborting, don't wait
+          await Future.any([Future.delayed(retryDelay), _abort!.onAbort]);
         }
       }
     } finally {

--- a/packages/powersync/test/streaming_sync_test.dart
+++ b/packages/powersync/test/streaming_sync_test.dart
@@ -59,6 +59,15 @@ void main() {
 
         await pdb.close();
 
+        // Give some time for connections to close
+        final watch = Stopwatch()..start();
+        while (server.connectionCount != 0 && watch.elapsedMilliseconds < 100) {
+          await Future.delayed(Duration(milliseconds: random.nextInt(10)));
+        }
+
+        expect(server.connectionCount, equals(0));
+        expect(server.maxConnectionCount, lessThanOrEqualTo(1));
+
         server.close();
       }
     });

--- a/packages/powersync/test/test_server.dart
+++ b/packages/powersync/test/test_server.dart
@@ -11,7 +11,6 @@ import 'package:shelf_router/shelf_router.dart';
 class TestServer {
   late HttpServer server;
   Router app = Router();
-  int connectionCount = 0;
   int maxConnectionCount = 0;
   int tokenExpiresIn;
 
@@ -27,19 +26,22 @@ class TestServer {
     return 'http://${server.address.host}:${server.port}';
   }
 
+  int get connectionCount {
+    return server.connectionsInfo().total;
+  }
+
+  HttpConnectionsInfo connectionsInfo() {
+    return server.connectionsInfo();
+  }
+
   Future<Response> handleSyncStream(Request request) async {
-    connectionCount += 1;
     maxConnectionCount = max(connectionCount, maxConnectionCount);
 
     stream() async* {
-      try {
-        var blob = "*" * 5000;
-        for (var i = 0; i < 50; i++) {
-          yield {"token_expires_in": tokenExpiresIn, "blob": blob};
-          await Future.delayed(Duration(microseconds: 1));
-        }
-      } finally {
-        connectionCount -= 1;
+      var blob = "*" * 5000;
+      for (var i = 0; i < 50; i++) {
+        yield {"token_expires_in": tokenExpiresIn, "blob": blob};
+        await Future.delayed(Duration(microseconds: 1));
       }
     }
 


### PR DESCRIPTION
Fixes #114.

This now ensures the http connection is properly closed when disconnecting, before killing the Isolate.

This waits for any requests in progress, since closing the http client while the request is starting causes unpredictable uncaught errors.

It is tricky to cover all cases, but the tests do a fairly good job of checking them. This PR also improves the connection counting in tests, avoiding some sporadic test failures we had previously.


