### PR TITLE
Fix: Malformed Framework macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,36 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2024-10-21
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`powersync` - `v1.8.8`](#powersync---v188)
+ - [`powersync_attachments_helper` - `v0.6.12`](#powersync_attachments_helper---v0612)
+ - [`powersync_flutter_libs` - `v0.4.1`](#powersync_flutter_libs---v041)
+
+---
+
+#### `powersync` - `v1.8.8`
+
+ - Update dependency `powersync_flutter_libs`
+
+#### `powersync_attachments_helper` - `v0.6.12`
+
+ - Update a dependency to the latest release.
+
+#### `powersync_flutter_libs` - `v0.4.1`
+
+  - powersync-sqlite-core v0.3.4
+
 ## 2024-10-17
 
 ### Changes

--- a/demos/django-todolist/pubspec.lock
+++ b/demos/django-todolist/pubspec.lock
@@ -310,7 +310,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.8.6"
+    version: "1.8.7"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.8.7
+  powersync: ^1.8.8
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-anonymous-auth/pubspec.lock
+++ b/demos/supabase-anonymous-auth/pubspec.lock
@@ -366,7 +366,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.8.6"
+    version: "1.8.7"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.8.7
+  powersync: ^1.8.8
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.lock
+++ b/demos/supabase-edge-function-auth/pubspec.lock
@@ -390,7 +390,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.8.6"
+    version: "1.8.7"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.8.7
+  powersync: ^1.8.8
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.lock
+++ b/demos/supabase-simple-chat/pubspec.lock
@@ -406,7 +406,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.8.6"
+    version: "1.8.7"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^2.0.2
   timeago: ^3.6.0
-  powersync: ^1.8.7
+  powersync: ^1.8.8
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist-drift/pubspec.lock
+++ b/demos/supabase-todolist-drift/pubspec.lock
@@ -686,14 +686,14 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.8.6"
+    version: "1.8.7"
   powersync_attachments_helper:
     dependency: "direct main"
     description:
       path: "../../packages/powersync_attachments_helper"
       relative: true
     source: path
-    version: "0.6.10"
+    version: "0.6.11"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-todolist-drift/pubspec.yaml
+++ b/demos/supabase-todolist-drift/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.11
-  powersync: ^1.8.7
+  powersync_attachments_helper: ^0.6.12
+  powersync: ^1.8.8
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist-optional-sync/pubspec.lock
+++ b/demos/supabase-todolist-optional-sync/pubspec.lock
@@ -470,7 +470,7 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.8.6"
+    version: "1.8.7"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-todolist-optional-sync/pubspec.yaml
+++ b/demos/supabase-todolist-optional-sync/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.8.7
+  powersync: ^1.8.8
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist/ios/Podfile.lock
+++ b/demos/supabase-todolist/ios/Podfile.lock
@@ -7,10 +7,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.3.0)
+  - powersync-sqlite-core (0.3.4)
   - powersync_flutter_libs (0.0.1):
     - Flutter
-    - powersync-sqlite-core (~> 0.3.0)
+    - powersync-sqlite-core (~> 0.3.4)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -73,8 +73,8 @@ SPEC CHECKSUMS:
   camera_avfoundation: dd002b0330f4981e1bbcb46ae9b62829237459a4
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  powersync-sqlite-core: ad0e70e23bacd858fe2e79032dc4aabdf972d1bd
-  powersync_flutter_libs: 064c44b51fb07df9486b735fb96ab7608a89e18b
+  powersync-sqlite-core: d029aa444d33acbb05b47f9f9757b2650578e2d3
+  powersync_flutter_libs: 29f1743509e9ada649dd38a365b3728b97d38c8b
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sqlite3: 0bb0e6389d824e40296f531b858a2a0b71c0d2fb
   sqlite3_flutter_libs: c00457ebd31e59fa6bb830380ddba24d44fbcd3b

--- a/demos/supabase-todolist/macos/Podfile.lock
+++ b/demos/supabase-todolist/macos/Podfile.lock
@@ -5,10 +5,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.2.1)
+  - powersync-sqlite-core (0.3.4)
   - powersync_flutter_libs (0.0.1):
     - FlutterMacOS
-    - powersync-sqlite-core (~> 0.2.1)
+    - powersync-sqlite-core (~> 0.3.4)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -67,8 +67,8 @@ SPEC CHECKSUMS:
   app_links: 10e0a0ab602ffaf34d142cd4862f29d34b303b2a
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  powersync-sqlite-core: 38ead13d8b21920cfbc79e9b3415b833574a506d
-  powersync_flutter_libs: 3f05f43c382c77cb7bec64785c2b6b1e9bd33c22
+  powersync-sqlite-core: d029aa444d33acbb05b47f9f9757b2650578e2d3
+  powersync_flutter_libs: 44829eda70d4f87c9271e963a54126ce19408d7c
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   sqlite3: 0bb0e6389d824e40296f531b858a2a0b71c0d2fb
   sqlite3_flutter_libs: 5ca46c1a04eddfbeeb5b16566164aa7ad1616e7b

--- a/demos/supabase-todolist/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/demos/supabase-todolist/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-               BuildableName = "powersync_flutter_demo.app"
+               BuildableName = "PowerSync Supabase Demo.app"
                BlueprintName = "Runner"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "powersync_flutter_demo.app"
+            BuildableName = "PowerSync Supabase Demo.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -65,7 +65,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "powersync_flutter_demo.app"
+            BuildableName = "PowerSync Supabase Demo.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -82,7 +82,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "powersync_flutter_demo.app"
+            BuildableName = "PowerSync Supabase Demo.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>

--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -470,14 +470,14 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.8.6"
+    version: "1.8.7"
   powersync_attachments_helper:
     dependency: "direct main"
     description:
       path: "../../packages/powersync_attachments_helper"
       relative: true
     source: path
-    version: "0.6.10"
+    version: "0.6.11"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.11
-  powersync: ^1.8.7
+  powersync_attachments_helper: ^0.6.12
+  powersync: ^1.8.8
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.8
+
+- Update dependency `powersync_flutter_libs`
+
 ## 1.8.7
 
 - **FIX**: Validate duplicate table names. ([47f71888](https://github.com/powersync-ja/powersync.dart/commit/47f71888e9adcdcec08c8ee59cb46ac52bd46640))

--- a/packages/powersync/lib/src/version.dart
+++ b/packages/powersync/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String libraryVersion = '1.8.7';
+const String libraryVersion = '1.8.8';

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   sqlite_async: ^0.9.0
   # We only use sqlite3 as a transitive dependency,
   # but right now we need a minimum of v2.4.6.
-  sqlite3: ">=2.4.5 <2.4.7"
+  sqlite3: ^2.4.6
   universal_io: ^2.0.0
   sqlite3_flutter_libs: ^0.5.23
   powersync_flutter_libs: ^0.4.1

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.8.7
+version: 1.8.8
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - sync engine for building local-first apps.
@@ -16,7 +16,7 @@ dependencies:
   sqlite3: ^2.4.6
   universal_io: ^2.0.0
   sqlite3_flutter_libs: ^0.5.23
-  powersync_flutter_libs: ^0.4.0
+  powersync_flutter_libs: ^0.4.1
   meta: ^1.0.0
   http: ^1.1.0
   uuid: ^4.2.0

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   sqlite_async: ^0.9.0
   # We only use sqlite3 as a transitive dependency,
   # but right now we need a minimum of v2.4.6.
-  sqlite3: ^2.4.6
+  sqlite3: ">=2.4.5 <2.4.7"
   universal_io: ^2.0.0
   sqlite3_flutter_libs: ^0.5.23
   powersync_flutter_libs: ^0.4.1

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.12
+
+ - Update a dependency to the latest release.
+
 ## 0.6.11
 
  - Update a dependency to the latest release.

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.6.11
+version: 0.6.12
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.8.7
+  powersync: ^1.8.8
   logging: ^1.2.0
   sqlite_async: ^0.9.0
   path_provider: ^2.0.13

--- a/packages/powersync_flutter_libs/CHANGELOG.md
+++ b/packages/powersync_flutter_libs/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+ - powersync-sqlite-core v0.3.4
+
 ## 0.4.0
 
  - powersync-sqlite-core v0.3.0

--- a/packages/powersync_flutter_libs/android/build.gradle
+++ b/packages/powersync_flutter_libs/android/build.gradle
@@ -50,5 +50,5 @@ android {
 }
 
 dependencies {
-    implementation 'co.powersync:powersync-sqlite-core:0.3.0'
+    implementation 'co.powersync:powersync-sqlite-core:0.3.4'
 }

--- a/packages/powersync_flutter_libs/ios/powersync_flutter_libs.podspec
+++ b/packages/powersync_flutter_libs/ios/powersync_flutter_libs.podspec
@@ -22,7 +22,7 @@ A new Flutter FFI plugin project.
   s.dependency 'Flutter'
   s.platform = :ios, '11.0'
 
-  s.dependency "powersync-sqlite-core", "~> 0.3.0"
+  s.dependency "powersync-sqlite-core", "~> 0.3.4"
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/packages/powersync_flutter_libs/macos/powersync_flutter_libs.podspec
+++ b/packages/powersync_flutter_libs/macos/powersync_flutter_libs.podspec
@@ -21,7 +21,7 @@ A new Flutter FFI plugin project.
   s.source_files     = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
 
-  s.dependency "powersync-sqlite-core", "~> 0.3.0"
+  s.dependency "powersync-sqlite-core", "~> 0.3.4"
 
   s.platform = :osx, '10.11'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }

--- a/packages/powersync_flutter_libs/pubspec.yaml
+++ b/packages/powersync_flutter_libs/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_flutter_libs
 description: PowerSync core binaries for the PowerSync Flutter SDK. Needs to be included for Flutter apps.
-version: 0.4.0
+version: 0.4.1
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 

--- a/scripts/download_core_binary_demos.dart
+++ b/scripts/download_core_binary_demos.dart
@@ -3,7 +3,7 @@
 import 'dart:io';
 
 final coreUrl =
-    'https://github.com/powersync-ja/powersync-sqlite-core/releases/download/v0.3.0';
+    'https://github.com/powersync-ja/powersync-sqlite-core/releases/download/v0.3.4';
 
 void main() async {
   final powersyncLibsLinuxPath = "packages/powersync_flutter_libs/linux";

--- a/scripts/init_powersync_core_binary.dart
+++ b/scripts/init_powersync_core_binary.dart
@@ -6,7 +6,7 @@ import 'dart:io';
 import 'package:melos/melos.dart';
 
 final sqliteUrl =
-    'https://github.com/powersync-ja/powersync-sqlite-core/releases/download/v0.3.0';
+    'https://github.com/powersync-ja/powersync-sqlite-core/releases/download/v0.3.4';
 
 void main() async {
   final sqliteCoreFilename = getLibraryForPlatform();


### PR DESCRIPTION
## Description 

This PR updates powersync-sqlite-core to version 0.3.4. It addresses the issues raised in #197. The underlying xcframework used by the cocoapod (`powersync-sqlite-core`) did not have the correct directory structure and symlinks which caused an error when deploying a macOS app to TestFlight or the AppStore. This was fixed in this [PR](https://github.com/powersync-ja/powersync-sqlite-core/pull/41). 

## Work done

- Upgrade powersync-sqlite-core to v0.3.4