### PR TITLE
Fixed updating schema when moving todos to synced table

### DIFF
--- a/demos/supabase-todolist-optional-sync/lib/models/schema.dart
+++ b/demos/supabase-todolist-optional-sync/lib/models/schema.dart
@@ -79,10 +79,12 @@ switchToSyncedSchema(PowerSyncDatabase db, String userId) async {
   await db.writeTransaction((tx) async {
     // Copy local-only data to the sync-enabled views.
     // This records each operation in the upload queue.
+    // Overwrites the local-only owner_id value with the logged-in user's id.
     await tx.execute(
         'INSERT INTO $listsTable(id, name, created_at, owner_id) SELECT id, name, created_at, ? FROM inactive_local_$listsTable',
         [userId]);
 
+    // Overwrites the local-only created_by value with the logged-in user's id.
     await tx.execute(
         'INSERT INTO $todosTable(id, list_id, created_at, completed_at, description, completed, created_by) SELECT id, list_id, created_at, completed_at, description, completed, ? FROM inactive_local_$todosTable',
         [userId]);

--- a/demos/supabase-todolist-optional-sync/lib/models/schema.dart
+++ b/demos/supabase-todolist-optional-sync/lib/models/schema.dart
@@ -84,7 +84,8 @@ switchToSyncedSchema(PowerSyncDatabase db, String userId) async {
         [userId]);
 
     await tx.execute(
-        'INSERT INTO $todosTable SELECT * FROM inactive_local_$todosTable');
+        'INSERT INTO $todosTable(id, list_id, created_at, completed_at, description, completed, created_by) SELECT id, list_id, created_at, completed_at, description, completed, ? FROM inactive_local_$todosTable',
+        [userId]);
 
     // Delete the local-only data.
     await tx.execute('DELETE FROM inactive_local_$todosTable');


### PR DESCRIPTION
Original issue reported in dart optional sync demo https://github.com/powersync-ja/powersync.dart/discussions/174.
This ensures that we correctly copy over the todos with the authed user ID instead of the default local ID.
Instead of copying the local data over to the sync table verbatim (and getting the owner ID from the local table), we use the newly logged in user's ID.




