### PR TITLE
Pass maxReaders parameter to PowerSync.withFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2024-09-30
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`powersync` - `v1.8.3`](#powersync---v183)
+ - [`powersync_attachments_helper` - `v0.6.7`](#powersync_attachments_helper---v067)
+
+---
+
+#### `powersync` - `v1.8.3`
+
+ - **FIX**: Pass maxReaders parameter to `PowerSyncDatabase.withFactory()`
+
+#### `powersync_attachments_helper` - `v0.6.7`
+
+ - Update a dependency to the latest release.
+
+
 ## 2024-09-13
 
 ### Changes

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.8.2
+  powersync: ^1.8.3
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.8.2
+  powersync: ^1.8.3
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.8.2
+  powersync: ^1.8.3
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^2.0.2
   timeago: ^3.6.0
-  powersync: ^1.8.2
+  powersync: ^1.8.3
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist-drift/pubspec.yaml
+++ b/demos/supabase-todolist-drift/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.6
-  powersync: ^1.8.2
+  powersync_attachments_helper: ^0.6.7
+  powersync: ^1.8.3
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist-optional-sync/pubspec.yaml
+++ b/demos/supabase-todolist-optional-sync/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.8.2
+  powersync: ^1.8.3
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist/ios/Podfile.lock
+++ b/demos/supabase-todolist/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - app_links (0.0.1):
+  - app_links (0.0.2):
     - Flutter
   - camera_avfoundation (0.0.1):
     - Flutter
@@ -7,23 +7,23 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.1.6)
+  - powersync-sqlite-core (0.2.1)
   - powersync_flutter_libs (0.0.1):
     - Flutter
-    - powersync-sqlite-core (~> 0.1.6)
+    - powersync-sqlite-core (~> 0.2.1)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - "sqlite3 (3.46.0+1)":
-    - "sqlite3/common (= 3.46.0+1)"
-  - "sqlite3/common (3.46.0+1)"
-  - "sqlite3/dbstatvtab (3.46.0+1)":
+  - "sqlite3 (3.46.1+1)":
+    - "sqlite3/common (= 3.46.1+1)"
+  - "sqlite3/common (3.46.1+1)"
+  - "sqlite3/dbstatvtab (3.46.1+1)":
     - sqlite3/common
-  - "sqlite3/fts5 (3.46.0+1)":
+  - "sqlite3/fts5 (3.46.1+1)":
     - sqlite3/common
-  - "sqlite3/perf-threadsafe (3.46.0+1)":
+  - "sqlite3/perf-threadsafe (3.46.1+1)":
     - sqlite3/common
-  - "sqlite3/rtree (3.46.0+1)":
+  - "sqlite3/rtree (3.46.1+1)":
     - sqlite3/common
   - sqlite3_flutter_libs (0.0.1):
     - Flutter
@@ -69,14 +69,14 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
-  app_links: e70ca16b4b0f88253b3b3660200d4a10b4ea9795
-  camera_avfoundation: 759172d1a77ae7be0de08fc104cfb79738b8a59e
+  app_links: e7a6750a915a9e161c58d91bc610e8cd1d4d0ad0
+  camera_avfoundation: dd002b0330f4981e1bbcb46ae9b62829237459a4
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  powersync-sqlite-core: 4c38c8f470f6dca61346789fd5436a6826d1e3dd
-  powersync_flutter_libs: 5d6b132a398de442c0853a8b14bfbb62cd4ff5a1
+  powersync-sqlite-core: 38ead13d8b21920cfbc79e9b3415b833574a506d
+  powersync_flutter_libs: 9d26987384a376a18879b9d4fa71629407683163
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sqlite3: 292c3e1bfe89f64e51ea7fc7dab9182a017c8630
+  sqlite3: 0bb0e6389d824e40296f531b858a2a0b71c0d2fb
   sqlite3_flutter_libs: c00457ebd31e59fa6bb830380ddba24d44fbcd3b
   url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
 

--- a/demos/supabase-todolist/macos/Podfile.lock
+++ b/demos/supabase-todolist/macos/Podfile.lock
@@ -5,23 +5,23 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.1.6)
+  - powersync-sqlite-core (0.2.1)
   - powersync_flutter_libs (0.0.1):
     - FlutterMacOS
-    - powersync-sqlite-core (~> 0.1.6)
+    - powersync-sqlite-core (~> 0.2.1)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - "sqlite3 (3.46.0+1)":
-    - "sqlite3/common (= 3.46.0+1)"
-  - "sqlite3/common (3.46.0+1)"
-  - "sqlite3/dbstatvtab (3.46.0+1)":
+  - "sqlite3 (3.46.1+1)":
+    - "sqlite3/common (= 3.46.1+1)"
+  - "sqlite3/common (3.46.1+1)"
+  - "sqlite3/dbstatvtab (3.46.1+1)":
     - sqlite3/common
-  - "sqlite3/fts5 (3.46.0+1)":
+  - "sqlite3/fts5 (3.46.1+1)":
     - sqlite3/common
-  - "sqlite3/perf-threadsafe (3.46.0+1)":
+  - "sqlite3/perf-threadsafe (3.46.1+1)":
     - sqlite3/common
-  - "sqlite3/rtree (3.46.0+1)":
+  - "sqlite3/rtree (3.46.1+1)":
     - sqlite3/common
   - sqlite3_flutter_libs (0.0.1):
     - FlutterMacOS
@@ -67,10 +67,10 @@ SPEC CHECKSUMS:
   app_links: 10e0a0ab602ffaf34d142cd4862f29d34b303b2a
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  powersync-sqlite-core: 4c38c8f470f6dca61346789fd5436a6826d1e3dd
-  powersync_flutter_libs: 1eb1c6790a72afe08e68d4cc489d71ab61da32ee
+  powersync-sqlite-core: 38ead13d8b21920cfbc79e9b3415b833574a506d
+  powersync_flutter_libs: 3f05f43c382c77cb7bec64785c2b6b1e9bd33c22
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sqlite3: 292c3e1bfe89f64e51ea7fc7dab9182a017c8630
+  sqlite3: 0bb0e6389d824e40296f531b858a2a0b71c0d2fb
   sqlite3_flutter_libs: 5ca46c1a04eddfbeeb5b16566164aa7ad1616e7b
   url_launcher_macos: 5f437abeda8c85500ceb03f5c1938a8c5a705399
 

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.6
-  powersync: ^1.8.2
+  powersync_attachments_helper: ^0.6.7
+  powersync: ^1.8.3
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,10 +1,14 @@
+## 1.8.3
+
+- **FIX**: Pass maxReaders parameter to `PowerSyncDatabase.withFactory()`
+
 ## 1.8.2
 
- - Added `refreshSchema()`, allowing queries and watch calls to work against updated schemas.
+- Added `refreshSchema()`, allowing queries and watch calls to work against updated schemas.
 
 ## 1.8.1
 
- - Fix powersync_flutter_libs dependency
+- Fix powersync_flutter_libs dependency
 
 ## 1.8.0
 

--- a/packages/powersync/lib/src/database/native/native_powersync_database.dart
+++ b/packages/powersync/lib/src/database/native/native_powersync_database.dart
@@ -81,7 +81,7 @@ class PowerSyncDatabaseImpl
         // ignore: deprecated_member_use_from_same_package
         PowerSyncOpenFactory(path: path, sqliteSetup: sqliteSetup);
     return PowerSyncDatabaseImpl.withFactory(factory,
-        schema: schema, logger: logger);
+        schema: schema, maxReaders: maxReaders, logger: logger);
   }
 
   /// Open a [PowerSyncDatabase] with a [PowerSyncOpenFactory].

--- a/packages/powersync/lib/src/database/powersync_database.dart
+++ b/packages/powersync/lib/src/database/powersync_database.dart
@@ -60,7 +60,7 @@ abstract class PowerSyncDatabase
       int maxReaders = SqliteDatabase.defaultMaxReaders,
       Logger? logger}) {
     return PowerSyncDatabaseImpl.withFactory(openFactory,
-        schema: schema, logger: logger);
+        schema: schema, maxReaders: maxReaders, logger: logger);
   }
 
   /// Open a PowerSyncDatabase on an existing [SqliteDatabase].

--- a/packages/powersync/lib/src/version.dart
+++ b/packages/powersync/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String libraryVersion = '1.8.2';
+const String libraryVersion = '1.8.3';

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.8.2
+version: 1.8.3
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - sync engine for building local-first apps.

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.7
+
+ - Update a dependency to the latest release.
+
 ## 0.6.6
 
  - Update a dependency to the latest release.

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.6.6
+version: 0.6.7
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.8.2
+  powersync: ^1.8.3
   logging: ^1.2.0
   sqlite_async: ^0.8.3
   path_provider: ^2.0.13


### PR DESCRIPTION
## Description

Originally created by David Martos in #171. Prior to this fix the maxReaders was always set to the default of 5 read connections and would not be changed according to the parameter passed in. This fix ensures that the maxReaders parameter is propagated down to the SQLite factory to create multiple read connections.

## Work done

- Pass maxReaders parameter to PowerSync.withFactory