### PR TITLE
[Fix] Offline has synced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 2024-07-16
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`powersync` - `v1.5.5`](#powersync---v155)
+ - [`powersync_attachments_helper` - `v0.5.1+1`](#powersync_attachments_helper---v0511)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `powersync_attachments_helper` - `v0.5.1+1`
+
+---
+
+#### `powersync` - `v1.5.5`
+
+ - Fix issue where `hasSynced` is cleared when offline.
+

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.5.0
+  powersync: ^1.5.5
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.5.0
+  powersync: ^1.5.5
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.5.0
+  powersync: ^1.5.5
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^1.10.25
   timeago: ^3.6.0
-  powersync: ^1.5.0
+  powersync: ^1.5.5
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist/macos/Podfile.lock
+++ b/demos/supabase-todolist/macos/Podfile.lock
@@ -12,18 +12,21 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - sqlite3 (3.46.0):
-    - sqlite3/common (= 3.46.0)
-  - sqlite3/common (3.46.0)
-  - sqlite3/fts5 (3.46.0):
+  - "sqlite3 (3.46.0+1)":
+    - "sqlite3/common (= 3.46.0+1)"
+  - "sqlite3/common (3.46.0+1)"
+  - "sqlite3/dbstatvtab (3.46.0+1)":
     - sqlite3/common
-  - sqlite3/perf-threadsafe (3.46.0):
+  - "sqlite3/fts5 (3.46.0+1)":
     - sqlite3/common
-  - sqlite3/rtree (3.46.0):
+  - "sqlite3/perf-threadsafe (3.46.0+1)":
+    - sqlite3/common
+  - "sqlite3/rtree (3.46.0+1)":
     - sqlite3/common
   - sqlite3_flutter_libs (0.0.1):
     - FlutterMacOS
-    - sqlite3 (~> 3.46.0)
+    - "sqlite3 (~> 3.46.0+1)"
+    - sqlite3/dbstatvtab
     - sqlite3/fts5
     - sqlite3/perf-threadsafe
     - sqlite3/rtree
@@ -67,8 +70,8 @@ SPEC CHECKSUMS:
   powersync-sqlite-core: 4c38c8f470f6dca61346789fd5436a6826d1e3dd
   powersync_flutter_libs: 1eb1c6790a72afe08e68d4cc489d71ab61da32ee
   shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
-  sqlite3: 154b084339ede06960a5b3c8160066adc9176b7d
-  sqlite3_flutter_libs: 1be4459672f8168ded2d8667599b8e3ca5e72b83
+  sqlite3: 292c3e1bfe89f64e51ea7fc7dab9182a017c8630
+  sqlite3_flutter_libs: 5ca46c1a04eddfbeeb5b16566164aa7ad1616e7b
   url_launcher_macos: d2691c7dd33ed713bf3544850a623080ec693d95
 
 PODFILE CHECKSUM: 236401fc2c932af29a9fcf0e97baeeb2d750d367

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.5.0
-  powersync: ^1.5.0
+  powersync_attachments_helper: ^0.5.1
+  powersync: ^1.5.5
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.5
+
+ - Fix issue where `hasSynced` is cleared when offline.
+
 ## 1.5.4
 
 - Fix watch query parameter `triggerOnTables` to prepend powersync view names.

--- a/packages/powersync/lib/src/powersync_database.dart
+++ b/packages/powersync/lib/src/powersync_database.dart
@@ -348,8 +348,8 @@ class PowerSyncDatabase with SqliteQueries implements SqliteConnection {
   void _setStatus(SyncStatus status) {
     if (status != currentStatus) {
       currentStatus = status.copyWith(
-          // Note that currently the streaming sync implementation will never set hasSynced
-          // lastSyncedAt implies that syncing has completed at some point hasSynced = true
+          // Note that currently the streaming sync implementation will never set hasSynced.
+          // lastSyncedAt implies that syncing has completed at some point (hasSynced = true).
           // The previous values of hasSynced should be preserved here.
           hasSynced: status.lastSyncedAt != null
               ? true

--- a/packages/powersync/lib/src/powersync_database.dart
+++ b/packages/powersync/lib/src/powersync_database.dart
@@ -348,7 +348,12 @@ class PowerSyncDatabase with SqliteQueries implements SqliteConnection {
   void _setStatus(SyncStatus status) {
     if (status != currentStatus) {
       currentStatus = status.copyWith(
-          hasSynced: status.hasSynced ?? status.lastSyncedAt != null);
+          // Note that currently the streaming sync implementation will never set hasSynced
+          // lastSyncedAt implies that syncing has completed at some point hasSynced = true
+          // The previous values of hasSynced should be preserved here.
+          hasSynced: status.lastSyncedAt != null
+              ? true
+              : status.hasSynced ?? currentStatus.hasSynced);
       _statusStreamController.add(currentStatus);
     }
   }

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.5.4
+version: 1.5.5
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - keep PostgreSQL databases in sync with on-device SQLite databases.

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.5.0
+  powersync: ^1.5.5
   logging: ^1.2.0
   sqlite_async: ^0.8.1
   path_provider: ^2.0.13


### PR DESCRIPTION
# Overview

Currently the `hasSynced` member of `SyncStatus` does not work if the device is offline.

The value is initially set to true after querying `ps_buckets` but if a sync request fails it's value will be cleared.

# Testing

## Before

When starting offline
<img width="811" alt="image" src="https://github.com/user-attachments/assets/c3cbafbc-755e-4d71-8a86-11630fa934b8">

Note that `lists` are present on the device
<img width="807" alt="image" src="https://github.com/user-attachments/assets/e0f1f147-e88e-4570-b0bb-8d9e90bd5d22">


## After
<img width="808" alt="image" src="https://github.com/user-attachments/assets/e4a4f983-1bf5-4098-afed-3809811e8611">
