### PR TITLE
fix: propagate maxReaders parameter in PowerSyncDatabase.withFactory

### DIFF
--- a/packages/powersync/lib/src/database/powersync_database.dart
+++ b/packages/powersync/lib/src/database/powersync_database.dart
@@ -60,7 +60,7 @@ abstract class PowerSyncDatabase
       int maxReaders = SqliteDatabase.defaultMaxReaders,
       Logger? logger}) {
     return PowerSyncDatabaseImpl.withFactory(openFactory,
-        schema: schema, logger: logger);
+        schema: schema, maxReaders: maxReaders, logger: logger);
   }
 
   /// Open a PowerSyncDatabase on an existing [SqliteDatabase].


### PR DESCRIPTION
The maxReaders parameter wasn't being passed down to the sqlite_async library, so always 5 readers were being used regardless of the value.