### PR TITLE
Fix multi-tab sync issues

### DIFF
--- a/packages/powersync/lib/src/database/web/web_powersync_database.dart
+++ b/packages/powersync/lib/src/database/web/web_powersync_database.dart
@@ -148,11 +148,11 @@ class PowerSyncDatabaseImpl
     // duplicating work across tabs.
     try {
       sync = await SyncWorkerHandle.start(
-        this,
-        connector,
-        crudThrottleTime.inMilliseconds,
-        Uri.base.resolve('/powersync_sync.worker.js'),
-      );
+          database: this,
+          connector: connector,
+          crudThrottleTimeMs: crudThrottleTime.inMilliseconds,
+          workerUri: Uri.base.resolve('/powersync_sync.worker.js'),
+          syncParams: params);
     } catch (e) {
       logger.warning(
         'Could not use shared worker for synchronization, falling back to locks.',

--- a/packages/powersync/lib/src/web/sync_worker_protocol.dart
+++ b/packages/powersync/lib/src/web/sync_worker_protocol.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:js_interop';
 
 import 'package:web/web.dart';
@@ -60,15 +61,16 @@ extension type SyncWorkerMessage._(JSObject _) implements JSObject {
 
 @anonymous
 extension type StartSynchronization._(JSObject _) implements JSObject {
-  external factory StartSynchronization({
-    required String databaseName,
-    required int crudThrottleTimeMs,
-    required int requestId,
-  });
+  external factory StartSynchronization(
+      {required String databaseName,
+      required int crudThrottleTimeMs,
+      required int requestId,
+      String? syncParamsEncoded});
 
   external String get databaseName;
   external int get requestId;
   external int get crudThrottleTimeMs;
+  external String? get syncParamsEncoded;
 }
 
 @anonymous
@@ -315,15 +317,17 @@ final class WorkerCommunicationChannel {
     await _numericRequest(SyncWorkerMessageType.ping);
   }
 
-  Future<void> startSynchronization(
-      String databaseName, int crudThrottleTimeMs) async {
+  Future<void> startSynchronization(String databaseName, int crudThrottleTimeMs,
+      Map<String, dynamic>? syncParams) async {
     final (id, completion) = _newRequest();
     port.postMessage(SyncWorkerMessage(
       type: SyncWorkerMessageType.startSynchronization.name,
       payload: StartSynchronization(
           databaseName: databaseName,
           crudThrottleTimeMs: crudThrottleTimeMs,
-          requestId: id),
+          requestId: id,
+          syncParamsEncoded:
+              syncParams == null ? null : jsonEncode(syncParams)),
     ));
     await completion;
   }

--- a/packages/powersync/lib/src/web/sync_worker_protocol.dart
+++ b/packages/powersync/lib/src/web/sync_worker_protocol.dart
@@ -14,10 +14,12 @@ enum SyncWorkerMessageType {
 
   /// Sent from client to the sync worker to request the synchronization
   /// starting.
+  /// If parameters change, the sync worker reconnects.
   startSynchronization,
 
-  /// Te [SyncWorkerMessage.payload] for the request is a numeric id, the
+  /// The [SyncWorkerMessage.payload] for the request is a numeric id, the
   /// response can be anything (void).
+  /// This disconnects immediately, even if other clients are still open.
   abortSynchronization,
 
   /// Sent from the sync worker to the client when it needs an endpoint to


### PR DESCRIPTION
 1. Fix client parameters not being passed to the server (regression from #200).
 2. Reconnect when a client calls `connect()` again with different parameters.
 3. Immediately disconnect when any client calls `disconnect()` (or `disconnectAndClear()`).

(2) is to make sure we connect with the latest client parameters. I'm not sure if it's perhaps better to _always_ reconnect when calling `connect()` - that's what we do in other SDKs (including native Flutter). However, that may not be optimal when working with multiple tabs, since it would effectively reconnect every time you open a new tab.

The last one is specifically an issue when calling `disconnectAndClear()`. If other tabs were open, the connection would remain open, despite deleting all data in the database. This caused the app to end up in a weird state.

