### PR TITLE
Update powersync dependency to version 1.3.0-alpha.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,36 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2024-07-18
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+- There are no breaking changes in this release.
+
+Packages with other changes:
+
+- [`powersync` - `v1.3.0-alpha.10`](#powersync---v130-alpha10)
+- [`powersync_attachments_helper` - `v0.3.0-alpha.5`](#powersync_attachments_helper---v030-alpha5)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+- `powersync_attachments_helper` - `v0.3.0-alpha.5`
+
+---
+
+#### `powersync` - `v1.3.0-alpha.10`
+
+- Added support for client parameters when connecting.
+- Fix watch query parameter `triggerOnTables` to prepend powersync view names.
+- Upgrade dependency `sqlite_async` to version 0.8.1.
+- Fix issue where `hasSynced` is cleared when offline.
+
 ## 2024-07-16
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Packages with breaking changes:
 Packages with other changes:
 
 - [`powersync` - `v1.6.0-alpha.1`](#powersync---v160-alpha1)
-- [`powersync_attachments_helper` - `v0.6.0-alpha.1`](#powersync_attachments_helper---v030-alpha5)
+- [`powersync_attachments_helper` - `v0.6.0-alpha.1`](#powersync_attachments_helper---v060-alpha1)
 
 Packages with dependency updates only:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,18 +15,18 @@ Packages with breaking changes:
 
 Packages with other changes:
 
-- [`powersync` - `v1.3.0-alpha.10`](#powersync---v130-alpha10)
-- [`powersync_attachments_helper` - `v0.3.0-alpha.5`](#powersync_attachments_helper---v030-alpha5)
+- [`powersync` - `v1.6.0-alpha.1`](#powersync---v160-alpha1)
+- [`powersync_attachments_helper` - `v0.6.0-alpha.1`](#powersync_attachments_helper---v030-alpha5)
 
 Packages with dependency updates only:
 
 > Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
 
-- `powersync_attachments_helper` - `v0.3.0-alpha.5`
+- `powersync_attachments_helper` - `v0.6.0-alpha.1`
 
 ---
 
-#### `powersync` - `v1.3.0-alpha.10`
+#### `powersync` - `v1.6.0-alpha.1`
 
 - Added support for client parameters when connecting.
 - Fix watch query parameter `triggerOnTables` to prepend powersync view names.

--- a/demos/django-todolist/pubspec.lock
+++ b/demos/django-todolist/pubspec.lock
@@ -294,7 +294,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.5.4"
+    version: "1.3.0-alpha.10"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/django-todolist/pubspec.lock
+++ b/demos/django-todolist/pubspec.lock
@@ -294,7 +294,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.3.0-alpha.10"
+    version: "1.6.0-alpha.1"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.5.5
+  powersync: 1.3.0-alpha.10
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: 1.3.0-alpha.10
+  powersync: ^1.6.0-alpha.1
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-anonymous-auth/pubspec.lock
+++ b/demos/supabase-anonymous-auth/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.5.4"
+    version: "1.3.0-alpha.10"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-anonymous-auth/pubspec.lock
+++ b/demos/supabase-anonymous-auth/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.3.0-alpha.10"
+    version: "1.6.0-alpha.1"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: 1.3.0-alpha.10
+  powersync: ^1.6.0-alpha.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.5.5
+  powersync: 1.3.0-alpha.10
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.lock
+++ b/demos/supabase-edge-function-auth/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.5.4"
+    version: "1.3.0-alpha.10"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-edge-function-auth/pubspec.lock
+++ b/demos/supabase-edge-function-auth/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.3.0-alpha.10"
+    version: "1.6.0-alpha.1"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: 1.3.0-alpha.10
+  powersync: ^1.6.0-alpha.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.5.5
+  powersync: 1.3.0-alpha.10
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.lock
+++ b/demos/supabase-simple-chat/pubspec.lock
@@ -366,7 +366,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.3.0-alpha.10"
+    version: "1.6.0-alpha.1"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-simple-chat/pubspec.lock
+++ b/demos/supabase-simple-chat/pubspec.lock
@@ -366,7 +366,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.5.4"
+    version: "1.3.0-alpha.10"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^2.0.2
   timeago: ^3.6.0
-  powersync: 1.3.0-alpha.10
+  powersync: ^1.6.0-alpha.1
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^2.0.2
   timeago: ^3.6.0
-  powersync: ^1.5.5
+  powersync: 1.3.0-alpha.10
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -454,14 +454,14 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.3.0-alpha.10"
+    version: "1.6.0-alpha.1"
   powersync_attachments_helper:
     dependency: "direct main"
     description:
       path: "../../packages/powersync_attachments_helper"
       relative: true
     source: path
-    version: "0.3.0-alpha.5"
+    version: "0.6.0-alpha.1"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -454,14 +454,14 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.5.4"
+    version: "1.3.0-alpha.10"
   powersync_attachments_helper:
     dependency: "direct main"
     description:
       path: "../../packages/powersync_attachments_helper"
       relative: true
     source: path
-    version: "0.5.1"
+    version: "0.3.0-alpha.5"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: 0.3.0-alpha.5
-  powersync: 1.3.0-alpha.10
+  powersync_attachments_helper: ^0.6.0-alpha.1
+  powersync: ^1.6.0-alpha.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.5.1
-  powersync: ^1.5.5
+  powersync_attachments_helper: 0.3.0-alpha.5
+  powersync: 1.3.0-alpha.10
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.5.5
 
- - Fix issue where `hasSynced` is cleared when offline.
+- Fix issue where `hasSynced` is cleared when offline.
 
 ## 1.5.4
 
@@ -38,6 +38,13 @@
 
 - Introduces the use of the `powersync-sqlite-core` native extension. This is our common Rust core which means all PowerSync SDKs now use the same core logic for PowerSync functionality, improving maintainability and support.
 - Added a new package dependency on `powersync_flutter_libs` for loading the extension.
+
+## 1.3.0-alpha.10
+
+- Added support for client parameters when connecting.
+- Fix watch query parameter `triggerOnTables` to prepend powersync view names.
+- Upgrade dependency `sqlite_async` to version 0.8.1.
+- Fix issue where `hasSynced` is cleared when offline.
 
 ## 1.3.0-alpha.9
 

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.6.0-alpha.1
+
+- Added support for client parameters when connecting.
+- Fix watch query parameter `triggerOnTables` to prepend powersync view names.
+- Upgrade dependency `sqlite_async` to version 0.8.1.
+- Fix issue where `hasSynced` is cleared when offline.
+
 ## 1.5.5
 
 - Fix issue where `hasSynced` is cleared when offline.
@@ -38,13 +45,6 @@
 
 - Introduces the use of the `powersync-sqlite-core` native extension. This is our common Rust core which means all PowerSync SDKs now use the same core logic for PowerSync functionality, improving maintainability and support.
 - Added a new package dependency on `powersync_flutter_libs` for loading the extension.
-
-## 1.3.0-alpha.10
-
-- Added support for client parameters when connecting.
-- Fix watch query parameter `triggerOnTables` to prepend powersync view names.
-- Upgrade dependency `sqlite_async` to version 0.8.1.
-- Fix issue where `hasSynced` is cleared when offline.
 
 ## 1.3.0-alpha.9
 

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.3.0-alpha.10
+version: 1.6.0-alpha.1
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - keep PostgreSQL databases in sync with on-device SQLite databases.

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.5.5
+version: 1.3.0-alpha.10
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - keep PostgreSQL databases in sync with on-device SQLite databases.

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Upgrade minimum Dart SDK constraint to `3.4.0`.
 - Upgrade `sqlite_async` to version 0.7.0.
 
+## 0.3.0-alpha.5
+
+- Update a dependency to the latest release.
+
 ## 0.3.0-alpha.4
 
 - Update a dependency to the latest release.

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0-alpha.1
+
+- Update a dependency to the latest release.
+
 ## 0.5.1
 
 - Upgrade `sqlite_async` to version 0.8.1.
@@ -6,10 +10,6 @@
 
 - Upgrade minimum Dart SDK constraint to `3.4.0`.
 - Upgrade `sqlite_async` to version 0.7.0.
-
-## 0.3.0-alpha.5
-
-- Update a dependency to the latest release.
 
 ## 0.3.0-alpha.4
 

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.5.1
+version: 0.3.0-alpha.5
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.5.5
+  powersync: 1.3.0-alpha.10
   logging: ^1.2.0
   sqlite_async: ^0.8.1
   path_provider: ^2.0.13

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.3.0-alpha.5
+version: 0.6.0-alpha.1
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: 1.3.0-alpha.10
+  powersync: ^1.6.0-alpha.1
   logging: ^1.2.0
   sqlite_async: ^0.8.1
   path_provider: ^2.0.13


### PR DESCRIPTION
## Description

This release adds a bunch of improvements and bug fixes for the powersync alpha release. These changes were pulled in from the upstream `master` branch.

## Work done

- Update powersync dependency to version 1.6.0-alpha.1
- Update powersync_attachments_helper dependency to version 0.6.0-alpha.1
- Update changelogs