### PR TITLE
IndexedDB flushing

### DIFF
--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -29,21 +29,3 @@ jobs:
         run: |
           ./.github/workflows/scripts/copy-config.sh
           melos analyze:demos
-
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: "3.x"
-          channel: "stable"
-      - name: Install melos
-        run: flutter pub global activate melos
-      - name: Install dependencies
-        run: melos prepare
-      - name: Run flutter tests
-        run: melos test
-      - name: Run dart tests
-        run: melos test:web

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -29,7 +29,22 @@ jobs:
         run: melos analyze:packages
       - name: Publish dry-run
         run: melos publish --dry-run --yes
-      - name: Check publish score
+
+  pana:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.x"
+          channel: "stable"
+
+      - name: Install Melos
+        run: flutter pub global activate melos
+      - name: Install dependencies
+        run: melos prepare
+      - name: Check pana score
         run: |
           flutter pub global activate pana
           melos analyze:packages:pana --no-select

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,34 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2024-11-06
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`powersync` - `v1.9.2`](#powersync---v192)
+ - [`powersync_attachments_helper` - `v0.6.15+1`](#powersync_attachments_helper---v06151)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `powersync_attachments_helper` - `v0.6.15+1`
+
+---
+
+#### `powersync` - `v1.9.2`
+
+ - [Web] Automatically flush IndexedDB storage to fix durability issues
+
+
 ## 2024-11-04
 
 ### Changes

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.9.1
+  powersync: ^1.9.2
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.10.1
+  sqlite_async: ^0.11.0
   http: ^1.2.1
   shared_preferences: ^2.2.3
 

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.9.1
+  powersync: ^1.9.2
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   supabase_flutter: ^2.0.2
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.10.1
+  sqlite_async: ^0.11.0
   universal_io: ^2.2.2
 
 dev_dependencies:

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.9.1
+  powersync: ^1.9.2
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   supabase_flutter: ^2.0.2
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.10.1
+  sqlite_async: ^0.11.0
   universal_io: ^2.2.2
 
 dev_dependencies:

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^2.0.2
   timeago: ^3.6.0
-  powersync: ^1.9.1
+  powersync: ^1.9.2
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist-drift/pubspec.yaml
+++ b/demos/supabase-todolist-drift/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.15
-  powersync: ^1.9.1
+  powersync_attachments_helper: ^0.6.15+1
+  powersync: ^1.9.2
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist-drift/pubspec.yaml
+++ b/demos/supabase-todolist-drift/pubspec.yaml
@@ -18,9 +18,9 @@ dependencies:
   camera: ^0.10.5+7
   image: ^4.1.3
   universal_io: ^2.2.2
-  sqlite_async: ^0.10.1
+  sqlite_async: ^0.11.0
   drift: ^2.20.2
-  drift_sqlite_async: ^0.2.0-alpha.3
+  drift_sqlite_async: ^0.2.0
 
 dev_dependencies:
   flutter_test:

--- a/demos/supabase-todolist-optional-sync/pubspec.yaml
+++ b/demos/supabase-todolist-optional-sync/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   camera: ^0.10.5+7
   image: ^4.1.3
   universal_io: ^2.2.2
-  sqlite_async: ^0.10.1
+  sqlite_async: ^0.11.0
 
 dev_dependencies:
   flutter_test:

--- a/demos/supabase-todolist-optional-sync/pubspec.yaml
+++ b/demos/supabase-todolist-optional-sync/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.9.1
+  powersync: ^1.9.2
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   camera: ^0.10.5+7
   image: ^4.1.3
   universal_io: ^2.2.2
-  sqlite_async: ^0.10.1
+  sqlite_async: ^0.11.0
 
 dev_dependencies:
   flutter_test:

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.15
-  powersync: ^1.9.1
+  powersync_attachments_helper: ^0.6.15+1
+  powersync: ^1.9.2
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.2
+
+ - [Web] Automatically flush IndexedDB storage to fix durability issues
+
 ## 1.9.1
 
 - Flutter Web Beta release

--- a/packages/powersync/lib/src/version.dart
+++ b/packages/powersync/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String libraryVersion = '1.9.1';
+const String libraryVersion = '1.9.2';

--- a/packages/powersync/lib/src/web/sync_worker.dart
+++ b/packages/powersync/lib/src/web/sync_worker.dart
@@ -16,8 +16,8 @@ import 'package:powersync/src/streaming_sync.dart';
 import 'package:sqlite_async/web.dart';
 import 'package:web/web.dart' hide RequestMode;
 
-import '../bucket_storage.dart';
 import 'sync_worker_protocol.dart';
+import 'web_bucket_storage.dart';
 
 final _logger = autoLogger;
 
@@ -258,7 +258,7 @@ class _SyncRunner {
         : jsonDecode(syncParamsEncoded!) as Map<String, dynamic>;
 
     sync = StreamingSyncImplementation(
-        adapter: BucketStorage(database),
+        adapter: WebBucketStorage(database),
         credentialsCallback: client.channel.credentialsCallback,
         invalidCredentialsCallback: client.channel.invalidCredentialsCallback,
         uploadCrud: client.channel.uploadCrud,

--- a/packages/powersync/lib/src/web/web_bucket_storage.dart
+++ b/packages/powersync/lib/src/web/web_bucket_storage.dart
@@ -1,0 +1,20 @@
+import 'package:powersync/sqlite_async.dart';
+import 'package:powersync/src/bucket_storage.dart';
+import 'package:sqlite_async/web.dart';
+
+class WebBucketStorage extends BucketStorage {
+  final WebSqliteConnection _webDb;
+
+  WebBucketStorage(this._webDb) : super(_webDb);
+
+  @override
+
+  /// Override to implement the flush parameter for web.
+  Future<T> writeTransaction<T>(
+      Future<T> Function(SqliteWriteContext tx) callback,
+      {Duration? lockTimeout,
+      required bool flush}) async {
+    return _webDb.writeTransaction(callback,
+        lockTimeout: lockTimeout, flush: flush);
+  }
+}

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  sqlite_async: ^0.10.1
+  sqlite_async: ^0.11.0
   # We only use sqlite3 as a transitive dependency,
   # but right now we need a minimum of v2.4.6.
   sqlite3: ^2.4.6

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.9.1
+version: 1.9.2
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - sync engine for building local-first apps.

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.15+1
+
+ - Update a dependency to the latest release.
+
 ## 0.6.15
 
  - Update a dependency to the latest release.

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.6.15
+version: 0.6.15+1
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.9.1
+  powersync: ^1.9.2
   logging: ^1.2.0
   sqlite_async: ^0.11.0
   path_provider: ^2.0.13

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
 
   powersync: ^1.9.1
   logging: ^1.2.0
-  sqlite_async: ^0.10.1
+  sqlite_async: ^0.11.0
   path_provider: ^2.0.13
 
 dev_dependencies:

--- a/scripts/compile_webworker.dart
+++ b/scripts/compile_webworker.dart
@@ -30,7 +30,7 @@ Future<void> main() async {
 
   if (dbWorkerProcess.exitCode != 0) {
     throw Exception(
-        'Could not compile db worker: ${dbWorkerProcess.stdout.toString()}');
+        'Could not compile db worker.\nstdout: ${dbWorkerProcess.stdout.toString()}\nstderr: ${dbWorkerProcess.stderr.toString()}');
   }
 
   final syncWorkerFilename = 'powersync_sync.worker.js';
@@ -54,7 +54,7 @@ Future<void> main() async {
 
   if (syncWorkerProcess.exitCode != 0) {
     throw Exception(
-        'Could not compile sync worker: ${dbWorkerProcess.stdout.toString()}');
+        'Could not compile sync worker:\nstdout: ${syncWorkerProcess.stdout.toString()}\nstderr: ${syncWorkerProcess.stderr.toString()}');
   }
 
   // Copy this to all demo apps web folders


### PR DESCRIPTION
An [update](https://github.com/powersync-ja/sqlite_async.dart/pull/77) in sqlite_async will automatically flush each write. This gives some durability guarantees, but significantly slows down initial sync of 100k rows.

This change configures bucket storage to selectively disable flushing in cases where durability is not important. This only has an effect for Flutter Web, and only when IndexedDB storage is used.

Despite this change, OPFS storage is still much better. This just makes IndexedDB storage a little less bad.