### PR TITLE
[Feature] Implement web sync locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2024-07-10
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`powersync` - `v1.3.0-alpha.9`](#powersync---v130-alpha9)
+ - [`powersync_attachments_helper` - `v0.3.0-alpha.4`](#powersync_attachments_helper---v030-alpha4)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `powersync_attachments_helper` - `v0.3.0-alpha.4`
+
+---
+
+#### `powersync` - `v1.3.0-alpha.9`
+
+ - Updated sqlite_async to use Navigator locks for limiting sync stream implementions in multiple tabs
+
+
 ## 2024-07-04
 
 ### Changes

--- a/demos/supabase-anonymous-auth/pubspec.lock
+++ b/demos/supabase-anonymous-auth/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.3.0-alpha.7"
+    version: "1.3.0-alpha.8"
   realtime_client:
     dependency: transitive
     description:
@@ -479,10 +479,11 @@ packages:
   sqlite_async:
     dependency: "direct main"
     description:
-      name: sqlite_async
-      sha256: "7c5a9bec86b6f5b7511b9ba30974fa7ea470aee2dc0d5b7021f6321a439a8d63"
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/sqlite_async"
+      ref: "feat/navigator-locks"
+      resolved-ref: "588d92f3dc98ab2629d2b420ad607639b835214b"
+      url: "https://github.com/powersync-ja/sqlite_async.dart.git"
+    source: git
     version: "0.8.0"
   stack_trace:
     dependency: transitive

--- a/demos/supabase-anonymous-auth/pubspec.lock
+++ b/demos/supabase-anonymous-auth/pubspec.lock
@@ -479,12 +479,11 @@ packages:
   sqlite_async:
     dependency: "direct main"
     description:
-      path: "packages/sqlite_async"
-      ref: "feat/navigator-locks"
-      resolved-ref: "588d92f3dc98ab2629d2b420ad607639b835214b"
-      url: "https://github.com/powersync-ja/sqlite_async.dart.git"
-    source: git
-    version: "0.8.0"
+      name: sqlite_async
+      sha256: "79e636c857ed43f6cd5e5be72b36967a29f785daa63ff5b078bd34f74f44cb54"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.1"
   stack_trace:
     dependency: transitive
     description:

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -16,11 +16,7 @@ dependencies:
   supabase_flutter: ^2.0.2
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async:
-    git:
-      url: https://github.com/powersync-ja/sqlite_async.dart.git
-      ref: feat/navigator-locks
-      path: packages/sqlite_async
+  sqlite_async: ^0.8.1
   universal_io: ^2.2.2
 
 dev_dependencies:

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -16,7 +16,11 @@ dependencies:
   supabase_flutter: ^2.0.2
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.8.0
+  sqlite_async:
+    git:
+      url: https://github.com/powersync-ja/sqlite_async.dart.git
+      ref: feat/navigator-locks
+      path: packages/sqlite_async
   universal_io: ^2.2.2
 
 dev_dependencies:

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: 1.3.0-alpha.8
+  powersync: 1.3.0-alpha.9
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.lock
+++ b/demos/supabase-edge-function-auth/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.3.0-alpha.7"
+    version: "1.3.0-alpha.8"
   realtime_client:
     dependency: transitive
     description:
@@ -479,10 +479,11 @@ packages:
   sqlite_async:
     dependency: "direct main"
     description:
-      name: sqlite_async
-      sha256: "7c5a9bec86b6f5b7511b9ba30974fa7ea470aee2dc0d5b7021f6321a439a8d63"
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/sqlite_async"
+      ref: "feat/navigator-locks"
+      resolved-ref: "588d92f3dc98ab2629d2b420ad607639b835214b"
+      url: "https://github.com/powersync-ja/sqlite_async.dart.git"
+    source: git
     version: "0.8.0"
   stack_trace:
     dependency: transitive

--- a/demos/supabase-edge-function-auth/pubspec.lock
+++ b/demos/supabase-edge-function-auth/pubspec.lock
@@ -479,12 +479,11 @@ packages:
   sqlite_async:
     dependency: "direct main"
     description:
-      path: "packages/sqlite_async"
-      ref: "feat/navigator-locks"
-      resolved-ref: "588d92f3dc98ab2629d2b420ad607639b835214b"
-      url: "https://github.com/powersync-ja/sqlite_async.dart.git"
-    source: git
-    version: "0.8.0"
+      name: sqlite_async
+      sha256: "79e636c857ed43f6cd5e5be72b36967a29f785daa63ff5b078bd34f74f44cb54"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.1"
   stack_trace:
     dependency: transitive
     description:

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -16,11 +16,7 @@ dependencies:
   supabase_flutter: ^2.0.2
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async:
-    git:
-      url: https://github.com/powersync-ja/sqlite_async.dart.git
-      ref: feat/navigator-locks
-      path: packages/sqlite_async
+  sqlite_async: ^0.8.1
   universal_io: ^2.2.2
 
 dev_dependencies:

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -16,7 +16,11 @@ dependencies:
   supabase_flutter: ^2.0.2
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.8.0
+  sqlite_async:
+    git:
+      url: https://github.com/powersync-ja/sqlite_async.dart.git
+      ref: feat/navigator-locks
+      path: packages/sqlite_async
   universal_io: ^2.2.2
 
 dev_dependencies:

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: 1.3.0-alpha.8
+  powersync: 1.3.0-alpha.9
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.lock
+++ b/demos/supabase-simple-chat/pubspec.lock
@@ -382,7 +382,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.3.0-alpha.7"
+    version: "1.3.0-alpha.8"
   realtime_client:
     dependency: transitive
     description:
@@ -535,10 +535,11 @@ packages:
   sqlite_async:
     dependency: transitive
     description:
-      name: sqlite_async
-      sha256: "7c5a9bec86b6f5b7511b9ba30974fa7ea470aee2dc0d5b7021f6321a439a8d63"
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/sqlite_async"
+      ref: "feat/navigator-locks"
+      resolved-ref: "588d92f3dc98ab2629d2b420ad607639b835214b"
+      url: "https://github.com/powersync-ja/sqlite_async.dart.git"
+    source: git
     version: "0.8.0"
   stack_trace:
     dependency: transitive

--- a/demos/supabase-simple-chat/pubspec.lock
+++ b/demos/supabase-simple-chat/pubspec.lock
@@ -535,12 +535,11 @@ packages:
   sqlite_async:
     dependency: transitive
     description:
-      path: "packages/sqlite_async"
-      ref: "feat/navigator-locks"
-      resolved-ref: "588d92f3dc98ab2629d2b420ad607639b835214b"
-      url: "https://github.com/powersync-ja/sqlite_async.dart.git"
-    source: git
-    version: "0.8.0"
+      name: sqlite_async
+      sha256: "79e636c857ed43f6cd5e5be72b36967a29f785daa63ff5b078bd34f74f44cb54"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.1"
   stack_trace:
     dependency: transitive
     description:

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^1.10.25
   timeago: ^3.6.0
-  powersync: 1.3.0-alpha.8
+  powersync: 1.3.0-alpha.9
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -454,14 +454,14 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.3.0-alpha.7"
+    version: "1.3.0-alpha.8"
   powersync_attachments_helper:
     dependency: "direct main"
     description:
       path: "../../packages/powersync_attachments_helper"
       relative: true
     source: path
-    version: "0.3.0-alpha.2"
+    version: "0.3.0-alpha.3"
   realtime_client:
     dependency: transitive
     description:
@@ -590,10 +590,11 @@ packages:
   sqlite_async:
     dependency: "direct main"
     description:
-      name: sqlite_async
-      sha256: "7c5a9bec86b6f5b7511b9ba30974fa7ea470aee2dc0d5b7021f6321a439a8d63"
-      url: "https://pub.dev"
-    source: hosted
+      path: "packages/sqlite_async"
+      ref: "feat/navigator-locks"
+      resolved-ref: "588d92f3dc98ab2629d2b420ad607639b835214b"
+      url: "https://github.com/powersync-ja/sqlite_async.dart.git"
+    source: git
     version: "0.8.0"
   stack_trace:
     dependency: transitive

--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -590,12 +590,11 @@ packages:
   sqlite_async:
     dependency: "direct main"
     description:
-      path: "packages/sqlite_async"
-      ref: "feat/navigator-locks"
-      resolved-ref: "588d92f3dc98ab2629d2b420ad607639b835214b"
-      url: "https://github.com/powersync-ja/sqlite_async.dart.git"
-    source: git
-    version: "0.8.0"
+      name: sqlite_async
+      sha256: "79e636c857ed43f6cd5e5be72b36967a29f785daa63ff5b078bd34f74f44cb54"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.1"
   stack_trace:
     dependency: transitive
     description:

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,9 +10,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.3.0-alpha.3
+  powersync_attachments_helper: ^0.3.0-alpha.4
 
-  powersync: 1.3.0-alpha.8
+  powersync: 1.3.0-alpha.9
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -20,11 +20,7 @@ dependencies:
   camera: ^0.10.5+7
   image: ^4.1.3
   universal_io: ^2.2.2
-  sqlite_async:
-    git:
-      url: https://github.com/powersync-ja/sqlite_async.dart.git
-      ref: feat/navigator-locks
-      path: packages/sqlite_async
+  sqlite_async: ^0.8.1
 
 dev_dependencies:
   flutter_test:

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -20,7 +20,11 @@ dependencies:
   camera: ^0.10.5+7
   image: ^4.1.3
   universal_io: ^2.2.2
-  sqlite_async: ^0.8.0
+  sqlite_async:
+    git:
+      url: https://github.com/powersync-ja/sqlite_async.dart.git
+      ref: feat/navigator-locks
+      path: packages/sqlite_async
 
 dev_dependencies:
   flutter_test:

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.3.0-alpha.9
 
- - Updated sqlite_async to use Navigator locks for limiting sync stream implementions in multiple tabs
+- Updated sqlite_async to use Navigator locks for limiting sync stream implementations in multiple tabs
 
 ## 1.3.0-alpha.8
 

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0-alpha.9
+
+ - Updated sqlite_async to use Navigator locks for limiting sync stream implementions in multiple tabs
+
 ## 1.3.0-alpha.8
 
 - **FIX**(powersync-attachements-helper): pubspec file (#29).

--- a/packages/powersync/lib/src/database/web/web_powersync_database.dart
+++ b/packages/powersync/lib/src/database/web/web_powersync_database.dart
@@ -134,9 +134,8 @@ class PowerSyncDatabaseImpl
 
     await isInitialized;
 
-    // TODO multitab support
+    // TODO better multitab support
     final storage = BucketStorage(database);
-
     final sync = StreamingSyncImplementation(
         adapter: storage,
         credentialsCallback: connector.getCredentialsCached,
@@ -144,7 +143,10 @@ class PowerSyncDatabaseImpl
         uploadCrud: () => connector.uploadData(this),
         updateStream: updates,
         retryDelay: Duration(seconds: 3),
-        client: FetchClient(mode: RequestMode.cors));
+        client: FetchClient(mode: RequestMode.cors),
+        // Only allows 1 sync implementation to run at a time per database
+        // This should be global (across tabs) when using Navigator locks.
+        identifier: database.openFactory.path);
     sync.statusStream.listen((event) {
       setStatus(event);
     });

--- a/packages/powersync/lib/src/streaming_sync.dart
+++ b/packages/powersync/lib/src/streaming_sync.dart
@@ -52,8 +52,8 @@ class StreamingSyncImplementation {
       /// A unique identifier for this streaming sync implementation
       /// A good value is typically the DB file path which it will mutate when syncing.
       String? identifier = "unknown"})
-      : syncMutex = Mutex(identifier: "sync-${identifier}"),
-        crudMutex = Mutex(identifier: "crud-${identifier}") {
+      : syncMutex = Mutex(identifier: "sync-$identifier"),
+        crudMutex = Mutex(identifier: "crud-$identifier") {
     _client = client;
     statusStream = _statusStreamController.stream;
   }

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.3.0-alpha.8
+version: 1.3.0-alpha.9
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - keep PostgreSQL databases in sync with on-device SQLite databases.

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -10,11 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  sqlite_async:
-    git:
-      url: https://github.com/powersync-ja/sqlite_async.dart.git
-      ref: feat/navigator-locks
-      path: packages/sqlite_async
+  sqlite_async: ^0.8.1
 
   universal_io: ^2.0.0
   sqlite3_flutter_libs: ^0.5.15

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -10,7 +10,12 @@ dependencies:
   flutter:
     sdk: flutter
 
-  sqlite_async: ^0.8.0
+  sqlite_async:
+    git:
+      url: https://github.com/powersync-ja/sqlite_async.dart.git
+      ref: feat/navigator-locks
+      path: packages/sqlite_async
+
   universal_io: ^2.0.0
   sqlite3_flutter_libs: ^0.5.15
   meta: ^1.0.0

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0-alpha.4
+
+ - Update a dependency to the latest release.
+
 ## 0.3.0-alpha.3
 
  - Update a dependency to the latest release.

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.3.0-alpha.3
+version: 0.3.0-alpha.4
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: 1.3.0-alpha.8
+  powersync: 1.3.0-alpha.9
   logging: ^1.2.0
   sqlite3: "^2.4.4"
   path_provider: ^2.0.13


### PR DESCRIPTION
# Overview

This uses the Navigator locks in the `Mutex` class from here https://github.com/powersync-ja/sqlite_async.dart/pull/54 to limit the number of active sync implementations when multiple tabs are used.

This is only a stop-gap to prevent multiple tabs with multiple `StreamingSyncImplementation`s from applying sync bucket changes at the same time (this can leave the local SQLite DB in an inconsistent or broken state).

This method enhances the safety of using multiple tabs, but is far from complete multiple tab support. 

This should address the issue of "Flutter web + PowerSync still has the issue where multiple open tabs will cause sqlite to get messed up"  from https://github.com/powersync-ja/powersync.dart/issues/11

## Testing

Note that the app works when switching between tabs. The sync status is isolated per tab - only 1 tab is ever connected or uploading at a time. 


https://github.com/powersync-ja/powersync.dart/assets/51082125/a5eab365-45d9-4523-b485-e110ea509e3e

## Todos:
- [x] Update sqlite_async package