### PR TITLE
fix: Download Flutter for package publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,14 @@ jobs:
 
       - uses: dart-lang/setup-dart@v1 # Creates and configures token for publishing
 
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.x"
+          channel: "stable"
+
       - name: Install melos
-        run: dart pub global activate melos
+        run: flutter pub global activate melos
 
       - name: Set powersync core version
         run: echo "CORE_VERSION=v0.1.8" >> $GITHUB_ENV


### PR DESCRIPTION
## Description

`melos publish` fails when running for `powersync_flutter_libs`. 

```
Because powersync_flutter_libs requires the Flutter SDK, version solving failed.

Flutter users should use `flutter pub` instead of `dart pub`.
```

## Work done

- Install flutter sdk before running melos publish