### PR TITLE
Fix upload queue monitoring issues

### DIFF
--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -2,7 +2,6 @@ name: Demos checks
 
 concurrency:
   group: demos-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 
 on:
   push:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -2,7 +2,6 @@ name: Packages check
 
 concurrency:
   group: packages-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
 
 on:
   push:

--- a/demos/django-todolist/pubspec.lock
+++ b/demos/django-todolist/pubspec.lock
@@ -310,14 +310,14 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.8.7"
+    version: "1.8.8"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.4.1"
   pub_semver:
     dependency: transitive
     description:
@@ -415,10 +415,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "45f168ae2213201b54e09429ed0c593dc2c88c924a1488d6f9c523a255d567cb"
+      sha256: bb174b3ec2527f9c5f680f73a89af8149dd99782fbb56ea88ad0807c5638f2ed
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.6"
+    version: "2.4.7"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
@@ -431,18 +431,18 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_web
-      sha256: b4043336e74cac54d3ca44c90434a3c310550b9a80851b09ad1af282af0df6d4
+      sha256: f22d1dda7a40be0867984f55cdf5c2d599e5f05d3be4a642d78f38b38983f554
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3"
+    version: "0.2.0"
   sqlite_async:
     dependency: "direct main"
     description:
       name: sqlite_async
-      sha256: c5c57b025133d0869cce6a647f99b378ab42cc26488ff22ff942ae9588201af0
+      sha256: "1f7b36e6b5b459bae89941ae1d3ae8151a3c14b8242c3b94e75aea4a692361e2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.0"
+    version: "0.9.1"
   stack_trace:
     dependency: transitive
     description:

--- a/demos/supabase-anonymous-auth/pubspec.lock
+++ b/demos/supabase-anonymous-auth/pubspec.lock
@@ -366,14 +366,14 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.8.7"
+    version: "1.8.8"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.4.1"
   pub_semver:
     dependency: transitive
     description:
@@ -495,10 +495,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "45f168ae2213201b54e09429ed0c593dc2c88c924a1488d6f9c523a255d567cb"
+      sha256: bb174b3ec2527f9c5f680f73a89af8149dd99782fbb56ea88ad0807c5638f2ed
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.6"
+    version: "2.4.7"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
@@ -511,18 +511,18 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_web
-      sha256: b4043336e74cac54d3ca44c90434a3c310550b9a80851b09ad1af282af0df6d4
+      sha256: f22d1dda7a40be0867984f55cdf5c2d599e5f05d3be4a642d78f38b38983f554
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3"
+    version: "0.2.0"
   sqlite_async:
     dependency: "direct main"
     description:
       name: sqlite_async
-      sha256: c5c57b025133d0869cce6a647f99b378ab42cc26488ff22ff942ae9588201af0
+      sha256: "1f7b36e6b5b459bae89941ae1d3ae8151a3c14b8242c3b94e75aea4a692361e2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.0"
+    version: "0.9.1"
   stack_trace:
     dependency: transitive
     description:

--- a/demos/supabase-edge-function-auth/pubspec.lock
+++ b/demos/supabase-edge-function-auth/pubspec.lock
@@ -390,14 +390,14 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.8.7"
+    version: "1.8.8"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.4.1"
   pub_semver:
     dependency: transitive
     description:
@@ -519,10 +519,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "45f168ae2213201b54e09429ed0c593dc2c88c924a1488d6f9c523a255d567cb"
+      sha256: bb174b3ec2527f9c5f680f73a89af8149dd99782fbb56ea88ad0807c5638f2ed
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.6"
+    version: "2.4.7"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
@@ -535,18 +535,18 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_web
-      sha256: b4043336e74cac54d3ca44c90434a3c310550b9a80851b09ad1af282af0df6d4
+      sha256: f22d1dda7a40be0867984f55cdf5c2d599e5f05d3be4a642d78f38b38983f554
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3"
+    version: "0.2.0"
   sqlite_async:
     dependency: "direct main"
     description:
       name: sqlite_async
-      sha256: c5c57b025133d0869cce6a647f99b378ab42cc26488ff22ff942ae9588201af0
+      sha256: "1f7b36e6b5b459bae89941ae1d3ae8151a3c14b8242c3b94e75aea4a692361e2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.0"
+    version: "0.9.1"
   stack_trace:
     dependency: transitive
     description:

--- a/demos/supabase-simple-chat/pubspec.lock
+++ b/demos/supabase-simple-chat/pubspec.lock
@@ -406,14 +406,14 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.8.7"
+    version: "1.8.8"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.4.1"
   pub_semver:
     dependency: transitive
     description:
@@ -535,10 +535,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "45f168ae2213201b54e09429ed0c593dc2c88c924a1488d6f9c523a255d567cb"
+      sha256: bb174b3ec2527f9c5f680f73a89af8149dd99782fbb56ea88ad0807c5638f2ed
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.6"
+    version: "2.4.7"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
@@ -551,18 +551,18 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_web
-      sha256: b4043336e74cac54d3ca44c90434a3c310550b9a80851b09ad1af282af0df6d4
+      sha256: f22d1dda7a40be0867984f55cdf5c2d599e5f05d3be4a642d78f38b38983f554
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3"
+    version: "0.2.0"
   sqlite_async:
     dependency: transitive
     description:
       name: sqlite_async
-      sha256: c5c57b025133d0869cce6a647f99b378ab42cc26488ff22ff942ae9588201af0
+      sha256: "1f7b36e6b5b459bae89941ae1d3ae8151a3c14b8242c3b94e75aea4a692361e2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.0"
+    version: "0.9.1"
   stack_trace:
     dependency: transitive
     description:

--- a/demos/supabase-todolist-drift/pubspec.lock
+++ b/demos/supabase-todolist-drift/pubspec.lock
@@ -686,21 +686,21 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.8.7"
+    version: "1.8.8"
   powersync_attachments_helper:
     dependency: "direct main"
     description:
       path: "../../packages/powersync_attachments_helper"
       relative: true
     source: path
-    version: "0.6.11"
+    version: "0.6.12"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.4.1"
   pub_semver:
     dependency: transitive
     description:
@@ -854,10 +854,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "45f168ae2213201b54e09429ed0c593dc2c88c924a1488d6f9c523a255d567cb"
+      sha256: bb174b3ec2527f9c5f680f73a89af8149dd99782fbb56ea88ad0807c5638f2ed
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.6"
+    version: "2.4.7"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
@@ -870,18 +870,18 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_web
-      sha256: b4043336e74cac54d3ca44c90434a3c310550b9a80851b09ad1af282af0df6d4
+      sha256: f22d1dda7a40be0867984f55cdf5c2d599e5f05d3be4a642d78f38b38983f554
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3"
+    version: "0.2.0"
   sqlite_async:
     dependency: "direct main"
     description:
       name: sqlite_async
-      sha256: c5c57b025133d0869cce6a647f99b378ab42cc26488ff22ff942ae9588201af0
+      sha256: "1f7b36e6b5b459bae89941ae1d3ae8151a3c14b8242c3b94e75aea4a692361e2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.0"
+    version: "0.9.1"
   sqlparser:
     dependency: transitive
     description:

--- a/demos/supabase-todolist-optional-sync/pubspec.lock
+++ b/demos/supabase-todolist-optional-sync/pubspec.lock
@@ -470,14 +470,14 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.8.7"
+    version: "1.8.8"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.4.1"
   pub_semver:
     dependency: transitive
     description:
@@ -599,10 +599,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "45f168ae2213201b54e09429ed0c593dc2c88c924a1488d6f9c523a255d567cb"
+      sha256: bb174b3ec2527f9c5f680f73a89af8149dd99782fbb56ea88ad0807c5638f2ed
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.6"
+    version: "2.4.7"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
@@ -615,18 +615,18 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_web
-      sha256: b4043336e74cac54d3ca44c90434a3c310550b9a80851b09ad1af282af0df6d4
+      sha256: f22d1dda7a40be0867984f55cdf5c2d599e5f05d3be4a642d78f38b38983f554
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3"
+    version: "0.2.0"
   sqlite_async:
     dependency: "direct main"
     description:
       name: sqlite_async
-      sha256: c5c57b025133d0869cce6a647f99b378ab42cc26488ff22ff942ae9588201af0
+      sha256: "1f7b36e6b5b459bae89941ae1d3ae8151a3c14b8242c3b94e75aea4a692361e2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.0"
+    version: "0.9.1"
   stack_trace:
     dependency: transitive
     description:

--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -470,21 +470,21 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.8.7"
+    version: "1.8.8"
   powersync_attachments_helper:
     dependency: "direct main"
     description:
       path: "../../packages/powersync_attachments_helper"
       relative: true
     source: path
-    version: "0.6.11"
+    version: "0.6.12"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.0"
+    version: "0.4.1"
   pub_semver:
     dependency: transitive
     description:
@@ -606,10 +606,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "45f168ae2213201b54e09429ed0c593dc2c88c924a1488d6f9c523a255d567cb"
+      sha256: bb174b3ec2527f9c5f680f73a89af8149dd99782fbb56ea88ad0807c5638f2ed
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.6"
+    version: "2.4.7"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
@@ -622,18 +622,18 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_web
-      sha256: b4043336e74cac54d3ca44c90434a3c310550b9a80851b09ad1af282af0df6d4
+      sha256: f22d1dda7a40be0867984f55cdf5c2d599e5f05d3be4a642d78f38b38983f554
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3"
+    version: "0.2.0"
   sqlite_async:
     dependency: "direct main"
     description:
       name: sqlite_async
-      sha256: c5c57b025133d0869cce6a647f99b378ab42cc26488ff22ff942ae9588201af0
+      sha256: "1f7b36e6b5b459bae89941ae1d3ae8151a3c14b8242c3b94e75aea4a692361e2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.0"
+    version: "0.9.1"
   stack_trace:
     dependency: transitive
     description:

--- a/packages/powersync/lib/src/database/native/native_powersync_database.dart
+++ b/packages/powersync/lib/src/database/native/native_powersync_database.dart
@@ -363,7 +363,8 @@ Future<void> _powerSyncDatabaseIsolate(
     Set<String> updatedTables = {};
 
     void maybeFireUpdates() {
-      if (updatedTables.isNotEmpty) {
+      // Only fire updates when we're not in a transaction
+      if (updatedTables.isNotEmpty && db?.autocommit == true) {
         upstreamDbClient.fire(UpdateNotification(updatedTables));
         updatedTables.clear();
         updateDebouncer?.cancel();
@@ -375,7 +376,7 @@ Future<void> _powerSyncDatabaseIsolate(
       updatedTables.add(event.tableName);
 
       updateDebouncer ??=
-          Timer(const Duration(milliseconds: 10), maybeFireUpdates);
+          Timer(const Duration(milliseconds: 1), maybeFireUpdates);
     });
   }, (error, stack) {
     // Properly dispose the database if an uncaught error occurs.

--- a/packages/powersync/lib/src/database/web/web_powersync_database.dart
+++ b/packages/powersync/lib/src/database/web/web_powersync_database.dart
@@ -135,6 +135,9 @@ class PowerSyncDatabaseImpl
 
     await isInitialized;
 
+    final crudStream =
+        database.onChange(['ps_crud'], throttle: crudThrottleTime);
+
     // TODO better multitab support
     final storage = BucketStorage(database);
     final sync = StreamingSyncImplementation(
@@ -142,7 +145,7 @@ class PowerSyncDatabaseImpl
         credentialsCallback: connector.getCredentialsCached,
         invalidCredentialsCallback: connector.fetchCredentials,
         uploadCrud: () => connector.uploadData(this),
-        updateStream: updates,
+        crudUpdateTriggerStream: crudStream,
         retryDelay: Duration(seconds: 3),
         client: FetchClient(mode: RequestMode.cors),
         syncParameters: params,

--- a/packages/powersync/lib/src/web/powersync_db.worker.dart
+++ b/packages/powersync/lib/src/web/powersync_db.worker.dart
@@ -20,10 +20,9 @@ final class PowerSyncAsyncSqliteController extends AsyncSqliteController {
   @override
   Future<WorkerDatabase> openDatabase(
       WasmSqlite3 sqlite3, String path, String vfs) async {
-    final db = sqlite3.open(path, vfs: vfs);
-    setupPowerSyncDatabase(db);
-
-    return AsyncSqliteDatabase(database: db);
+    final asyncDb = await super.openDatabase(sqlite3, path, vfs);
+    setupPowerSyncDatabase(asyncDb.database);
+    return asyncDb;
   }
 
   @override

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  sqlite_async: ^0.9.0
+  sqlite_async: ^0.9.1
   # We only use sqlite3 as a transitive dependency,
   # but right now we need a minimum of v2.4.6.
   sqlite3: ^2.4.6

--- a/packages/powersync/test/crud_test.dart
+++ b/packages/powersync/test/crud_test.dart
@@ -151,8 +151,8 @@ void main() {
           [testId, 'INFO', 'test log']);
 
       expect(
-          await powersync
-              .getAll("SELECT data ->> 'id' as id FROM ps_crud ORDER BY id"),
+          await powersync.getAll(
+              "SELECT json_extract(data, '\$.id') as id FROM ps_crud ORDER BY id"),
           equals([
             {'id': testId}
           ]));
@@ -179,8 +179,8 @@ void main() {
               .get('SELECT quantity FROM assets WHERE id = ?', [testId]),
           equals({'quantity': bigNumber}));
       expect(
-          await powersync
-              .getAll('SELECT data ->> \'id\' as id FROM ps_crud ORDER BY id'),
+          await powersync.getAll(
+              "SELECT json_extract(data, '\$.id') as id FROM ps_crud ORDER BY id"),
           equals([
             {"id": testId}
           ]));

--- a/packages/powersync/test/crud_test.dart
+++ b/packages/powersync/test/crud_test.dart
@@ -151,12 +151,10 @@ void main() {
           [testId, 'INFO', 'test log']);
 
       expect(
-          await powersync.getAll('SELECT data FROM ps_crud ORDER BY id'),
+          await powersync
+              .getAll("SELECT data ->> 'id' as id FROM ps_crud ORDER BY id"),
           equals([
-            {
-              'data':
-                  '{"op":"PUT","type":"logs","id":"$testId","data":{"level":"INFO","content":"test log"}}'
-            }
+            {'id': testId}
           ]));
 
       expect(await powersync.getAll('SELECT * FROM logs'), equals([]));
@@ -181,12 +179,10 @@ void main() {
               .get('SELECT quantity FROM assets WHERE id = ?', [testId]),
           equals({'quantity': bigNumber}));
       expect(
-          await powersync.getAll('SELECT data FROM ps_crud ORDER BY id'),
+          await powersync
+              .getAll('SELECT data ->> \'id\' as id FROM ps_crud ORDER BY id'),
           equals([
-            {
-              'data':
-                  '{"op":"PUT","type":"assets","id":"$testId","data":{"quantity":$bigNumber}}'
-            }
+            {"id": testId}
           ]));
 
       var tx = (await powersync.getNextCrudTransaction())!;
@@ -223,15 +219,14 @@ void main() {
       await powersync.execute('DELETE FROM ps_crud WHERE 1');
 
       await powersync.execute(
-          'UPDATE assets SET description = ?, quantity = quantity + 1 WHERE id = ?',
-          ['updated', testId]);
+          'UPDATE assets SET quantity = quantity + 1 WHERE id = ?', [testId]);
 
       expect(
           await powersync.getAll('SELECT data FROM ps_crud ORDER BY id'),
           equals([
             {
               'data':
-                  '{"op":"PATCH","type":"assets","id":"$testId","data":{"quantity":${bigNumber + 1},"description":"updated"}}'
+                  '{"op":"PATCH","type":"assets","id":"$testId","data":{"quantity":${bigNumber + 1}}}'
             }
           ]));
     });

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
 
   powersync: ^1.8.8
   logging: ^1.2.0
-  sqlite_async: ^0.9.0
+  sqlite_async: ^0.9.1
   path_provider: ^2.0.13
 
 dev_dependencies:


### PR DESCRIPTION
The is a combination of multiple related issues:
1. To detect whether we should trigger a crud upload iteration, the entire database was watched, instead of only the `ps_crud` table.
2. Update notifications were not throttled at all on web, and not correctly handled during transactions (see https://github.com/powersync-ja/sqlite_async.dart/pull/68 for the issue and fix).
3. The connection status was changed to `uploading: true` whenever we get an update notification, rather than only when there is something to upload.

The result was that on Flutter web, after an initial sync of 10k+ rows, there would be a couple of seconds of the sync indicator flickering between "uploading" and "connected". This also added performance overhead.

TODO:
 * [x] Include sqlite_async dependency updates for https://github.com/powersync-ja/sqlite_async.dart/pull/68 when released.
 * [x] Rebase onto main branch.
