### PR TITLE
fix: Run melos bootstrap before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install melos
         run: flutter pub global activate melos
 
+      - name: Install dependencies
+        run: melos bootstrap
+
       - name: Set powersync core version
         run: echo "CORE_VERSION=v0.1.8" >> $GITHUB_ENV
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,10 @@ on:
       - "powersync_flutter_libs-v[0-9]+.[0-9]+.[0-9]+*"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   publish-packages:
     name: Publish packages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Description 

Version solving fails if the `pubspec_overrides.yaml` is not generated before running `melos publish (dart pub publish --dry-run)`. It tends to look for a new version online before it has been published. This change ensures that the override is present before trying to validate the pubspec.

## Work done

- Add step to install dependencies and generate a `pubspec_overrides.yaml` so that version solving does not fail when validating the pubspec with `melos publish`.
- Only run publish workflow once per tag push