### PR TITLE
[Fix] CRUD Upload on Reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2024-10-31
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`powersync` - `v1.8.9`](#powersync---v189)
+ - [`powersync_attachments_helper` - `v0.6.13`](#powersync_attachments_helper---v0613)
+ - [`powersync_flutter_libs` - `v0.4.2`](#powersync_flutter_libs---v042)
+
+---
+
+#### `powersync` - `v1.8.9`
+
+ - **FIX**: Issue where CRUD uploads were not triggered when the SDK reconnected to the PowerSync service after being offline.
+
+#### `powersync_attachments_helper` - `v0.6.13`
+
+ - Update a dependency to the latest release.
+
+#### `powersync_flutter_libs` - `v0.4.2`
+
+ - Update a dependency to the latest release.
+
+
 ## 2024-10-21
 
 ### Changes

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.8.8
+  powersync: ^1.8.9
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.8.8
+  powersync: ^1.8.9
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.8.8
+  powersync: ^1.8.9
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^2.0.2
   timeago: ^3.6.0
-  powersync: ^1.8.8
+  powersync: ^1.8.9
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist-drift/pubspec.yaml
+++ b/demos/supabase-todolist-drift/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.12
-  powersync: ^1.8.8
+  powersync_attachments_helper: ^0.6.13
+  powersync: ^1.8.9
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist-optional-sync/pubspec.yaml
+++ b/demos/supabase-todolist-optional-sync/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.8.8
+  powersync: ^1.8.9
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.12
-  powersync: ^1.8.8
+  powersync_attachments_helper: ^0.6.13
+  powersync: ^1.8.9
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.9
+
+ - **FIX**: issue where CRUD uploads were not triggered when the SDK reconnected to the PowerSync service after being offline.
+
 ## 1.8.8
 
 - Update dependency `powersync_flutter_libs`

--- a/packages/powersync/lib/src/streaming_sync.dart
+++ b/packages/powersync/lib/src/streaming_sync.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:convert' as convert;
 
-import 'package:async/async.dart';
 import 'package:http/http.dart' as http;
 import 'package:powersync/src/abort_controller.dart';
 import 'package:powersync/src/exceptions.dart';
@@ -171,7 +170,7 @@ class StreamingSyncImplementation {
     // This has the potential (in rare cases) to affect the crudThrottleTime,
     // but it should not result in excessive uploads since the
     // sync reconnects are also throttled.
-    await for (var _ in StreamGroup.merge(
+    await for (var _ in mergeStreams(
         [crudUpdateTriggerStream, _internalCrudTriggerController.stream])) {
       if (_abort?.aborted == true) {
         break;

--- a/packages/powersync/lib/src/streaming_sync.dart
+++ b/packages/powersync/lib/src/streaming_sync.dart
@@ -158,6 +158,9 @@ class StreamingSyncImplementation {
         }
       }
     } finally {
+      // The client should no longer be connected at this point
+      // Adding this update allows for breaking out of an in-progress updateLoop
+      _updateStatus(connected: false);
       _abort!.completeAbort();
     }
   }

--- a/packages/powersync/lib/src/streaming_sync.dart
+++ b/packages/powersync/lib/src/streaming_sync.dart
@@ -89,7 +89,6 @@ class StreamingSyncImplementation {
     // However, we still need to close the underlying stream explicitly, otherwise
     // the break will wait for the next line of data received on the stream.
     _localPingController.add(null);
-    await _internalCrudTriggerController.close();
     // According to the documentation, the behavior is undefined when calling
     // close() while requests are pending. However, this is no other
     // known way to cancel open streams, and this appears to end the stream with

--- a/packages/powersync/lib/src/streaming_sync.dart
+++ b/packages/powersync/lib/src/streaming_sync.dart
@@ -30,7 +30,7 @@ class StreamingSyncImplementation {
 
   // An internal controller which is used to trigger CRUD uploads internally
   // e.g. when reconnecting.
-  // This is only a broadcast stream since the `crudLoop` method is public
+  // This is only a broadcast controller since the `crudLoop` method is public
   // and could potentially be called multiple times externally.
   final StreamController<Null> _internalCrudTriggerController =
       StreamController<Null>.broadcast();

--- a/packages/powersync/lib/src/streaming_sync.dart
+++ b/packages/powersync/lib/src/streaming_sync.dart
@@ -158,9 +158,6 @@ class StreamingSyncImplementation {
         }
       }
     } finally {
-      // The client should no longer be connected at this point
-      // Adding this update allows for breaking out of an in-progress updateLoop
-      _updateStatus(connected: false);
       _abort!.completeAbort();
     }
   }
@@ -493,7 +490,7 @@ class StreamingSyncImplementation {
     }
   }
 
-  /// Delays the standard `retryDelay` Duration, but exists early if
+  /// Delays the standard `retryDelay` Duration, but exits early if
   /// an abort has been requested.
   Future<void> _delayRetry() async {
     await Future.any([Future.delayed(retryDelay), _abort!.onAbort]);

--- a/packages/powersync/lib/src/version.dart
+++ b/packages/powersync/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String libraryVersion = '1.8.8';
+const String libraryVersion = '1.8.9';

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.8.8
+version: 1.8.9
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - sync engine for building local-first apps.
@@ -16,7 +16,7 @@ dependencies:
   sqlite3: ^2.4.6
   universal_io: ^2.0.0
   sqlite3_flutter_libs: ^0.5.23
-  powersync_flutter_libs: ^0.4.1
+  powersync_flutter_libs: ^0.4.2
   meta: ^1.0.0
   http: ^1.1.0
   uuid: ^4.2.0

--- a/packages/powersync/test/connected_test.dart
+++ b/packages/powersync/test/connected_test.dart
@@ -59,7 +59,7 @@ void main() {
     expect(db.connected, isTrue);
   });
 
-  test('should trigger uploads when connection is established', () async {
+  test('should trigger uploads when connection is re-established', () async {
     int uploadCounter = 0;
     Completer uploadTriggeredCompleter = Completer();
 

--- a/packages/powersync/test/connected_test.dart
+++ b/packages/powersync/test/connected_test.dart
@@ -1,3 +1,6 @@
+@TestOn('!browser')
+// This test uses a local server which is possible to control in Web via hybrid main,
+// but this makes the test significantly more complex.
 import 'dart:async';
 
 import 'package:powersync/powersync.dart';

--- a/packages/powersync/test/connected_test.dart
+++ b/packages/powersync/test/connected_test.dart
@@ -27,14 +27,12 @@ void main() {
     createTestServer() async {
       final testServer = TestHttpServerHelper();
       await testServer.start();
+      addTearDown(() => testServer.stop());
       return testServer;
     }
 
     test('should connect to mock PowerSync instance', () async {
       final testServer = await createTestServer();
-      // Cant do this inside the createTestServer function unfortunately
-      addTearDown(() => testServer.stop());
-
       final connector = TestConnector(() async {
         return PowerSyncCredentials(
             endpoint: testServer.uri.toString(),
@@ -70,9 +68,6 @@ void main() {
       int uploadCounter = 0;
       Completer uploadTriggeredCompleter = Completer();
       final testServer = await createTestServer();
-      // Cant do this inside the createTestServer function unfortunately
-      addTearDown(() => testServer.stop());
-
       final connector = TestConnector(() async {
         return PowerSyncCredentials(
             endpoint: testServer.uri.toString(),

--- a/packages/powersync/test/connected_test.dart
+++ b/packages/powersync/test/connected_test.dart
@@ -21,7 +21,7 @@ void main() {
     });
 
     tearDown(() async {
-      // await testUtils.cleanDb(path: path);
+      await testUtils.cleanDb(path: path);
     });
 
     createTestServer() async {

--- a/packages/powersync/test/connected_test.dart
+++ b/packages/powersync/test/connected_test.dart
@@ -14,115 +14,128 @@ import 'utils/test_utils_impl.dart';
 final testUtils = TestUtils();
 
 void main() {
-  late TestHttpServerHelper testServer;
-  late String path;
-
-  setUp(() async {
-    path = testUtils.dbPath();
-    testServer = TestHttpServerHelper();
-    await testServer.start();
-  });
-
-  tearDown(() async {
-    await testUtils.cleanDb(path: path);
-    await testServer.stop();
-  });
-
-  test('should connect to mock PowerSync instance', () async {
-    final connector = TestConnector(() async {
-      return PowerSyncCredentials(
-          endpoint: testServer.uri.toString(),
-          token: 'token not used here',
-          expiresAt: DateTime.now());
+  group('connected tests', () {
+    late String path;
+    setUp(() async {
+      path = testUtils.dbPath();
     });
 
-    final db = PowerSyncDatabase.withFactory(
-        await testUtils.testFactory(path: path),
-        schema: defaultSchema,
-        maxReaders: 3);
-    await db.initialize();
-
-    final connectedCompleter = Completer();
-
-    db.statusStream.listen((status) {
-      if (status.connected) {
-        connectedCompleter.complete();
-      }
+    tearDown(() async {
+      // await testUtils.cleanDb(path: path);
     });
 
-    // Add a basic command for the test server to send
-    testServer.addEvent('{"token_expires_in": 3600}\n');
+    createTestServer() async {
+      final testServer = TestHttpServerHelper();
+      await testServer.start();
+      return testServer;
+    }
 
-    await db.connect(connector: connector);
-    await connectedCompleter.future;
+    test('should connect to mock PowerSync instance', () async {
+      final testServer = await createTestServer();
+      // Cant do this inside the createTestServer function unfortunately
+      addTearDown(() => testServer.stop());
 
-    expect(db.connected, isTrue);
-  });
+      final connector = TestConnector(() async {
+        return PowerSyncCredentials(
+            endpoint: testServer.uri.toString(),
+            token: 'token not used here',
+            expiresAt: DateTime.now());
+      });
 
-  test('should trigger uploads when connection is re-established', () async {
-    int uploadCounter = 0;
-    Completer uploadTriggeredCompleter = Completer();
+      final db = PowerSyncDatabase.withFactory(
+          await testUtils.testFactory(path: path),
+          schema: defaultSchema,
+          maxReaders: 3);
+      await db.initialize();
 
-    final connector = TestConnector(() async {
-      return PowerSyncCredentials(
-          endpoint: testServer.uri.toString(),
-          token: 'token not used here',
-          expiresAt: DateTime.now());
-    }, uploadData: (database) async {
-      uploadCounter++;
-      uploadTriggeredCompleter.complete();
-      throw Exception('No uploads occur here');
+      final connectedCompleter = Completer();
+
+      db.statusStream.listen((status) {
+        if (status.connected) {
+          connectedCompleter.complete();
+        }
+      });
+
+      // Add a basic command for the test server to send
+      testServer.addEvent('{"token_expires_in": 3600}\n');
+
+      await db.connect(connector: connector);
+      await connectedCompleter.future;
+
+      expect(db.connected, isTrue);
+      await db.disconnect();
     });
 
-    final db = PowerSyncDatabase.withFactory(
-        await testUtils.testFactory(path: path),
-        schema: defaultSchema,
-        maxReaders: 3);
-    await db.initialize();
+    test('should trigger uploads when connection is re-established', () async {
+      int uploadCounter = 0;
+      Completer uploadTriggeredCompleter = Completer();
+      final testServer = await createTestServer();
+      // Cant do this inside the createTestServer function unfortunately
+      addTearDown(() => testServer.stop());
 
-    // Create an item which should trigger an upload.
-    await db.execute(
-        'INSERT INTO customers (id, name) VALUES (uuid(), ?)', ['steven']);
+      final connector = TestConnector(() async {
+        return PowerSyncCredentials(
+            endpoint: testServer.uri.toString(),
+            token: 'token not used here',
+            expiresAt: DateTime.now());
+      }, uploadData: (database) async {
+        uploadCounter++;
+        uploadTriggeredCompleter.complete();
+        throw Exception('No uploads occur here');
+      });
 
-    // Create a new completer to await the next upload
-    uploadTriggeredCompleter = Completer();
+      final db = PowerSyncDatabase.withFactory(
+          await testUtils.testFactory(path: path),
+          schema: defaultSchema,
+          maxReaders: 3);
+      await db.initialize();
 
-    // Connect the PowerSync instance
-    final connectedCompleter = Completer();
-    // The first connection attempt will fail
-    final connectedErroredCompleter = Completer();
+      // Create an item which should trigger an upload.
+      await db.execute(
+          'INSERT INTO customers (id, name) VALUES (uuid(), ?)', ['steven']);
 
-    db.statusStream.listen((status) {
-      if (status.connected) {
-        connectedCompleter.complete();
-      }
-      if (status.downloadError != null &&
-          !connectedErroredCompleter.isCompleted) {
-        connectedErroredCompleter.complete();
-      }
+      // Create a new completer to await the next upload
+      uploadTriggeredCompleter = Completer();
+
+      // Connect the PowerSync instance
+      final connectedCompleter = Completer();
+      // The first connection attempt will fail
+      final connectedErroredCompleter = Completer();
+
+      db.statusStream.listen((status) {
+        if (status.connected && !connectedCompleter.isCompleted) {
+          connectedCompleter.complete();
+        }
+        if (status.downloadError != null &&
+            !connectedErroredCompleter.isCompleted) {
+          connectedErroredCompleter.complete();
+        }
+      });
+
+      // The first command will not be valid, this simulates a failed connection
+      testServer.addEvent('asdf\n');
+      await db.connect(connector: connector);
+
+      // The connect operation should have triggered an upload (even though it fails to connect)
+      await uploadTriggeredCompleter.future;
+      expect(uploadCounter, equals(1));
+      // Create a new completer for the next iteration
+      uploadTriggeredCompleter = Completer();
+
+      // Connection attempt should initially fail
+      await connectedErroredCompleter.future;
+      expect(db.currentStatus.anyError, isNotNull);
+
+      // Now send a valid command. Which will result in successful connection
+      await testServer.clearEvents();
+      testServer.addEvent('{"token_expires_in": 3600}\n');
+      await connectedCompleter.future;
+      expect(db.connected, isTrue);
+
+      await uploadTriggeredCompleter.future;
+      expect(uploadCounter, equals(2));
+
+      await db.disconnect();
     });
-
-    // The first command will not be valid, this simulates a failed connection
-    testServer.addEvent('asdf\n');
-    await db.connect(connector: connector);
-
-    // The connect operation should have triggered an upload (even though it fails to connect)
-    await uploadTriggeredCompleter.future;
-    expect(uploadCounter, equals(1));
-    // Create a new completer for the next iteration
-    uploadTriggeredCompleter = Completer();
-
-    // Connection attempt should initially fail
-    await connectedErroredCompleter.future;
-    expect(db.currentStatus.anyError, isNotNull);
-
-    // Now send a valid command. Which will result in successful connection
-    await testServer.clearEvents();
-    testServer.addEvent('{"token_expires_in": 3600}\n');
-    await connectedCompleter.future;
-    expect(db.connected, isTrue);
-
-    await uploadTriggeredCompleter.future;
-    expect(uploadCounter, equals(2));
   });
 }

--- a/packages/powersync/test/connected_test.dart
+++ b/packages/powersync/test/connected_test.dart
@@ -93,7 +93,6 @@ void main() {
     final connectedErroredCompleter = Completer();
 
     db.statusStream.listen((status) {
-      // print('status updated: ${status.connected}, ${status.downloadError}');
       if (status.connected) {
         connectedCompleter.complete();
       }

--- a/packages/powersync/test/connected_test.dart
+++ b/packages/powersync/test/connected_test.dart
@@ -1,0 +1,63 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+import 'server/sync_server/mock_sync_server.dart';
+
+void main() {
+  late TestHttpServerHelper testServer;
+
+  setUp(() async {
+    testServer = TestHttpServerHelper();
+    await testServer.start();
+  });
+
+  tearDown(() async {
+    await testServer.stop();
+  });
+
+  test('should receive events from the sync stream without waiting for close',
+      () async {
+    final client = http.Client();
+    final request =
+        http.Request('POST', testServer.uri.replace(path: '/sync/stream'));
+    request.headers['Content-Type'] = 'application/json';
+
+    // Send the request and get the response stream
+    final responseStream = await client.send(request);
+
+    final expectedEvents = ['event1', 'event2', 'event3'];
+    final receivedEvents = <String>[];
+    final completer = Completer<void>();
+
+    // Listen to the response stream for real-time processing of incoming events
+    final subscription = responseStream.stream
+        .transform(utf8.decoder)
+        .transform(LineSplitter())
+        .listen(
+      (event) {
+        receivedEvents.add(event);
+        if (receivedEvents.length == expectedEvents.length) {
+          completer.complete(); // Complete once all events are received
+        }
+      },
+      onError: (e) => completer.completeError(e),
+    );
+
+    // Programmatically trigger events on the server
+    for (final event in expectedEvents) {
+      testServer.addEvent('$event\n');
+      await Future.delayed(
+          Duration(milliseconds: 100)); // Small delay for each event
+    }
+
+    // Wait for the events to be received
+    await completer.future.timeout(Duration(seconds: 5));
+    await subscription.cancel();
+    client.close();
+
+    expect(receivedEvents.toSet().containsAll(expectedEvents.toSet()), isTrue);
+  });
+}

--- a/packages/powersync/test/connected_test.dart
+++ b/packages/powersync/test/connected_test.dart
@@ -1,63 +1,126 @@
 import 'dart:async';
-import 'dart:convert';
 
-import 'package:http/http.dart' as http;
+import 'package:powersync/powersync.dart';
 import 'package:test/test.dart';
 
 import 'server/sync_server/mock_sync_server.dart';
+import 'streaming_sync_test.dart';
+import 'utils/abstract_test_utils.dart';
+import 'utils/test_utils_impl.dart';
+
+final testUtils = TestUtils();
 
 void main() {
   late TestHttpServerHelper testServer;
+  late String path;
 
   setUp(() async {
+    path = testUtils.dbPath();
     testServer = TestHttpServerHelper();
     await testServer.start();
   });
 
   tearDown(() async {
+    await testUtils.cleanDb(path: path);
     await testServer.stop();
   });
 
-  test('should receive events from the sync stream without waiting for close',
-      () async {
-    final client = http.Client();
-    final request =
-        http.Request('POST', testServer.uri.replace(path: '/sync/stream'));
-    request.headers['Content-Type'] = 'application/json';
+  test('should connect to mock PowerSync instance', () async {
+    final connector = TestConnector(() async {
+      return PowerSyncCredentials(
+          endpoint: testServer.uri.toString(),
+          token: 'token not used here',
+          expiresAt: DateTime.now());
+    });
 
-    // Send the request and get the response stream
-    final responseStream = await client.send(request);
+    final db = PowerSyncDatabase.withFactory(
+        await testUtils.testFactory(path: path),
+        schema: defaultSchema,
+        maxReaders: 3);
+    await db.initialize();
 
-    final expectedEvents = ['event1', 'event2', 'event3'];
-    final receivedEvents = <String>[];
-    final completer = Completer<void>();
+    final connectedCompleter = Completer();
 
-    // Listen to the response stream for real-time processing of incoming events
-    final subscription = responseStream.stream
-        .transform(utf8.decoder)
-        .transform(LineSplitter())
-        .listen(
-      (event) {
-        receivedEvents.add(event);
-        if (receivedEvents.length == expectedEvents.length) {
-          completer.complete(); // Complete once all events are received
-        }
-      },
-      onError: (e) => completer.completeError(e),
-    );
+    db.statusStream.listen((status) {
+      if (status.connected) {
+        connectedCompleter.complete();
+      }
+    });
 
-    // Programmatically trigger events on the server
-    for (final event in expectedEvents) {
-      testServer.addEvent('$event\n');
-      await Future.delayed(
-          Duration(milliseconds: 100)); // Small delay for each event
-    }
+    // Add a basic command for the test server to send
+    testServer.addEvent('{"token_expires_in": 3600}\n');
 
-    // Wait for the events to be received
-    await completer.future.timeout(Duration(seconds: 5));
-    await subscription.cancel();
-    client.close();
+    await db.connect(connector: connector);
+    await connectedCompleter.future;
 
-    expect(receivedEvents.toSet().containsAll(expectedEvents.toSet()), isTrue);
+    expect(db.connected, isTrue);
+  });
+
+  test('should trigger uploads when connection is established', () async {
+    int uploadCounter = 0;
+    Completer uploadTriggeredCompleter = Completer();
+
+    final connector = TestConnector(() async {
+      return PowerSyncCredentials(
+          endpoint: testServer.uri.toString(),
+          token: 'token not used here',
+          expiresAt: DateTime.now());
+    }, uploadData: (database) async {
+      uploadCounter++;
+      uploadTriggeredCompleter.complete();
+      throw Exception('No uploads occur here');
+    });
+
+    final db = PowerSyncDatabase.withFactory(
+        await testUtils.testFactory(path: path),
+        schema: defaultSchema,
+        maxReaders: 3);
+    await db.initialize();
+
+    // Create an item which should trigger an upload.
+    await db.execute(
+        'INSERT INTO customers (id, name) VALUES (uuid(), ?)', ['steven']);
+
+    // Create a new completer to await the next upload
+    uploadTriggeredCompleter = Completer();
+
+    // Connect the PowerSync instance
+    final connectedCompleter = Completer();
+    // The first connection attempt will fail
+    final connectedErroredCompleter = Completer();
+
+    db.statusStream.listen((status) {
+      // print('status updated: ${status.connected}, ${status.downloadError}');
+      if (status.connected) {
+        connectedCompleter.complete();
+      }
+      if (status.downloadError != null &&
+          !connectedErroredCompleter.isCompleted) {
+        connectedErroredCompleter.complete();
+      }
+    });
+
+    // The first command will not be valid, this simulates a failed connection
+    testServer.addEvent('asdf\n');
+    await db.connect(connector: connector);
+
+    // The connect operation should have triggered an upload (even though it fails to connect)
+    await uploadTriggeredCompleter.future;
+    expect(uploadCounter, equals(1));
+    // Create a new completer for the next iteration
+    uploadTriggeredCompleter = Completer();
+
+    // Connection attempt should initially fail
+    await connectedErroredCompleter.future;
+    expect(db.currentStatus.anyError, isNotNull);
+
+    // Now send a valid command. Which will result in successful connection
+    await testServer.clearEvents();
+    testServer.addEvent('{"token_expires_in": 3600}\n');
+    await connectedCompleter.future;
+    expect(db.connected, isTrue);
+
+    await uploadTriggeredCompleter.future;
+    expect(uploadCounter, equals(2));
   });
 }

--- a/packages/powersync/test/server/sync_server/mock_sync_server.dart
+++ b/packages/powersync/test/server/sync_server/mock_sync_server.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart' as io;
+import 'package:shelf_router/shelf_router.dart';
+
+class TestHttpServerHelper {
+  final StreamController<String> _controller = StreamController<String>();
+  late HttpServer _server;
+  // late Timer _timer;
+
+  Uri get uri => Uri.parse('http://localhost:${_server.port}');
+
+  // Start the HTTP server
+  Future<void> start() async {
+    final router = Router()
+      ..post('/sync/stream', (Request request) async {
+        // Respond immediately with a stream
+        return Response.ok(_controller.stream.transform(utf8.encoder),
+            headers: {
+              'Content-Type': 'text/event-stream',
+              'Cache-Control': 'no-cache',
+              'Connection': 'keep-alive',
+              'Transfer-Encoding': 'identity', // Use chunked transfer encoding
+            },
+            context: {
+              "shelf.io.buffer_output": false
+            });
+      });
+
+    // Sending a newline gets the stream going and resolving on the client side
+    _controller.add("\n");
+
+    // // Add data. The mock stream does not seem to resolve without data
+    // _timer = Timer.periodic(Duration(seconds: 1), (Timer timer) {
+    //   // This code will execute every second
+    //   _controller.add('{ "token_expires_in": 3600}\n');
+    // });
+
+    _server = await io.serve(router, 'localhost', 0);
+    print('Test server running at ${_server.address}:${_server.port}');
+  }
+
+  // Programmatically add data to the stream
+  void addEvent(String data) {
+    _controller.add(data);
+  }
+
+  // Stop the HTTP server
+  Future<void> stop() async {
+    // _timer.cancel();
+    await _controller.close();
+    await _server.close();
+  }
+}

--- a/packages/powersync/test/server/sync_server/mock_sync_server.dart
+++ b/packages/powersync/test/server/sync_server/mock_sync_server.dart
@@ -31,7 +31,7 @@ class TestHttpServerHelper {
             });
       });
 
-    _server = await io.serve(router, 'localhost', 0);
+    _server = await io.serve(router.call, 'localhost', 0);
     print('Test server running at ${_server.address}:${_server.port}');
   }
 

--- a/packages/powersync/test/server/sync_server/mock_sync_server.dart
+++ b/packages/powersync/test/server/sync_server/mock_sync_server.dart
@@ -24,7 +24,7 @@ class TestHttpServerHelper {
               'Content-Type': 'text/event-stream',
               'Cache-Control': 'no-cache',
               'Connection': 'keep-alive',
-              'Transfer-Encoding': 'identity', // Use chunked transfer encoding
+              'Transfer-Encoding': 'identity',
             },
             context: {
               "shelf.io.buffer_output": false

--- a/packages/powersync/test/server/sync_server/mock_sync_server.dart
+++ b/packages/powersync/test/server/sync_server/mock_sync_server.dart
@@ -21,10 +21,9 @@ class TestHttpServerHelper {
         // Respond immediately with a stream
         return Response.ok(_controller.stream.transform(utf8.encoder),
             headers: {
-              'Content-Type': 'text/event-stream',
+              'Content-Type': 'application/x-ndjson',
               'Cache-Control': 'no-cache',
               'Connection': 'keep-alive',
-              'Transfer-Encoding': 'identity',
             },
             context: {
               "shelf.io.buffer_output": false

--- a/packages/powersync/test/streaming_sync_test.dart
+++ b/packages/powersync/test/streaming_sync_test.dart
@@ -13,8 +13,11 @@ final testUtils = TestUtils();
 
 class TestConnector extends PowerSyncBackendConnector {
   final Function _fetchCredentials;
+  final Future<void> Function(PowerSyncDatabase)? _uploadData;
 
-  TestConnector(this._fetchCredentials);
+  TestConnector(this._fetchCredentials,
+      {Future<void> Function(PowerSyncDatabase)? uploadData})
+      : _uploadData = uploadData;
 
   @override
   Future<PowerSyncCredentials?> fetchCredentials() {
@@ -22,7 +25,11 @@ class TestConnector extends PowerSyncBackendConnector {
   }
 
   @override
-  Future<void> uploadData(PowerSyncDatabase database) async {}
+  Future<void> uploadData(PowerSyncDatabase database) async {
+    if (_uploadData != null) {
+      await _uploadData(database);
+    }
+  }
 }
 
 void main() {

--- a/packages/powersync/test/streaming_sync_test.dart
+++ b/packages/powersync/test/streaming_sync_test.dart
@@ -26,9 +26,7 @@ class TestConnector extends PowerSyncBackendConnector {
 
   @override
   Future<void> uploadData(PowerSyncDatabase database) async {
-    if (_uploadData != null) {
-      await _uploadData(database);
-    }
+    await _uploadData?.call(database);
   }
 }
 

--- a/packages/powersync/test/upload_test.dart
+++ b/packages/powersync/test/upload_test.dart
@@ -66,7 +66,9 @@ void main() {
 
       powersync =
           await testUtils.setupPowerSync(path: path, logger: testWarningLogger);
-      powersync.retryDelay = Duration(milliseconds: 0);
+      // Use a short retry delay here.
+      // A zero retry delay makes this test unstable, since it expects `2` error logs later.
+      powersync.retryDelay = Duration(milliseconds: 100);
       var connector = TestConnector(credentialsCallback, uploadData);
       powersync.connect(connector: connector);
 

--- a/packages/powersync/test/utils/abstract_test_utils.dart
+++ b/packages/powersync/test/utils/abstract_test_utils.dart
@@ -26,8 +26,8 @@ final testLogger = _makeTestLogger();
 
 final testWarningLogger = _makeTestLogger(level: Level.WARNING);
 
-Logger _makeTestLogger({Level level = Level.ALL}) {
-  final logger = Logger.detached('PowerSync Tests');
+Logger _makeTestLogger({Level level = Level.ALL, String? name}) {
+  final logger = Logger.detached(name ?? 'PowerSync Tests');
   logger.level = level;
   logger.onRecord.listen((record) {
     print(
@@ -53,11 +53,11 @@ Logger _makeTestLogger({Level level = Level.ALL}) {
 }
 
 abstract class AbstractTestUtils {
+  String get _testName => Invoker.current!.liveTest.test.name;
+
   String dbPath() {
-    final test = Invoker.current!.liveTest;
-    var testName = test.test.name;
     var testShortName =
-        testName.replaceAll(RegExp(r'[\s\./]'), '_').toLowerCase();
+        _testName.replaceAll(RegExp(r'[\s\./]'), '_').toLowerCase();
     var dbName = "test-db/$testShortName.db";
     return dbName;
   }
@@ -74,7 +74,8 @@ abstract class AbstractTestUtils {
   Future<PowerSyncDatabase> setupPowerSync(
       {String? path, Schema? schema, Logger? logger}) async {
     final db = PowerSyncDatabase.withFactory(await testFactory(path: path),
-        schema: schema ?? defaultSchema, logger: logger ?? testLogger);
+        schema: schema ?? defaultSchema,
+        logger: logger ?? _makeTestLogger(name: _testName));
     await db.initialize();
     return db;
   }

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.13
+
+ - Update a dependency to the latest release.
+
 ## 0.6.12
 
  - Update a dependency to the latest release.

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.6.12
+version: 0.6.13
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.8.8
+  powersync: ^1.8.9
   logging: ^1.2.0
   sqlite_async: ^0.9.1
   path_provider: ^2.0.13

--- a/packages/powersync_flutter_libs/CHANGELOG.md
+++ b/packages/powersync_flutter_libs/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2
+
+ - Update a dependency to the latest release.
+
 ## 0.4.1
 
  - powersync-sqlite-core v0.3.4

--- a/packages/powersync_flutter_libs/pubspec.yaml
+++ b/packages/powersync_flutter_libs/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_flutter_libs
 description: PowerSync core binaries for the PowerSync Flutter SDK. Needs to be included for Flutter apps.
-version: 0.4.1
+version: 0.4.2
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 


### PR DESCRIPTION
# Overview

This fixes an issue where CRUD uploads are not triggered when the SDK reconnects to the PowerSync service after being offline.

Previously uploads were only triggered when an initial call to `.connect` has been made or when changes to the `ps_crud` table have occurred. If an application called `.connect` successfully, then went offline and made CRUD operations - the SDK would not trigger a CRUD upload once it had re-established a connection.

This now triggers a CRUD upload whenever the SDK establishes a connection or a change has been made to `ps_crud`.

## Testing

This was tested locally and unit tests have been added using a mock PowerSync service. 