### PR TITLE
powersync-sqlite-core 0.3.0

### DIFF
--- a/demos/django-todolist/ios/Podfile.lock
+++ b/demos/django-todolist/ios/Podfile.lock
@@ -3,10 +3,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.2.1)
+  - powersync-sqlite-core (0.3.0)
   - powersync_flutter_libs (0.0.1):
     - Flutter
-    - powersync-sqlite-core (~> 0.2.1)
+    - powersync-sqlite-core (~> 0.3.0)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -56,8 +56,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  powersync-sqlite-core: 38ead13d8b21920cfbc79e9b3415b833574a506d
-  powersync_flutter_libs: 9d26987384a376a18879b9d4fa71629407683163
+  powersync-sqlite-core: ad0e70e23bacd858fe2e79032dc4aabdf972d1bd
+  powersync_flutter_libs: 064c44b51fb07df9486b735fb96ab7608a89e18b
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sqlite3: 0bb0e6389d824e40296f531b858a2a0b71c0d2fb
   sqlite3_flutter_libs: c00457ebd31e59fa6bb830380ddba24d44fbcd3b

--- a/demos/django-todolist/pubspec.lock
+++ b/demos/django-todolist/pubspec.lock
@@ -310,7 +310,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.8.2"
+    version: "1.8.4"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-anonymous-auth/pubspec.lock
+++ b/demos/supabase-anonymous-auth/pubspec.lock
@@ -366,7 +366,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.8.2"
+    version: "1.8.4"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-edge-function-auth/pubspec.lock
+++ b/demos/supabase-edge-function-auth/pubspec.lock
@@ -390,7 +390,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.8.2"
+    version: "1.8.4"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-simple-chat/pubspec.lock
+++ b/demos/supabase-simple-chat/pubspec.lock
@@ -406,7 +406,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.8.2"
+    version: "1.8.4"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-todolist-drift/ios/Podfile.lock
+++ b/demos/supabase-todolist-drift/ios/Podfile.lock
@@ -7,10 +7,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.1.6)
+  - powersync-sqlite-core (0.3.0)
   - powersync_flutter_libs (0.0.1):
     - Flutter
-    - powersync-sqlite-core (~> 0.1.6)
+    - powersync-sqlite-core (~> 0.3.0)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -73,8 +73,8 @@ SPEC CHECKSUMS:
   camera_avfoundation: dd002b0330f4981e1bbcb46ae9b62829237459a4
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  powersync-sqlite-core: 4c38c8f470f6dca61346789fd5436a6826d1e3dd
-  powersync_flutter_libs: 5d6b132a398de442c0853a8b14bfbb62cd4ff5a1
+  powersync-sqlite-core: ad0e70e23bacd858fe2e79032dc4aabdf972d1bd
+  powersync_flutter_libs: 064c44b51fb07df9486b735fb96ab7608a89e18b
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sqlite3: 292c3e1bfe89f64e51ea7fc7dab9182a017c8630
   sqlite3_flutter_libs: c00457ebd31e59fa6bb830380ddba24d44fbcd3b

--- a/demos/supabase-todolist-drift/pubspec.lock
+++ b/demos/supabase-todolist-drift/pubspec.lock
@@ -686,14 +686,14 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.8.2"
+    version: "1.8.4"
   powersync_attachments_helper:
     dependency: "direct main"
     description:
       path: "../../packages/powersync_attachments_helper"
       relative: true
     source: path
-    version: "0.6.6"
+    version: "0.6.8"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-todolist-optional-sync/ios/Podfile.lock
+++ b/demos/supabase-todolist-optional-sync/ios/Podfile.lock
@@ -7,10 +7,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.2.1)
+  - powersync-sqlite-core (0.3.0)
   - powersync_flutter_libs (0.0.1):
     - Flutter
-    - powersync-sqlite-core (~> 0.2.1)
+    - powersync-sqlite-core (~> 0.3.0)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -73,8 +73,8 @@ SPEC CHECKSUMS:
   camera_avfoundation: 759172d1a77ae7be0de08fc104cfb79738b8a59e
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  powersync-sqlite-core: 38ead13d8b21920cfbc79e9b3415b833574a506d
-  powersync_flutter_libs: 9d26987384a376a18879b9d4fa71629407683163
+  powersync-sqlite-core: ad0e70e23bacd858fe2e79032dc4aabdf972d1bd
+  powersync_flutter_libs: 064c44b51fb07df9486b735fb96ab7608a89e18b
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sqlite3: 0bb0e6389d824e40296f531b858a2a0b71c0d2fb
   sqlite3_flutter_libs: c00457ebd31e59fa6bb830380ddba24d44fbcd3b

--- a/demos/supabase-todolist-optional-sync/pubspec.lock
+++ b/demos/supabase-todolist-optional-sync/pubspec.lock
@@ -470,7 +470,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.8.2"
+    version: "1.8.4"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-todolist/ios/Podfile.lock
+++ b/demos/supabase-todolist/ios/Podfile.lock
@@ -7,10 +7,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.2.1)
+  - powersync-sqlite-core (0.3.0)
   - powersync_flutter_libs (0.0.1):
     - Flutter
-    - powersync-sqlite-core (~> 0.2.1)
+    - powersync-sqlite-core (~> 0.3.0)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -73,8 +73,8 @@ SPEC CHECKSUMS:
   camera_avfoundation: dd002b0330f4981e1bbcb46ae9b62829237459a4
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  powersync-sqlite-core: 38ead13d8b21920cfbc79e9b3415b833574a506d
-  powersync_flutter_libs: 9d26987384a376a18879b9d4fa71629407683163
+  powersync-sqlite-core: ad0e70e23bacd858fe2e79032dc4aabdf972d1bd
+  powersync_flutter_libs: 064c44b51fb07df9486b735fb96ab7608a89e18b
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sqlite3: 0bb0e6389d824e40296f531b858a2a0b71c0d2fb
   sqlite3_flutter_libs: c00457ebd31e59fa6bb830380ddba24d44fbcd3b

--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -470,14 +470,14 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.8.2"
+    version: "1.8.4"
   powersync_attachments_helper:
     dependency: "direct main"
     description:
       path: "../../packages/powersync_attachments_helper"
       relative: true
     source: path
-    version: "0.6.6"
+    version: "0.6.8"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/melos.yaml
+++ b/melos.yaml
@@ -89,7 +89,7 @@ scripts:
 
   test:web:
     description: Run web tests in a specific package.
-    run: dart test -p chrome
+    run: dart test -p chrome --concurrency=1
     exec:
       concurrency: 1
     packageFilters:

--- a/packages/powersync/bin/setup_web.dart
+++ b/packages/powersync/bin/setup_web.dart
@@ -90,8 +90,10 @@ void main(List<String> arguments) async {
 }
 
 bool coreVersionIsInRange(String tag) {
-  //Sets the range of powersync core version that is compatible with the sqlite3 version
-  VersionConstraint constraint = VersionConstraint.parse('>=0.2.0 <0.4.0');
+  // Sets the range of powersync core version that is compatible with the sqlite3 version
+  // We're a little more selective in the versions chosen here than the range
+  // we're compatible with.
+  VersionConstraint constraint = VersionConstraint.parse('>=0.3.0 <0.4.0');
   List<String> parts = tag.split('-');
   String powersyncPart = parts[1];
 

--- a/packages/powersync/bin/setup_web.dart
+++ b/packages/powersync/bin/setup_web.dart
@@ -91,7 +91,7 @@ void main(List<String> arguments) async {
 
 bool coreVersionIsInRange(String tag) {
   //Sets the range of powersync core version that is compatible with the sqlite3 version
-  VersionConstraint constraint = VersionConstraint.parse('>=0.2.0 <0.3.0');
+  VersionConstraint constraint = VersionConstraint.parse('>=0.2.0 <0.4.0');
   List<String> parts = tag.split('-');
   String powersyncPart = parts[1];
 

--- a/packages/powersync/lib/src/database/powersync_db_mixin.dart
+++ b/packages/powersync/lib/src/database/powersync_db_mixin.dart
@@ -104,13 +104,15 @@ mixin PowerSyncDatabaseMixin implements SqliteConnection {
           version.split(RegExp(r'[./]')).take(3).map(int.parse).toList();
     } catch (e) {
       throw SqliteException(1,
-          'Unsupported powersync extension version. Need ^0.2.0, got: $version. Details: $e');
+          'Unsupported powersync extension version. Need >=0.2.0 <0.4.0, got: $version. Details: $e');
     }
 
-    // Validate ^0.2.0
-    if (versionInts[0] != 0 || versionInts[1] != 2 || versionInts[2] < 0) {
+    // Validate >=0.2.0 <0.4.0
+    if (versionInts[0] != 0 ||
+        (versionInts[1] != 2 && versionInts[1] != 3) ||
+        versionInts[2] < 0) {
       throw SqliteException(1,
-          'Unsupported powersync extension version. Need ^0.2.0, got: $version');
+          'Unsupported powersync extension version. Need >=0.2.0 <0.4.0, got: $version');
     }
   }
 

--- a/packages/powersync/lib/src/database/powersync_db_mixin.dart
+++ b/packages/powersync/lib/src/database/powersync_db_mixin.dart
@@ -104,15 +104,15 @@ mixin PowerSyncDatabaseMixin implements SqliteConnection {
           version.split(RegExp(r'[./]')).take(3).map(int.parse).toList();
     } catch (e) {
       throw SqliteException(1,
-          'Unsupported powersync extension version. Need >=0.2.0 <0.4.0, got: $version. Details: $e');
+          'Unsupported powersync extension version. Need >=0.2.0 <1.0.0, got: $version. Details: $e');
     }
 
-    // Validate >=0.2.0 <0.4.0
+    // Validate >=0.2.0 <1.0.0
     if (versionInts[0] != 0 ||
-        (versionInts[1] != 2 && versionInts[1] != 3) ||
-        versionInts[2] < 0) {
+        (versionInts[1] < 2) ||
+        (versionInts[1] == 2 && versionInts[2] < 0)) {
       throw SqliteException(1,
-          'Unsupported powersync extension version. Need >=0.2.0 <0.4.0, got: $version');
+          'Unsupported powersync extension version. Need >=0.2.0 <1.0.0, got: $version');
     }
   }
 

--- a/packages/powersync_flutter_libs/android/build.gradle
+++ b/packages/powersync_flutter_libs/android/build.gradle
@@ -50,5 +50,5 @@ android {
 }
 
 dependencies {
-    implementation 'co.powersync:powersync-sqlite-core:0.2.1'
+    implementation 'co.powersync:powersync-sqlite-core:0.3.0'
 }

--- a/packages/powersync_flutter_libs/ios/powersync_flutter_libs.podspec
+++ b/packages/powersync_flutter_libs/ios/powersync_flutter_libs.podspec
@@ -22,7 +22,7 @@ A new Flutter FFI plugin project.
   s.dependency 'Flutter'
   s.platform = :ios, '11.0'
 
-  s.dependency "powersync-sqlite-core", "~> 0.2.1"
+  s.dependency "powersync-sqlite-core", "~> 0.3.0"
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/packages/powersync_flutter_libs/macos/powersync_flutter_libs.podspec
+++ b/packages/powersync_flutter_libs/macos/powersync_flutter_libs.podspec
@@ -21,7 +21,7 @@ A new Flutter FFI plugin project.
   s.source_files     = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
 
-  s.dependency "powersync-sqlite-core", "~> 0.2.1"
+  s.dependency "powersync-sqlite-core", "~> 0.3.0"
 
   s.platform = :osx, '10.11'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }

--- a/scripts/download_core_binary_demos.dart
+++ b/scripts/download_core_binary_demos.dart
@@ -3,7 +3,7 @@
 import 'dart:io';
 
 final coreUrl =
-    'https://github.com/powersync-ja/powersync-sqlite-core/releases/download/v0.2.1';
+    'https://github.com/powersync-ja/powersync-sqlite-core/releases/download/v0.3.0';
 
 void main() async {
   final powersyncLibsLinuxPath = "packages/powersync_flutter_libs/linux";

--- a/scripts/init_powersync_core_binary.dart
+++ b/scripts/init_powersync_core_binary.dart
@@ -6,7 +6,7 @@ import 'dart:io';
 import 'package:melos/melos.dart';
 
 final sqliteUrl =
-    'https://github.com/powersync-ja/powersync-sqlite-core/releases/download/v0.2.1';
+    'https://github.com/powersync-ja/powersync-sqlite-core/releases/download/v0.3.0';
 
 void main() async {
   final sqliteCoreFilename = getLibraryForPlatform();


### PR DESCRIPTION
Release notes: https://github.com/powersync-ja/powersync-sqlite-core/releases/tag/v0.3.0

> This release removes major performance bottlenecks during incremental sync. Previously, incremental sync would have overhead proportional to the number of synced rows, which typically caused noticeable latency when syncing around 10-100k+ rows. Now, the overhead is only proportional to the number of buckets synced.
> 
> The performance improvements required a restructure in the data storage format. Data is migrated automatically, and an app can downgrade back to v0.2.0 or v0.2.1 of powersync-sqlite-core.
> 
> Changes:
>  * Persist checksums to improve incremental sync performance.
>  * Restructure persistence of REMOVE operations to further improve incremental sync performance.
>  * Create internal views on `powersync_init()` instead of extension init, to support SQLCipher.
 