### PR TITLE
Avoid emitting duplicate sync status events

### DIFF
--- a/packages/powersync_core/CHANGELOG.md
+++ b/packages/powersync_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1-dev
+
+- Fix `statusStream` emitting the same sync status multiple times.
+
 ## 1.1.0
 
  - Increase limit on number of columns per table to 1999.

--- a/packages/powersync_core/pubspec.yaml
+++ b/packages/powersync_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync_core
-version: 1.1.0
+version: 1.1.1-dev
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Dart SDK - sync engine for building local-first apps.


### PR DESCRIPTION
We generally have mechanisms in place that try to prevent duplicate sync state events being emitted by `statusStream`. In the powersync mixin however, we apply a transformation on incoming events to set `hasSynced` (a field that is not set on the events that method receives). This means that incoming events only differing due to `hasSynced` being absent effectively cause us to re-emit the last snapshot.

I've also added a call to close the stream when the database is closed (generally useful to free up listeners, and also makes testing this easier).

Closes https://github.com/powersync-ja/powersync.dart/issues/224