### PR TITLE
Handle `PowersyncNotReadyException` printing the message for the user

### DIFF
--- a/packages/powersync/lib/src/database/powersync_db_mixin.dart
+++ b/packages/powersync/lib/src/database/powersync_db_mixin.dart
@@ -2,11 +2,11 @@ import 'dart:async';
 
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
-import 'package:powersync/src/connector.dart';
-import 'package:powersync/src/crud.dart';
 import 'package:powersync/sqlite3_common.dart';
 import 'package:powersync/sqlite_async.dart';
 import 'package:powersync/src/abort_controller.dart';
+import 'package:powersync/src/connector.dart';
+import 'package:powersync/src/crud.dart';
 import 'package:powersync/src/powersync_update_notification.dart';
 import 'package:powersync/src/schema.dart';
 import 'package:powersync/src/schema_logic.dart';

--- a/packages/powersync/lib/src/database/powersync_db_mixin.dart
+++ b/packages/powersync/lib/src/database/powersync_db_mixin.dart
@@ -2,15 +2,12 @@ import 'dart:async';
 
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
+import 'package:powersync/powersync.dart';
 import 'package:powersync/sqlite3_common.dart';
 import 'package:powersync/sqlite_async.dart';
 import 'package:powersync/src/abort_controller.dart';
-import 'package:powersync/src/connector.dart';
-import 'package:powersync/src/crud.dart';
 import 'package:powersync/src/powersync_update_notification.dart';
-import 'package:powersync/src/schema.dart';
 import 'package:powersync/src/schema_logic.dart';
-import 'package:powersync/src/sync_status.dart';
 
 mixin PowerSyncDatabaseMixin implements SqliteConnection {
   /// Schema used for the local database.

--- a/packages/powersync/lib/src/database/powersync_db_mixin.dart
+++ b/packages/powersync/lib/src/database/powersync_db_mixin.dart
@@ -2,12 +2,15 @@ import 'dart:async';
 
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
-import 'package:powersync/powersync.dart';
+import 'package:powersync/src/connector.dart';
+import 'package:powersync/src/crud.dart';
 import 'package:powersync/sqlite3_common.dart';
 import 'package:powersync/sqlite_async.dart';
 import 'package:powersync/src/abort_controller.dart';
 import 'package:powersync/src/powersync_update_notification.dart';
+import 'package:powersync/src/schema.dart';
 import 'package:powersync/src/schema_logic.dart';
+import 'package:powersync/src/sync_status.dart';
 
 mixin PowerSyncDatabaseMixin implements SqliteConnection {
   /// Schema used for the local database.

--- a/packages/powersync/lib/src/open_factory/native/native_open_factory.dart
+++ b/packages/powersync/lib/src/open_factory/native/native_open_factory.dart
@@ -71,6 +71,7 @@ class PowerSyncOpenFactory extends AbstractPowerSyncOpenFactory {
       enableExtension();
     } on PowersyncNotReadyException catch (e) {
       autoLogger.severe(e.message);
+      rethrow;
     }
 
     var db = super.open(options);

--- a/packages/powersync/lib/src/open_factory/native/native_open_factory.dart
+++ b/packages/powersync/lib/src/open_factory/native/native_open_factory.dart
@@ -13,13 +13,14 @@ class PowerSyncOpenFactory extends AbstractPowerSyncOpenFactory {
   @Deprecated('Override PowerSyncOpenFactory instead.')
   final SqliteConnectionSetup? _sqliteSetup;
 
-  PowerSyncOpenFactory(
-      {required super.path,
-      super.sqliteOptions,
-      @Deprecated('Override PowerSyncOpenFactory instead.')
-      SqliteConnectionSetup? sqliteSetup})
-      // ignore: deprecated_member_use_from_same_package
-      : _sqliteSetup = sqliteSetup;
+  PowerSyncOpenFactory({
+    required super.path,
+    super.sqliteOptions,
+    @Deprecated('Override PowerSyncOpenFactory instead.')
+    SqliteConnectionSetup? sqliteSetup,
+  })
+  // ignore: deprecated_member_use_from_same_package
+  : _sqliteSetup = sqliteSetup;
 
   @override
   void enableExtension() {
@@ -66,7 +67,11 @@ class PowerSyncOpenFactory extends AbstractPowerSyncOpenFactory {
     // ignore: deprecated_member_use_from_same_package
     _sqliteSetup?.setup();
 
-    enableExtension();
+    try {
+      enableExtension();
+    } on PowersyncNotReadyException catch (e) {
+      autoLogger.severe(e.message);
+    }
 
     var db = super.open(options);
     db.execute('PRAGMA recursive_triggers = TRUE');


### PR DESCRIPTION
The SDK will now print the exception message for unsupported platforms when loading the core extension. The error message will state if the platform is unsupported. Addresses the issue reported in #166.

```
I/flutter ( 6406): [PowerSync] SEVERE: 2024-09-19 16:27:01.970790: Unsupported processor architecture. 
X86 Android emulators are not supported. 
Please use an x86_64 emulator instead. All physical Android devices are supported including 32bit ARM.
```

## Work done
- Print exception message when loading extension
- Remove unused imports