### PR TITLE
Fix: Validate duplicate table names

### DIFF
--- a/packages/powersync/lib/src/schema.dart
+++ b/packages/powersync/lib/src/schema.dart
@@ -13,8 +13,15 @@ class Schema {
   Map<String, dynamic> toJson() => {'tables': tables};
 
   void validate() {
+    Set<String> tableNames = {};
     for (var table in tables) {
       table.validate();
+
+      if (tableNames.contains(table.name)) {
+        throw AssertionError("Duplicate table name: ${table.name}");
+      }
+
+      tableNames.add(table.name);
     }
   }
 }

--- a/packages/powersync/test/schema_test.dart
+++ b/packages/powersync/test/schema_test.dart
@@ -321,6 +321,41 @@ void main() {
       );
     });
 
+    test('Schema without duplicate table names', () {
+      final schema = Schema([
+        Table('duplicate', [
+          Column.text('name'),
+        ]),
+        Table('not_duplicate', [
+          Column.text('name'),
+        ]),
+      ]);
+
+      expect(() => schema.validate(), returnsNormally);
+    });
+
+    test('Schema with duplicate table names', () {
+      final schema = Schema([
+        Table('clone', [
+          Column.text('name'),
+        ]),
+        Table('clone', [
+          Column.text('name'),
+        ]),
+      ]);
+
+      expect(
+        () => schema.validate(),
+        throwsA(
+          isA<AssertionError>().having(
+            (e) => e.message,
+            'message',
+            'Duplicate table name: clone',
+          ),
+        ),
+      );
+    });
+
     test('toJson method', () {
       final table = Table('users', [
         Column('name', ColumnType.text),


### PR DESCRIPTION
## Description

Currently calling `validate()` on a schema does not check for duplicate table names. This checks that there are no duplicate table names and throws an assertion error if there are duplicates.

## Work done

- Check for duplicate table names in schema validation