### PR TITLE
Fix Future already completed when calling waitForFirstSync

### DIFF
--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.2
+
+- Fix `Bad state: Future already completed` error when calling `waitForFirstSync()`.
+
 ## 1.5.1
 
 - Adds a hasSynced flag to check if initial data has been synced.

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.5.2
 
-- Fix `Bad state: Future already completed` error when calling `waitForFirstSync()`.
+- Refactor `waitForFirstSync()` to iterate through the stream and remove the use of a `Future`.
 - Fix sync connection not immediately closed when calling `db.disconnect()` (#114).
 
 ## 1.5.1

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.5.2
 
 - Fix `Bad state: Future already completed` error when calling `waitForFirstSync()`.
+- Fix sync connection not immediately closed when calling `db.disconnect()` (#114).
 
 ## 1.5.1
 

--- a/packages/powersync/lib/src/powersync_database.dart
+++ b/packages/powersync/lib/src/powersync_database.dart
@@ -199,7 +199,7 @@ class PowerSyncDatabase with SqliteQueries implements SqliteConnection {
     }
     final completer = Completer<void>();
     statusStream.listen((result) {
-      if (result.hasSynced ?? false) {
+      if ((result.hasSynced ?? false) && !completer.isCompleted) {
         completer.complete();
       }
     });

--- a/packages/powersync/lib/src/powersync_database.dart
+++ b/packages/powersync/lib/src/powersync_database.dart
@@ -197,14 +197,11 @@ class PowerSyncDatabase with SqliteQueries implements SqliteConnection {
     if (currentStatus.hasSynced ?? false) {
       return;
     }
-    final completer = Completer<void>();
-    statusStream.listen((result) {
-      if ((result.hasSynced ?? false) && !completer.isCompleted) {
-        completer.complete();
+    await for (final result in statusStream) {
+      if (result.hasSynced ?? false) {
+        break;
       }
-    });
-
-    return completer.future;
+    }
   }
 
   @override

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.5.1
+version: 1.5.2
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - keep PostgreSQL databases in sync with on-device SQLite databases.


### PR DESCRIPTION
## Work done

- Refactor `waitForFirstSync()` to iterate through the stream and remove the use of a `Future`.