### PR TITLE
Web: Enable PowerSync extensions even without worker

### DIFF
--- a/packages/powersync_core/lib/src/open_factory/web/web_open_factory.dart
+++ b/packages/powersync_core/lib/src/open_factory/web/web_open_factory.dart
@@ -3,14 +3,28 @@ import 'dart:async';
 import 'package:powersync_core/src/open_factory/abstract_powersync_open_factory.dart';
 import 'package:powersync_core/src/uuid.dart';
 import 'package:sqlite_async/sqlite3_common.dart';
+import 'package:sqlite_async/sqlite3_web.dart';
 import 'package:sqlite_async/sqlite_async.dart';
+import 'package:sqlite_async/web.dart';
+
+import '../../web/worker_utils.dart';
 
 /// Web implementation for [AbstractPowerSyncOpenFactory]
-class PowerSyncOpenFactory extends AbstractPowerSyncOpenFactory {
+class PowerSyncOpenFactory extends AbstractPowerSyncOpenFactory
+    implements WebSqliteOpenFactory {
   PowerSyncOpenFactory({
     required super.path,
     super.sqliteOptions,
   });
+
+  @override
+  Future<WebSqlite> openWebSqlite(WebSqliteOptions options) async {
+    return WebSqlite.open(
+      wasmModule: Uri.parse(sqliteOptions.webSqliteOptions.wasmUri),
+      worker: Uri.parse(sqliteOptions.webSqliteOptions.workerUri),
+      controller: PowerSyncAsyncSqliteController(),
+    );
+  }
 
   @override
   void enableExtension() {

--- a/packages/powersync_core/lib/src/web/powersync_db.worker.dart
+++ b/packages/powersync_core/lib/src/web/powersync_db.worker.dart
@@ -4,30 +4,10 @@
 
 library;
 
-import 'dart:js_interop';
-
-import 'package:sqlite_async/sqlite3_web_worker.dart';
 import 'package:sqlite_async/sqlite3_web.dart';
-import 'package:sqlite_async/sqlite3_wasm.dart';
 
 import 'worker_utils.dart';
 
 void main() {
   WebSqlite.workerEntrypoint(controller: PowerSyncAsyncSqliteController());
-}
-
-final class PowerSyncAsyncSqliteController extends AsyncSqliteController {
-  @override
-  Future<WorkerDatabase> openDatabase(
-      WasmSqlite3 sqlite3, String path, String vfs) async {
-    final asyncDb = await super.openDatabase(sqlite3, path, vfs);
-    setupPowerSyncDatabase(asyncDb.database);
-    return asyncDb;
-  }
-
-  @override
-  Future<JSAny?> handleCustomRequest(
-      ClientConnection connection, JSAny? request) {
-    throw UnimplementedError();
-  }
 }

--- a/packages/powersync_core/lib/src/web/worker_utils.dart
+++ b/packages/powersync_core/lib/src/web/worker_utils.dart
@@ -1,6 +1,26 @@
-import 'package:powersync_core/sqlite3_common.dart';
+import 'dart:js_interop';
+
 import 'package:powersync_core/src/open_factory/common_db_functions.dart';
+import 'package:sqlite_async/sqlite3_wasm.dart';
+import 'package:sqlite_async/sqlite3_web.dart';
+import 'package:sqlite_async/sqlite3_web_worker.dart';
 import 'package:uuid/uuid.dart';
+
+final class PowerSyncAsyncSqliteController extends AsyncSqliteController {
+  @override
+  Future<WorkerDatabase> openDatabase(
+      WasmSqlite3 sqlite3, String path, String vfs) async {
+    final asyncDb = await super.openDatabase(sqlite3, path, vfs);
+    setupPowerSyncDatabase(asyncDb.database);
+    return asyncDb;
+  }
+
+  @override
+  Future<JSAny?> handleCustomRequest(
+      ClientConnection connection, JSAny? request) {
+    throw UnimplementedError();
+  }
+}
 
 // Registers custom SQLite functions for the SQLite connection
 void setupPowerSyncDatabase(CommonDatabase database) {

--- a/packages/powersync_core/pubspec.yaml
+++ b/packages/powersync_core/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.4.3
 
 dependencies:
-  sqlite_async: ^0.11.0
+  sqlite_async: ^0.11.1
   # We only use sqlite3 as a transitive dependency,
   # but right now we need a minimum of v2.4.6.
   sqlite3: ^2.4.6


### PR DESCRIPTION
When we're running in a context where workers haven't been set up (like e.g. the Test Run environment from FlutterFlow), fall back to hosting the SQLite database in the main JavaScript context. This also requires setting up the powersync extension, which is normally initialized by the worker.

The new `sqlite_async` / `sqlite3_web` package versions will use our database controller when workers are unavailable. 