### PR TITLE
powersync 1.8.1 / powersync_flutter_libs 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,48 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2024-09-09
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`powersync_flutter_libs` - `v0.3.0`](#powersync_flutter_libs---v023)
+
+---
+
+#### `powersync_flutter_libs` - `v0.3.0`
+
+ - powersync-sqlite-core v0.2.1
+
+
+## 2024-09-09
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`powersync` - `v1.8.1`](#powersync---v181)
+
+---
+
+#### `powersync` - `v1.8.1`
+
+ - Fix powersync_flutter_libs dependency
+
+
 ## 2024-09-06
 
 ### Changes

--- a/demos/django-todolist/pubspec.lock
+++ b/demos/django-todolist/pubspec.lock
@@ -310,14 +310,14 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.7.0"
+    version: "1.8.1"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.2.2"
+    version: "0.3.0"
   pub_semver:
     dependency: transitive
     description:

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.8.0
+  powersync: ^1.8.1
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-anonymous-auth/pubspec.lock
+++ b/demos/supabase-anonymous-auth/pubspec.lock
@@ -366,14 +366,14 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.7.0"
+    version: "1.8.1"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.2.2"
+    version: "0.3.0"
   pub_semver:
     dependency: transitive
     description:

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.8.0
+  powersync: ^1.8.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.lock
+++ b/demos/supabase-edge-function-auth/pubspec.lock
@@ -390,14 +390,14 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.7.0"
+    version: "1.8.1"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.2.2"
+    version: "0.3.0"
   pub_semver:
     dependency: transitive
     description:

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.8.0
+  powersync: ^1.8.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.lock
+++ b/demos/supabase-simple-chat/pubspec.lock
@@ -406,14 +406,14 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.7.0"
+    version: "1.8.1"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.2.2"
+    version: "0.3.0"
   pub_semver:
     dependency: transitive
     description:

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^2.0.2
   timeago: ^3.6.0
-  powersync: ^1.8.0
+  powersync: ^1.8.1
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist-drift/pubspec.lock
+++ b/demos/supabase-todolist-drift/pubspec.lock
@@ -686,7 +686,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.7.0"
+    version: "1.8.1"
   powersync_attachments_helper:
     dependency: "direct main"
     description:
@@ -700,7 +700,7 @@ packages:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.2.2"
+    version: "0.3.0"
   pub_semver:
     dependency: transitive
     description:

--- a/demos/supabase-todolist-drift/pubspec.yaml
+++ b/demos/supabase-todolist-drift/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   powersync_attachments_helper: ^0.6.5+1
-  powersync: ^1.8.0
+  powersync: ^1.8.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -470,7 +470,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.7.0"
+    version: "1.8.1"
   powersync_attachments_helper:
     dependency: "direct main"
     description:
@@ -484,7 +484,7 @@ packages:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.2.2"
+    version: "0.3.0"
   pub_semver:
     dependency: transitive
     description:

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   powersync_attachments_helper: ^0.6.5+1
-  powersync: ^1.8.0
+  powersync: ^1.8.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.1
+
+ - Fix powersync_flutter_libs dependency
+
 ## 1.8.0
 
  - Requires `journeyapps/powersync-service` v0.5.0 or later when self-hosting

--- a/packages/powersync/lib/src/version.dart
+++ b/packages/powersync/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String libraryVersion = '1.8.0';
+const String libraryVersion = '1.8.1';

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.8.0
+version: 1.8.1
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - keep PostgreSQL databases in sync with on-device SQLite databases.
@@ -16,7 +16,7 @@ dependencies:
   sqlite3: ^2.4.5
   universal_io: ^2.0.0
   sqlite3_flutter_libs: ^0.5.23
-  powersync_flutter_libs: ^0.2.2
+  powersync_flutter_libs: ^0.3.0
   meta: ^1.0.0
   http: ^1.1.0
   uuid: ^4.2.0

--- a/packages/powersync_flutter_libs/CHANGELOG.md
+++ b/packages/powersync_flutter_libs/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+ - powersync-sqlite-core v0.2.1
+
 ## 0.2.2
 
  - **FIX**: Prebundling downloaded core binaries.

--- a/packages/powersync_flutter_libs/pubspec.yaml
+++ b/packages/powersync_flutter_libs/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_flutter_libs
 description: PowerSync core binaries for the PowerSync Flutter SDK. Needs to be included for Flutter apps.
-version: 0.2.2
+version: 0.3.0
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 


### PR DESCRIPTION
https://github.com/powersync-ja/powersync.dart/pull/155 missed the version bump to powersync_flutter_libs, causing:
>  SqliteException(1): Unsupported powersync extension version. Need ˆ0.2.0, got 0.1.6/14f7c2b0

See #156.