### PR TITLE
Downgrade JS dependency to version >=0.6.7 <0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2024-07-31
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`powersync` - `v1.6.3`](#powersync---v163)
+ - [`powersync_attachments_helper` - `v0.6.3`](#powersync_attachments_helper---v063)
+
+---
+
+#### `powersync` - `v1.6.3`
+
+#### `powersync_attachments_helper` - `v0.6.3`
+
+ - Update a dependency to the latest release.
+
+
 ## 2024-07-30
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Packages with other changes:
 
 #### `powersync` - `v1.6.3`
 
+ - **FIX**: Lower JS dependency to version range ">=0.6.7 <0.8.0"
+
 #### `powersync_attachments_helper` - `v0.6.3`
 
  - Update a dependency to the latest release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Packages with other changes:
 
 #### `powersync` - `v1.6.3`
 
-- **FIX**: Move JS to dev dependencies to lower version range ">=0.6.7 <0.8.0"
+- **FIX**: Move JS to dev dependencies and lower version range ">=0.6.7 <0.8.0"
 
 #### `powersync_attachments_helper` - `v0.6.3`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,23 +11,22 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 Packages with breaking changes:
 
- - There are no breaking changes in this release.
+- There are no breaking changes in this release.
 
 Packages with other changes:
 
- - [`powersync` - `v1.6.3`](#powersync---v163)
- - [`powersync_attachments_helper` - `v0.6.3`](#powersync_attachments_helper---v063)
+- [`powersync` - `v1.6.3`](#powersync---v163)
+- [`powersync_attachments_helper` - `v0.6.3`](#powersync_attachments_helper---v063)
 
 ---
 
 #### `powersync` - `v1.6.3`
 
- - **FIX**: Lower JS dependency to version range ">=0.6.7 <0.8.0"
+- **FIX**: Move JS to dev dependencies to lower version range ">=0.6.7 <0.8.0"
 
 #### `powersync_attachments_helper` - `v0.6.3`
 
- - Update a dependency to the latest release.
-
+- Update a dependency to the latest release.
 
 ## 2024-07-30
 

--- a/demos/django-todolist/pubspec.lock
+++ b/demos/django-todolist/pubspec.lock
@@ -152,14 +152,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -318,7 +310,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.6.2"
+    version: "1.6.3"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/django-todolist/pubspec.lock
+++ b/demos/django-todolist/pubspec.lock
@@ -156,10 +156,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -318,7 +318,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.6.1"
+    version: "1.6.2"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.6.2
+  powersync: ^1.6.3
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-anonymous-auth/pubspec.lock
+++ b/demos/supabase-anonymous-auth/pubspec.lock
@@ -188,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -374,7 +374,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.6.1"
+    version: "1.6.2"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-anonymous-auth/pubspec.lock
+++ b/demos/supabase-anonymous-auth/pubspec.lock
@@ -184,14 +184,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -374,7 +366,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.6.2"
+    version: "1.6.3"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.6.2
+  powersync: ^1.6.3
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.lock
+++ b/demos/supabase-edge-function-auth/pubspec.lock
@@ -188,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -374,7 +374,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.6.1"
+    version: "1.6.2"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-edge-function-auth/pubspec.lock
+++ b/demos/supabase-edge-function-auth/pubspec.lock
@@ -184,14 +184,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -374,7 +366,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.6.2"
+    version: "1.6.3"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.6.2
+  powersync: ^1.6.3
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.lock
+++ b/demos/supabase-simple-chat/pubspec.lock
@@ -200,14 +200,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.19.0"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -390,7 +382,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.6.2"
+    version: "1.6.3"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-simple-chat/pubspec.lock
+++ b/demos/supabase-simple-chat/pubspec.lock
@@ -204,10 +204,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -390,7 +390,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.6.1"
+    version: "1.6.2"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^2.0.2
   timeago: ^3.6.0
-  powersync: ^1.6.2
+  powersync: ^1.6.3
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -280,14 +280,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.0"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -478,14 +470,14 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.6.2"
+    version: "1.6.3"
   powersync_attachments_helper:
     dependency: "direct main"
     description:
       path: "../../packages/powersync_attachments_helper"
       relative: true
     source: path
-    version: "0.6.2"
+    version: "0.6.3"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -284,10 +284,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -478,14 +478,14 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.6.1"
+    version: "1.6.2"
   powersync_attachments_helper:
     dependency: "direct main"
     description:
       path: "../../packages/powersync_attachments_helper"
       relative: true
     source: path
-    version: "0.6.1"
+    version: "0.6.2"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.2
-  powersync: ^1.6.2
+  powersync_attachments_helper: ^0.6.3
+  powersync: ^1.6.3
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.6.3
+
 ## 1.6.2
 
 - **FEAT**: Introduces a custom script to download the sqlite3 wasm and powersync worker files. The command `dart run powersync:setup_web` must be run in the application's folder.

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.6.3
 
-- **FIX**: Move JS to dev dependencies to lower version range ">=0.6.7 <0.8.0"
+- **FIX**: Move JS to dev dependencies and lower version range ">=0.6.7 <0.8.0"
 
 ## 1.6.2
 

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.6.3
 
+- **FIX**: Lower JS dependency to version range ">=0.6.7 <0.8.0"
+
 ## 1.6.2
 
 - **FEAT**: Introduces a custom script to download the sqlite3 wasm and powersync worker files. The command `dart run powersync:setup_web` must be run in the application's folder.

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.6.3
 
-- **FIX**: Lower JS dependency to version range ">=0.6.7 <0.8.0"
+- **FIX**: Move JS to dev dependencies to lower version range ">=0.6.7 <0.8.0"
 
 ## 1.6.2
 

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   logging: ^1.1.1
   collection: ^1.17.0
   fetch_client: ^1.1.2
-  js: ^0.7.0
+  js: ^0.6.7
   pubspec_parse: ^1.3.0
   args: ^2.5.0
   pub_semver: ^2.1.4

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.6.2
+version: 1.6.3
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - keep PostgreSQL databases in sync with on-device SQLite databases.

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   logging: ^1.1.1
   collection: ^1.17.0
   fetch_client: ^1.1.2
-  js: ^0.6.7
+  js: ">= 0.6.7 <0.8.0"
   pubspec_parse: ^1.3.0
   args: ^2.5.0
   pub_semver: ^2.1.4

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   logging: ^1.1.1
   collection: ^1.17.0
   fetch_client: ^1.1.2
-  js: ">= 0.6.7 <0.8.0"
+  js: ">=0.6.7 <0.8.0"
   pubspec_parse: ^1.3.0
   args: ^2.5.0
   pub_semver: ^2.1.4

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -11,7 +11,6 @@ dependencies:
     sdk: flutter
 
   sqlite_async: ^0.8.1
-
   universal_io: ^2.0.0
   sqlite3_flutter_libs: ^0.5.23
   powersync_flutter_libs: ^0.1.0
@@ -22,7 +21,6 @@ dependencies:
   logging: ^1.1.1
   collection: ^1.17.0
   fetch_client: ^1.1.2
-  js: ">=0.6.7 <0.8.0"
   pubspec_parse: ^1.3.0
   args: ^2.5.0
   pub_semver: ^2.1.4
@@ -38,6 +36,7 @@ dev_dependencies:
   shelf_static: ^1.1.2
   stream_channel: ^2.1.2
   path: ^1.8.3
+  js: ">=0.6.7 <0.8.0"
 
 platforms:
   android:

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.3
+
+ - Update a dependency to the latest release.
+
 ## 0.6.2
 
  - Update a dependency to the latest release.

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.6.2
+version: 0.6.3
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.6.2
+  powersync: ^1.6.3
   logging: ^1.2.0
   sqlite_async: ^0.8.1
   path_provider: ^2.0.13


### PR DESCRIPTION
## Description

There is a build error in FlutterFlow as some of packages used by default rely on `js: 0.6.7`. We only use the JS dependency for web tests and the package downgrade does not break those tests.

```
Error Getting Packages
Check the following custom dependencies: powersync: ^1.6.2.
Because sign _in_with_apple_web <2.0.0-dev.1 depends on js ^0.6.3 
and powersync>=1.6.0-alpha.1 depends on js ^0.7.0, 
sign in with_apple _web <2.0.0-dev.1 is incompatible with powersync >=1.6.0-alpha.1.
```

## Work done

- Downgrade JS dependency to version 0.6.7

