### PR TITLE
[Chore] Update Sqlite Async Web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2024-07-04
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`powersync` - `v1.3.0-alpha.8`](#powersync---v130-alpha8)
+ - [`powersync_attachments_helper` - `v0.3.0-alpha.3`](#powersync_attachments_helper---v030-alpha3)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `powersync_attachments_helper` - `v0.3.0-alpha.3`
+
+---
+
+#### `powersync` - `v1.3.0-alpha.8`
+
+ - **FIX**(powersync-attachements-helper): pubspec file (#29).
+ - **DOCS**: update readme and getting started (#51).
+
+
 ## 2024-05-30
 
 ### Changes

--- a/demos/supabase-anonymous-auth/pubspec.lock
+++ b/demos/supabase-anonymous-auth/pubspec.lock
@@ -480,10 +480,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqlite_async
-      sha256: bf989697c50db97043702c625330895a8ebec4491548a8e46d315b9f60b7582e
+      sha256: "7c5a9bec86b6f5b7511b9ba30974fa7ea470aee2dc0d5b7021f6321a439a8d63"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0-alpha.5"
+    version: "0.8.0"
   stack_trace:
     dependency: transitive
     description:

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.3.0-alpha.7
+  powersync: 1.3.0-alpha.7
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: 1.3.0-alpha.7
+  powersync: 1.3.0-alpha.8
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   supabase_flutter: ^2.0.2
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: 0.7.0-alpha.5
+  sqlite_async: ^0.8.0
   universal_io: ^2.2.2
 
 dev_dependencies:

--- a/demos/supabase-edge-function-auth/pubspec.lock
+++ b/demos/supabase-edge-function-auth/pubspec.lock
@@ -480,10 +480,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqlite_async
-      sha256: bf989697c50db97043702c625330895a8ebec4491548a8e46d315b9f60b7582e
+      sha256: "7c5a9bec86b6f5b7511b9ba30974fa7ea470aee2dc0d5b7021f6321a439a8d63"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0-alpha.5"
+    version: "0.8.0"
   stack_trace:
     dependency: transitive
     description:

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.3.0-alpha.7
+  powersync: 1.3.0-alpha.7
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: 1.3.0-alpha.7
+  powersync: 1.3.0-alpha.8
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   supabase_flutter: ^2.0.2
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: 0.7.0-alpha.5
+  sqlite_async: ^0.8.0
   universal_io: ^2.2.2
 
 dev_dependencies:

--- a/demos/supabase-simple-chat/pubspec.lock
+++ b/demos/supabase-simple-chat/pubspec.lock
@@ -536,10 +536,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite_async
-      sha256: bf989697c50db97043702c625330895a8ebec4491548a8e46d315b9f60b7582e
+      sha256: "7c5a9bec86b6f5b7511b9ba30974fa7ea470aee2dc0d5b7021f6321a439a8d63"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0-alpha.5"
+    version: "0.8.0"
   stack_trace:
     dependency: transitive
     description:

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^1.10.25
   timeago: ^3.6.0
-  powersync: 1.3.0-alpha.7
+  powersync: 1.3.0-alpha.8
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^1.10.25
   timeago: ^3.6.0
-  powersync: ^1.3.0-alpha.7
+  powersync: 1.3.0-alpha.7
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -591,10 +591,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqlite_async
-      sha256: bf989697c50db97043702c625330895a8ebec4491548a8e46d315b9f60b7582e
+      sha256: "7c5a9bec86b6f5b7511b9ba30974fa7ea470aee2dc0d5b7021f6321a439a8d63"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0-alpha.5"
+    version: "0.8.0"
   stack_trace:
     dependency: transitive
     description:

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.3.0-alpha.2
+  powersync_attachments_helper: ^0.3.0-alpha.3
 
-  powersync: 1.3.0-alpha.7
+  powersync: 1.3.0-alpha.8
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   powersync_attachments_helper: ^0.3.0-alpha.2
 
-  powersync: ^1.3.0-alpha.7
+  powersync: 1.3.0-alpha.7
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   camera: ^0.10.5+7
   image: ^4.1.3
   universal_io: ^2.2.2
-  sqlite_async: 0.7.0-alpha.5
+  sqlite_async: ^0.8.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.0-alpha.8
+
+ - **FIX**(powersync-attachements-helper): pubspec file (#29).
+ - **DOCS**: update readme and getting started (#51).
+
 ## 1.3.0-alpha.7
 
 - Updates and uses the latest `sqlite_async` alpha.

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 1.3.0-alpha.8
 
- - **FIX**(powersync-attachements-helper): pubspec file (#29).
- - **DOCS**: update readme and getting started (#51).
+- **FIX**(powersync-attachements-helper): pubspec file (#29).
+- **DOCS**: update readme and getting started (#51).
+- Updates and uses the latest `sqlite_async` package.
 
 ## 1.3.0-alpha.7
 

--- a/packages/powersync/lib/src/database/native/native_powersync_database.dart
+++ b/packages/powersync/lib/src/database/native/native_powersync_database.dart
@@ -325,7 +325,7 @@ Future<void> _powerSyncDatabaseIsolate(
   }
 
   runZonedGuarded(() async {
-    db = await args.dbRef.openFactory
+    db = args.dbRef.openFactory
         .open(SqliteOpenOptions(primaryConnection: false, readOnly: false));
     final connection = SyncSqliteConnection(db!, mutex);
 

--- a/packages/powersync/lib/src/open_factory/abstract_powersync_open_factory.dart
+++ b/packages/powersync/lib/src/open_factory/abstract_powersync_open_factory.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'dart:io';
+import 'package:universal_io/io.dart';
 import 'dart:math';
 
 import 'package:powersync/sqlite_async.dart';

--- a/packages/powersync/lib/src/open_factory/abstract_powersync_open_factory.dart
+++ b/packages/powersync/lib/src/open_factory/abstract_powersync_open_factory.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:math';
 
 import 'package:powersync/sqlite_async.dart';
@@ -28,8 +29,8 @@ abstract class AbstractPowerSyncOpenFactory extends DefaultSqliteOpenFactory {
   }
 
   @override
-  FutureOr<CommonDatabase> open(SqliteOpenOptions options) async {
-    var db = await _retriedOpen(options);
+  CommonDatabase open(SqliteOpenOptions options) {
+    var db = _retriedOpen(options);
     for (final statement in pragmaStatements(options)) {
       db.select(statement);
     }
@@ -48,7 +49,7 @@ abstract class AbstractPowerSyncOpenFactory extends DefaultSqliteOpenFactory {
   /// Usually a delay of 1-2ms is sufficient for the next try to succeed, but
   /// we increase the retry delay up to 16ms per retry, and a maximum of 500ms
   /// in total.
-  FutureOr<CommonDatabase> _retriedOpen(SqliteOpenOptions options) async {
+  CommonDatabase _retriedOpen(SqliteOpenOptions options) {
     final stopwatch = Stopwatch()..start();
     var retryDelay = 2;
     while (stopwatch.elapsedMilliseconds < 500) {
@@ -56,7 +57,7 @@ abstract class AbstractPowerSyncOpenFactory extends DefaultSqliteOpenFactory {
         return super.open(options);
       } catch (e) {
         if (e is SqliteException && e.resultCode == 5) {
-          await Future.delayed(Duration(milliseconds: retryDelay));
+          sleep(Duration(milliseconds: retryDelay));
           retryDelay = min(retryDelay * 2, 16);
           continue;
         }

--- a/packages/powersync/lib/src/open_factory/native/native_open_factory.dart
+++ b/packages/powersync/lib/src/open_factory/native/native_open_factory.dart
@@ -1,5 +1,4 @@
-import 'dart:async';
-import 'dart:io';
+import 'package:universal_io/io.dart';
 import 'dart:isolate';
 import 'package:powersync/src/open_factory/abstract_powersync_open_factory.dart';
 import 'package:sqlite_async/sqlite3.dart' as sqlite;
@@ -59,10 +58,10 @@ class PowerSyncOpenFactory extends AbstractPowerSyncOpenFactory {
   }
 
   @override
-  FutureOr<CommonDatabase> open(SqliteOpenOptions options) async {
+  CommonDatabase open(SqliteOpenOptions options) {
     // ignore: deprecated_member_use_from_same_package
     _sqliteSetup?.setup();
-    var db = await super.open(options);
+    var db = super.open(options);
     db.execute('PRAGMA recursive_triggers = TRUE');
     return db;
   }

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.3.0-alpha.7
+version: 1.3.0-alpha.8
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - keep PostgreSQL databases in sync with on-device SQLite databases.

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -10,7 +10,8 @@ dependencies:
   flutter:
     sdk: flutter
 
-  sqlite_async: 0.7.0-alpha.5
+  sqlite_async: ^0.8.0
+  universal_io: ^2.0.0
   sqlite3_flutter_libs: ^0.5.15
   meta: ^1.0.0
   http: ^1.1.0

--- a/packages/powersync/test/utils/native_test_utils.dart
+++ b/packages/powersync/test/utils/native_test_utils.dart
@@ -14,7 +14,7 @@ class TestOpenFactory extends PowerSyncOpenFactory {
   TestOpenFactory({required super.path});
 
   @override
-  FutureOr<CommonDatabase> open(SqliteOpenOptions options) {
+  CommonDatabase open(SqliteOpenOptions options) {
     sqlite_open.open.overrideFor(sqlite_open.OperatingSystem.linux, () {
       return DynamicLibrary.open('libsqlite3.so.0');
     });

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0-alpha.3
+
+ - Update a dependency to the latest release.
+
 ## 0.3.0-alpha.2
 
 > Note: This release has breaking changes.

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.3.0-alpha.7
+  powersync: 1.3.0-alpha.7
   logging: ^1.2.0
   sqlite3: "^2.4.4"
   path_provider: ^2.0.13

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.3.0-alpha.2
+version: 0.3.0-alpha.3
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: 1.3.0-alpha.7
+  powersync: 1.3.0-alpha.8
   logging: ^1.2.0
   sqlite3: "^2.4.4"
   path_provider: ^2.0.13

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -266,7 +266,7 @@ packages:
     source: hosted
     version: "2.1.0"
   path:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: path
       sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A sample command-line application.
 version: 1.0.0
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: ">=3.3.0 <4.0.0"
 
 # Add regular dependencies here.
 
@@ -11,3 +11,4 @@ dev_dependencies:
   lints: ^2.1.1
   melos: ^3.4.0
   test: ^1.25.0
+  path: ^1.0.0


### PR DESCRIPTION
# Overview

This updates the `sqlite_async` package to `0.8.0` which now contains web support.

Testing: Verified that the Supabase Todolist app works as expected.