### PR TITLE
Fix watch query table names

### DIFF
--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.7.0
+  sqlite_async: ^0.8.1
   http: ^1.2.1
   shared_preferences: ^2.2.3
 

--- a/demos/supabase-anonymous-auth/pubspec.lock
+++ b/demos/supabase-anonymous-auth/pubspec.lock
@@ -232,6 +232,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  mutex:
+    dependency: transitive
+    description:
+      name: mutex
+      sha256: "8827da25de792088eb33e572115a5eb0d61d61a3c01acbc8bcbe76ed78f1a1f2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   path:
     dependency: "direct main"
     description:
@@ -318,7 +326,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.5.3"
+    version: "1.5.4"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
@@ -443,14 +451,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.24"
+  sqlite3_web:
+    dependency: transitive
+    description:
+      name: sqlite3_web
+      sha256: "51fec34757577841cc72d79086067e3651c434669d5af557a5c106787198a76f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2-wip"
   sqlite_async:
     dependency: "direct main"
     description:
       name: sqlite_async
-      sha256: "7c121bd76b9063cd8189ce54512f243709c88addeced0f3d027eea5db64d3220"
+      sha256: "79e636c857ed43f6cd5e5be72b36967a29f785daa63ff5b078bd34f74f44cb54"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -615,10 +631,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "1d9158c616048c38f712a6646e317a3426da10e884447626167240d45209cbad"
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.5.1"
   web_socket_channel:
     dependency: transitive
     description:

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   supabase_flutter: ^2.0.2
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.7.0
+  sqlite_async: ^0.8.1
 
 dev_dependencies:
   flutter_test:

--- a/demos/supabase-edge-function-auth/pubspec.lock
+++ b/demos/supabase-edge-function-auth/pubspec.lock
@@ -232,6 +232,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  mutex:
+    dependency: transitive
+    description:
+      name: mutex
+      sha256: "8827da25de792088eb33e572115a5eb0d61d61a3c01acbc8bcbe76ed78f1a1f2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   path:
     dependency: "direct main"
     description:
@@ -318,7 +326,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.5.3"
+    version: "1.5.4"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
@@ -443,14 +451,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.24"
+  sqlite3_web:
+    dependency: transitive
+    description:
+      name: sqlite3_web
+      sha256: "51fec34757577841cc72d79086067e3651c434669d5af557a5c106787198a76f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2-wip"
   sqlite_async:
     dependency: "direct main"
     description:
       name: sqlite_async
-      sha256: "7c121bd76b9063cd8189ce54512f243709c88addeced0f3d027eea5db64d3220"
+      sha256: "79e636c857ed43f6cd5e5be72b36967a29f785daa63ff5b078bd34f74f44cb54"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -615,10 +631,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "1d9158c616048c38f712a6646e317a3426da10e884447626167240d45209cbad"
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.5.1"
   web_socket_channel:
     dependency: transitive
     description:

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   supabase_flutter: ^2.0.2
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.7.0
+  sqlite_async: ^0.8.1
 
 dev_dependencies:
   flutter_test:

--- a/demos/supabase-simple-chat/pubspec.lock
+++ b/demos/supabase-simple-chat/pubspec.lock
@@ -272,6 +272,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  mutex:
+    dependency: transitive
+    description:
+      name: mutex
+      sha256: "8827da25de792088eb33e572115a5eb0d61d61a3c01acbc8bcbe76ed78f1a1f2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   path:
     dependency: "direct main"
     description:
@@ -358,7 +366,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.5.3"
+    version: "1.5.4"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
@@ -507,14 +515,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.24"
+  sqlite3_web:
+    dependency: transitive
+    description:
+      name: sqlite3_web
+      sha256: "51fec34757577841cc72d79086067e3651c434669d5af557a5c106787198a76f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2-wip"
   sqlite_async:
     dependency: transitive
     description:
       name: sqlite_async
-      sha256: "7c121bd76b9063cd8189ce54512f243709c88addeced0f3d027eea5db64d3220"
+      sha256: "79e636c857ed43f6cd5e5be72b36967a29f785daa63ff5b078bd34f74f44cb54"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -687,10 +703,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "1d9158c616048c38f712a6646e317a3426da10e884447626167240d45209cbad"
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.5.1"
   web_socket_channel:
     dependency: transitive
     description:

--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -304,6 +304,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  mutex:
+    dependency: transitive
+    description:
+      name: mutex
+      sha256: "8827da25de792088eb33e572115a5eb0d61d61a3c01acbc8bcbe76ed78f1a1f2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   path:
     dependency: "direct main"
     description:
@@ -398,7 +406,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.5.3"
+    version: "1.5.4"
   powersync_attachments_helper:
     dependency: "direct main"
     description:
@@ -530,14 +538,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.24"
+  sqlite3_web:
+    dependency: transitive
+    description:
+      name: sqlite3_web
+      sha256: "51fec34757577841cc72d79086067e3651c434669d5af557a5c106787198a76f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2-wip"
   sqlite_async:
     dependency: "direct main"
     description:
       name: sqlite_async
-      sha256: "7c121bd76b9063cd8189ce54512f243709c88addeced0f3d027eea5db64d3220"
+      sha256: "79e636c857ed43f6cd5e5be72b36967a29f785daa63ff5b078bd34f74f44cb54"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.8.1"
   stack_trace:
     dependency: transitive
     description:

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   supabase_flutter: ^2.0.1
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.7.0
+  sqlite_async: ^0.8.1
   camera: ^0.10.5+7
   image: ^4.1.3
 

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.4
+
+- Fix watch query parameter `triggerOnTables` to prepend powersync view names.
+
 ## 1.5.3
 
 - Added support for client parameters when connecting.

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.5.4
 
 - Fix watch query parameter `triggerOnTables` to prepend powersync view names.
+- Upgrade dependency `sqlite_async` to version 0.8.1.
 
 ## 1.5.3
 

--- a/packages/powersync/lib/src/powersync_database.dart
+++ b/packages/powersync/lib/src/powersync_database.dart
@@ -561,8 +561,33 @@ class PowerSyncDatabase with SqliteQueries implements SqliteConnection {
   }
 
   @override
+  Stream<ResultSet> watch(String sql,
+      {List<Object?> parameters = const [],
+      Duration throttle = const Duration(milliseconds: 30),
+      Iterable<String>? triggerOnTables}) {
+    if (triggerOnTables == null) {
+      return super.watch(sql, parameters: parameters, throttle: throttle);
+    }
+    List<String> powersyncTables = [];
+    for (String tableName in triggerOnTables) {
+      powersyncTables.add(tableName);
+      powersyncTables.add(_prefixTableNames(tableName, 'ps_data__'));
+      powersyncTables.add(_prefixTableNames(tableName, 'ps_data_local__'));
+    }
+    return super.watch(sql,
+        parameters: parameters,
+        throttle: throttle,
+        triggerOnTables: powersyncTables);
+  }
+
+  @override
   Future<bool> getAutoCommit() {
     return database.getAutoCommit();
+  }
+
+  String _prefixTableNames(String tableName, String prefix) {
+    String prefixedString = tableName.replaceRange(0, 0, prefix);
+    return prefixedString;
   }
 }
 

--- a/packages/powersync/lib/src/powersync_database.dart
+++ b/packages/powersync/lib/src/powersync_database.dart
@@ -565,7 +565,7 @@ class PowerSyncDatabase with SqliteQueries implements SqliteConnection {
       {List<Object?> parameters = const [],
       Duration throttle = const Duration(milliseconds: 30),
       Iterable<String>? triggerOnTables}) {
-    if (triggerOnTables == null) {
+    if (triggerOnTables == null || triggerOnTables.isEmpty) {
       return super.watch(sql, parameters: parameters, throttle: throttle);
     }
     List<String> powersyncTables = [];

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.5.3
+version: 1.5.4
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - keep PostgreSQL databases in sync with on-device SQLite databases.
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  sqlite_async: ^0.7.0
+  sqlite_async: ^0.8.1
   sqlite3_flutter_libs: ^0.5.23
   powersync_flutter_libs: ^0.1.0
   http: ^1.1.0

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1
+
+- Upgrade `sqlite_async` to version 0.8.1.
+
 ## 0.5.0
 
 - Upgrade minimum Dart SDK constraint to `3.4.0`.

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.5.0
+version: 0.5.1
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
 
   powersync: ^1.5.0
   logging: ^1.2.0
-  sqlite_async: ^0.7.0
+  sqlite_async: ^0.8.1
   path_provider: ^2.0.13
 
 dev_dependencies:


### PR DESCRIPTION
## Description

Addresses the enhancement in #116 with `watch` queries not recognizing powersync table names.

## Work done

- Prepend powersync identifiers to tables specified in a the `triggerOnTables` parameter in a watch query.
- Upgrade dependency `sqlite_async` to 0.8.1