### PR TITLE
Simplify Flutter Web Readme

### DIFF
--- a/packages/powersync/README.md
+++ b/packages/powersync/README.md
@@ -22,7 +22,7 @@ Our [full SDK reference](https://docs.powersync.com/client-sdk-references/flutte
 
 ## **Web support - Beta**
 
-Flutter Web support in version 1.9.0 is currently in a beta release. It is functionally ready for production use, provided that you've tested your use cases. 
+Flutter Web support in version `^1.9.0` is currently in a beta release. It is functionally ready for production use, provided that you've tested your use cases. 
 
 Please familiarize yourself with the Current Limitations for Flutter Web documented [here](https://docs.powersync.com/client-sdk-references/flutter/flutter-web-support#current-limitations).
 

--- a/packages/powersync/README.md
+++ b/packages/powersync/README.md
@@ -22,15 +22,15 @@ Our [full SDK reference](https://docs.powersync.com/client-sdk-references/flutte
 
 ## **Web support - Beta**
 
-Web support in version 1.9.0 is currently in a beta release. It is functionally ready for production use, provided that you've tested your use cases. 
+Flutter Web support in version 1.9.0 is currently in a beta release. It is functionally ready for production use, provided that you've tested your use cases. 
 
-Please familiarize yourself with the Current Limitations for Web documented [here](https://docs.powersync.com/client-sdk-references/flutter/flutter-web-support#current-limitations).
+Please familiarize yourself with the Current Limitations for Flutter Web documented [here](https://docs.powersync.com/client-sdk-references/flutter/flutter-web-support#current-limitations).
 
 ### Demo app
 
 The easiest way to test Flutter Web support is to run the [Supabase Todo-List](https://github.com/powersync-ja/powersync.dart/tree/main/demos/supabase-todolist) demo app:
 
-1. Checkout [this repo's](https://github.com/powersync-ja/powersync.dart/tree/main) `main` branch.
+1. Clone [this repo](https://github.com/powersync-ja/powersync.dart/tree/main).
 
 - Note: If you are an existing user updating to the latest code after a git pull, run `melos exec 'flutter pub upgrade'` in the repo's root directory and make sure it succeeds.
 
@@ -49,11 +49,7 @@ flutter pub add powersync:'^1.9.0'
 
 #### Additional config
 
-Web support requires `sqlite3.wasm` and worker (`powersync_db.worker.js` and `powersync_sync.worker.js`) assets to be served from the web application. They can be downloaded to the web directory by running the following command in your application's root folder.
-
-```bash
-dart run powersync:setup_web
-```
+Additional config is required for web projects. Please see our docs [here](https://docs.powersync.com/client-sdk-references/flutter/flutter-web-support#additional-config) for details.
 
 # Changelog
 

--- a/packages/powersync/README.md
+++ b/packages/powersync/README.md
@@ -18,11 +18,13 @@ flutter pub add powersync
 
 # Getting Started
 
-Our [full SDK reference](https://docs.powersync.com/client-sdk-references/flutter) contains everything you need to know to get started implementing PowerSync in your project.
+Our [full SDK reference](https://docs.powersync.com/client-sdk-references/flutter) contains everything you need to know to get started implementing PowerSync in your project. 
 
 ## **Web support - Beta**
 
-Web support in version 1.9.0 is currently in a beta release. This means it is safe to use in production, provided that you've tested your use cases.
+Web support in version 1.9.0 is currently in a beta release. It is functionally ready for production use, provided that you've tested your use cases. 
+
+Please familiarize yourself with the Current Limitations for Web documented [here](https://docs.powersync.com/client-sdk-references/flutter/flutter-web-support#current-limitations).
 
 ### Demo app
 
@@ -39,52 +41,19 @@ The easiest way to test Flutter Web support is to run the [Supabase Todo-List](h
 
 ### Installing PowerSync in your own project
 
-Install the latest version of the package, for example:
+Install the [latest version]((https://pub.dev/packages/powersync/versions)) of the package, for example:
 
 ```
 flutter pub add powersync:'^1.9.0'
 ```
 
-The latest version can be found [here](https://pub.dev/packages/powersync/versions).
+#### Additional config
 
-### Additional config
+Web support requires `sqlite3.wasm` and worker (`powersync_db.worker.js` and `powersync_sync.worker.js`) assets to be served from the web application. They can be downloaded to the web directory by running the following command in your application's root folder.
 
-Web support requires `sqlite3.wasm` and worker (`powersync_db.worker.js` and `powersync_sync.worker.js`) assets to be served from the web application. They can be downloaded to the `web` directory by running the following command in your application's root folder.
-
-```dart
+```bash
 dart run powersync:setup_web
 ```
-
-The same code is used for initializing native and web `PowerSyncDatabase` clients.
-
-### Limitations
-
-The API for Web is essentially the same as for native platforms, however, some features within `PowerSyncDatabase` clients are not available.
-
-#### Imports
-
-Flutter Web does not support importing directly from `sqlite3.dart` as it uses `dart:ffi`.
-
-Change imports from
-
-```Dart
-import 'package/powersync/sqlite3.dart`
-```
-
-to
-
-```Dart
-import 'package/powersync/sqlite3_common.dart'
-```
-
-In code which needs to run on the Web platform. Isolated native specific code can still import from `sqlite3.dart`.
-
-#### Database connections
-
-Web DB connections do not support concurrency. A single DB connection is used. `readLock` and `writeLock` contexts do not
-implement checks for preventing writable queries in read connections and vice-versa.
-
-Direct access to the synchronous `CommonDatabase` (`sqlite.Database` equivalent for web) connection is not available. `computeWithDatabase` is not available on web.
 
 # Changelog
 

--- a/packages/powersync/README.md
+++ b/packages/powersync/README.md
@@ -24,7 +24,7 @@ Our [full SDK reference](https://docs.powersync.com/client-sdk-references/flutte
 
 Flutter Web support in version `^1.9.0` is currently in a beta release. It is functionally ready for production use, provided that you've tested your use cases. 
 
-Please familiarize yourself with the Current Limitations for Flutter Web documented [here](https://docs.powersync.com/client-sdk-references/flutter/flutter-web-support#current-limitations).
+Please familiarize yourself with the limitations for Flutter Web documented [here](https://docs.powersync.com/client-sdk-references/flutter/flutter-web-support#limitations).
 
 ### Demo app
 

--- a/packages/powersync/README.md
+++ b/packages/powersync/README.md
@@ -41,7 +41,7 @@ The easiest way to test Flutter Web support is to run the [Supabase Todo-List](h
 
 ### Installing PowerSync in your own project
 
-Install the [latest version]((https://pub.dev/packages/powersync/versions)) of the package, for example:
+Install the [latest version](https://pub.dev/packages/powersync/versions) of the package, for example:
 
 ```
 flutter pub add powersync:'^1.9.0'


### PR DESCRIPTION
Most content will be moved to [docs](https://docs.powersync.com/client-sdk-references/flutter/flutter-web-support), so only keep the essential getting started instructions in the Readme.

Depends on https://github.com/powersync-ja/mintlify-docs/pull/17/files