### PR TITLE
[Fix]  Reset hasSynced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Packages with dependency updates only:
 
 #### `powersync` - `v1.6.4`
 
- - **FIX**: should be reset after  has been called. ([5e12a079](https://github.com/powersync-ja/powersync.dart/commit/5e12a07918ca16d3dcf90f26a42c5a61c09fb978))
+ - **FIX**: `hasSynced` status should be reset after `disconnectAndClear` has been called. ([5e12a079](https://github.com/powersync-ja/powersync.dart/commit/5e12a07918ca16d3dcf90f26a42c5a61c09fb978))
 
 
 ## 2024-07-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2024-08-06
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`powersync` - `v1.6.4`](#powersync---v164)
+ - [`powersync_attachments_helper` - `v0.6.3+1`](#powersync_attachments_helper---v0631)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `powersync_attachments_helper` - `v0.6.3+1`
+
+---
+
+#### `powersync` - `v1.6.4`
+
+ - **FIX**: should be reset after  has been called. ([5e12a079](https://github.com/powersync-ja/powersync.dart/commit/5e12a07918ca16d3dcf90f26a42c5a61c09fb978))
+
+
 ## 2024-07-31
 
 ### Changes

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.6.3
+  powersync: ^1.6.4
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.6.3
+  powersync: ^1.6.4
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.6.3
+  powersync: ^1.6.4
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^2.0.2
   timeago: ^3.6.0
-  powersync: ^1.6.3
+  powersync: ^1.6.4
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.3
-  powersync: ^1.6.3
+  powersync_attachments_helper: ^0.6.3+1
+  powersync: ^1.6.4
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.4
+
+ - **FIX**: should be reset after  has been called. ([5e12a079](https://github.com/powersync-ja/powersync.dart/commit/5e12a07918ca16d3dcf90f26a42c5a61c09fb978))
+
 ## 1.6.3
 
 - **FIX**: Move JS to dev dependencies and lower version range ">=0.6.7 <0.8.0"

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.6.4
 
- - **FIX**: should be reset after  has been called. ([5e12a079](https://github.com/powersync-ja/powersync.dart/commit/5e12a07918ca16d3dcf90f26a42c5a61c09fb978))
+- **FIX**: `hasSynced` status should be reset after `disconnectAndClear` has been called. ([5e12a079](https://github.com/powersync-ja/powersync.dart/commit/5e12a07918ca16d3dcf90f26a42c5a61c09fb978))
 
 ## 1.6.3
 

--- a/packages/powersync/lib/src/database/powersync_db_mixin.dart
+++ b/packages/powersync/lib/src/database/powersync_db_mixin.dart
@@ -239,6 +239,8 @@ mixin PowerSyncDatabaseMixin implements SqliteConnection {
         await tx.execute('DELETE FROM ${quoteIdentifier(row['name'])}');
       }
     });
+    // The data has been deleted - reset these
+    setStatus(SyncStatus(lastSyncedAt: null, hasSynced: false));
   }
 
   @Deprecated('Use [disconnectAndClear] instead.')

--- a/packages/powersync/lib/src/streaming_sync.dart
+++ b/packages/powersync/lib/src/streaming_sync.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert' as convert;
+
 import 'package:http/http.dart' as http;
 import 'package:powersync/src/abort_controller.dart';
 import 'package:powersync/src/exceptions.dart';
@@ -143,6 +144,9 @@ class StreamingSyncImplementation {
     await uploadAllCrud();
 
     await for (var _ in updateStream) {
+      if (_abort?.aborted == true) {
+        break;
+      }
       await uploadAllCrud();
     }
   }

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.6.3
+version: 1.6.4
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - keep PostgreSQL databases in sync with on-device SQLite databases.

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.3+1
+
+ - Update a dependency to the latest release.
+
 ## 0.6.3
 
  - Update a dependency to the latest release.

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.6.3
+version: 0.6.3+1
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.6.3
+  powersync: ^1.6.4
   logging: ^1.2.0
   sqlite_async: ^0.8.1
   path_provider: ^2.0.13


### PR DESCRIPTION
# Overview

The `hasSycned` status would be retained after calls to `disconnectAndClear` have been made. 

Steps to reproduce the issue:

- Log in
- Wait for first sync > works fine
- Log out
- Log in
- Wait for first sync > no longer works

The previous `hasSynced: true` would cause the check to immediately pass before syncing had completed on the second round. 

This PR clears the `hasSynced` status when disconnecting and clearing. The PowerSync client typically checks the setting in the `initialize` method which won't be called again, but the status will be updated on the next full sync when `lastSyncedAt` has been set.


# Testing

This was tested on MacOS by syncing locally then logging out. The local PowerSync service was then stopped to delay the syncing process. The next login should show the loading message until a sync has occurred.

The first test is without the fix, the second test contains the fix.

https://github.com/user-attachments/assets/47be618f-a883-47fc-82cc-13bf51d5ad2e



On web it was observed that a large queue of sync status updates were present after `disconnectAndClear` this was due to the `crudLoop` not ending when the `StreamingSyncImplementation` was aborted. A break for uploads was added.

This only shows the fix present.

https://github.com/user-attachments/assets/8f9520e7-a2f5-47f6-bdd4-85e71c4d1dd0

