### PR TITLE
chore(demos): remove shared preferences on logout

### DIFF
--- a/demos/django-todolist/lib/api_client.dart
+++ b/demos/django-todolist/lib/api_client.dart
@@ -1,8 +1,5 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
-import 'package:logging/logging.dart';
-
-final log = Logger('powersync-django-todolist');
 
 class ApiClient {
   final String baseUrl;

--- a/demos/django-todolist/lib/main.dart
+++ b/demos/django-todolist/lib/main.dart
@@ -53,6 +53,7 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    log.info('YOWDY');
     return MaterialApp(
         title: 'PowerSync Django Todolist Demo',
         theme: ThemeData(

--- a/demos/django-todolist/lib/main.dart
+++ b/demos/django-todolist/lib/main.dart
@@ -53,7 +53,6 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    log.info('YOWDY');
     return MaterialApp(
         title: 'PowerSync Django Todolist Demo',
         theme: ThemeData(

--- a/demos/django-todolist/lib/powersync.dart
+++ b/demos/django-todolist/lib/powersync.dart
@@ -11,6 +11,7 @@ import './app_config.dart';
 import './models/schema.dart';
 
 final log = Logger('powersync-django');
+final prefs = SharedPreferencesAsync();
 
 /// Postgres Response codes that we cannot recover from by retrying.
 final List<RegExp> fatalResponseCodes = [
@@ -89,8 +90,7 @@ bool _dbInitialized = false;
 
 /// id of the user currently logged in
 Future<String?> getUserId() async {
-  final prefs = await SharedPreferences.getInstance();
-  return prefs.getString('id');
+  return await prefs.getString('id');
 }
 
 Future<bool> isLoggedIn() async {
@@ -129,5 +129,6 @@ Future<void> openDatabase() async {
 
 /// Explicit sign out - clear database and log out.
 Future<void> logout() async {
+  await prefs.remove('id');
   await db.disconnectAndClear();
 }

--- a/demos/django-todolist/lib/widgets/login_page.dart
+++ b/demos/django-todolist/lib/widgets/login_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:powersync_django_todolist_demo/api_client.dart';
 import 'package:powersync_django_todolist_demo/app_config.dart';
 import 'package:powersync_django_todolist_demo/powersync.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import '../main.dart';
 
@@ -42,7 +41,6 @@ class _LoginPageState extends State<LoginPage> {
 
       final payload = _parseJwt(session['access_token']);
       if (payload.containsKey('sub')) {
-        final prefs = await SharedPreferences.getInstance();
         await prefs.setString('id', payload['sub'].toString());
 
         //re-init PowerSync manually for first time sign in


### PR DESCRIPTION
## Description
Currently Shared Preferences are not removed on logout as described in https://github.com/powersync-ja/powersync.dart/issues/167

## Work Done
* Updated deprecated `SharedPreferences` to use `SharedPreferencesAsync`. 
* Removed duplicate logger

## Testing
Confirmed preferences are set on log in and are unset on log out.