### PR TITLE
Reintroduce waitForFirstSync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       # This action is not compatible with tags such as `powersync-v1.1.1`
       # marvinpinto/action-automatic-releases struggles to generate changelogs
       # Be sure to manually tag the commit to trigger this action
-      - 'v*'
+      - "powersync-v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   build:
@@ -22,8 +22,8 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.x'
-          channel: 'stable'
+          flutter-version: "3.x"
+          channel: "stable"
 
       - name: Install Melos
         run: flutter pub global activate melos
@@ -32,10 +32,8 @@ jobs:
         run: melos prepare
 
       - name: Create Draft Release
-        uses: 'marvinpinto/action-automatic-releases@latest'
-        with:
-          repo_token: '${{ secrets.GITHUB_TOKEN }}'
-          prerelease: true # TODO update when out of alpha
-          draft: true
-          files: |
-            assets/powersync_db.worker.js
+        run: |
+          tag="${{ github.ref_name }}"
+          body="Release $tag"
+          gh release create --draft "$tag" --title "$tag" --notes "$body" --generate-notes --prerelease
+          gh release upload "${{ github.ref_name }}" assets/powersync_db.worker.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2024-07-29
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`powersync` - `v1.6.1`](#powersync---v161)
+ - [`powersync_attachments_helper` - `v0.6.1`](#powersync_attachments_helper---v061)
+
+---
+
+#### `powersync` - `v1.6.1`
+
+ - **FIX**: Reintroduce waitForFirstSync.
+
+#### `powersync_attachments_helper` - `v0.6.1`
+
+ - Update a dependency to the latest release.
+
+
 ## 2024-07-25
 
 ### Changes

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.6.0
+  powersync: ^1.6.1
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.6.0
+  powersync: ^1.6.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.6.0
+  powersync: ^1.6.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^2.0.2
   timeago: ^3.6.0
-  powersync: ^1.6.0
+  powersync: ^1.6.1
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.0
-  powersync: ^1.6.0
+  powersync_attachments_helper: ^0.6.1
+  powersync: ^1.6.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/melos.yaml
+++ b/melos.yaml
@@ -8,6 +8,11 @@ packages:
 ide:
   intellij: false
 
+command:
+  version:
+    packageFilters:
+      noPrivate: true
+
 scripts:
   prepare: melos bootstrap && dart ./scripts/compile_webworker.dart && dart ./scripts/init_sqlite_wasm.dart && dart ./scripts/init_powersync_core_binary.dart
 

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.1
+
+ - **FIX**: Reintroduce waitForFirstSync.
+
 ## 1.6.0
 
 - Web support is now included in the standard release but remains in alpha. Web support may have some limitations or bugs.

--- a/packages/powersync/lib/src/database/powersync_db_mixin.dart
+++ b/packages/powersync/lib/src/database/powersync_db_mixin.dart
@@ -104,6 +104,18 @@ mixin PowerSyncDatabaseMixin implements SqliteConnection {
     }
   }
 
+  /// Returns a [Future] which will resolve once the first full sync has completed.
+  Future<void> waitForFirstSync() async {
+    if (currentStatus.hasSynced ?? false) {
+      return;
+    }
+    await for (final result in statusStream) {
+      if (result.hasSynced ?? false) {
+        break;
+      }
+    }
+  }
+
   @protected
   void setStatus(SyncStatus status) {
     if (status != currentStatus) {

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.6.0
+version: 1.6.1
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - keep PostgreSQL databases in sync with on-device SQLite databases.

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1
+
+ - Update a dependency to the latest release.
+
 ## 0.6.0
 
 - Update a dependency to the latest release.

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.6.0
+version: 0.6.1
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.6.0
+  powersync: ^1.6.1
   logging: ^1.2.0
   sqlite_async: ^0.8.1
   path_provider: ^2.0.13


### PR DESCRIPTION
## Description

The `waitForFirstSync` method was removed during the merge from alpha-release to master. This adds it back.

## Work done

- Reintroduce waitForFirstSync
- Improve versioning and releases using `melos`