### PR TITLE
chore: Improve Release Automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,5 +38,5 @@ jobs:
           changes=$(awk "/## $version/{flag=1;next}/##/{flag=0}flag" packages/powersync/CHANGELOG.md)
           body="Release $tag
           $changes"
-          gh release "$tag" --title "$tag" --notes "$body"
+          gh release create "$tag" --title "$tag" --notes "$body"
           gh release upload "${{ github.ref_name }}" packages/powersync/assets/powersync_db.worker.js packages/powersync/assets/powersync_sync.worker.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: Compile Assets and Create Draft Release
 on:
   push:
     tags:
-      - "powersync-v[0-9]+.[0-9]+.[0-9]+"
+      - 'powersync-v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build:
@@ -19,8 +19,8 @@ jobs:
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.x"
-          channel: "stable"
+          flutter-version: '3.x'
+          channel: 'stable'
 
       - name: Install Melos
         run: flutter pub global activate melos
@@ -34,6 +34,9 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           tag="${{ github.ref_name }}"
-          body="Release $tag"
-          gh release create --draft "$tag" --title "$tag" --notes "$body" --generate-notes
+          version="${tag#powersync-v}"
+          changes=$(awk "/## $version/{flag=1;next}/##/{flag=0}flag" packages/powersync/CHANGELOG.md)
+          body="Release $tag
+          $changes"
+          gh release  --draft "$tag" --title "$tag" --notes "$body"
           gh release upload "${{ github.ref_name }}" packages/powersync/assets/powersync_db.worker.js packages/powersync/assets/powersync_sync.worker.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,5 +38,5 @@ jobs:
           changes=$(awk "/## $version/{flag=1;next}/##/{flag=0}flag" packages/powersync/CHANGELOG.md)
           body="Release $tag
           $changes"
-          gh release  --draft "$tag" --title "$tag" --notes "$body"
+          gh release "$tag" --title "$tag" --notes "$body"
           gh release upload "${{ github.ref_name }}" packages/powersync/assets/powersync_db.worker.js packages/powersync/assets/powersync_sync.worker.js

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,4 +27,4 @@ git push --follow-tags
 
 **Note: This will launch the `release.yaml` and `publish.yaml` github actions in `.github/workflows`. So only run it when you are absolutely sure you want to release.**
 
-A version bump and tag push for `powersync` will also create a draft github release for the powersync web worker. The worker needs to be manually published in the GitHub [releases](https://github.com/powersync-ja/powersync.dart/releases).
+A version bump and tag push for `powersync` will also create a Github release for the PowerSync web workers. Verify the release exists and is published in the [releases](https://github.com/powersync-ja/powersync.dart/releases).


### PR DESCRIPTION
# Overview

The PowerSync SDK requires assets for Webworkers which are downloaded from Github releases. The SDK release process currently creates a draft Github Release which needs to be reviewed an published manually. This step is often forgotten.

This PR updates the release process to publish the release as it is created. The Github release's body is taken from the corresponding version entry in the PowerSync package's CHANGELOG.md file. This release can still be edited after publish.

