### PR TITLE
Make melos prepare command a single line

### DIFF
--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -34,7 +34,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -32,7 +32,10 @@ jobs:
           melos analyze:demos
 
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Install Flutter

--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -34,7 +34,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -32,10 +32,7 @@ jobs:
           melos analyze:demos
 
   test:
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install Flutter

--- a/melos.yaml
+++ b/melos.yaml
@@ -24,8 +24,7 @@ scripts:
   prepare:
     description: Download SQLite3 WASM for demos
     run: |
-      melos bootstrap && melos prepare:assets && dart ./scripts/compile_webworker.dart && dart ./scripts/init_powersync_core_binary.dart
-      dart ./scripts/download_core_binary_demos.dart && melos prepare:demos
+      melos bootstrap && melos prepare:assets && dart ./scripts/compile_webworker.dart && dart ./scripts/init_powersync_core_binary.dart && dart ./scripts/download_core_binary_demos.dart && melos prepare:demos
 
   prepare:demos:
     description: Download SQLite3 wasm for demos

--- a/melos.yaml
+++ b/melos.yaml
@@ -22,7 +22,7 @@ command:
 
 scripts:
   prepare:
-    description: Download SQLite3 WASM for demos
+    description: Download and prepare assets for demos
     run: |
       melos bootstrap && melos prepare:assets && dart ./scripts/compile_webworker.dart && dart ./scripts/init_powersync_core_binary.dart && dart ./scripts/download_core_binary_demos.dart && melos prepare:demos
 


### PR DESCRIPTION
## Description

Having a `melos run` command on multiple lines works on macOS and Linux but fails to run additional new lines on windows

## Work done

- Make all prepare commands run in a single line with & separators.