### PR TITLE
Use database logger for sync protocol

### DIFF
--- a/packages/powersync_core/lib/src/web/sync_controller.dart
+++ b/packages/powersync_core/lib/src/web/sync_controller.dart
@@ -29,6 +29,7 @@ class SyncWorkerHandle implements StreamingSync {
     _channel = WorkerCommunicationChannel(
       port: sendToWorker,
       errors: EventStreamProviders.errorEvent.forTarget(worker),
+      logger: database.logger,
       requestHandler: (type, payload) async {
         switch (type) {
           case SyncWorkerMessageType.requestEndpoint:
@@ -84,12 +85,13 @@ class SyncWorkerHandle implements StreamingSync {
       Map<String, dynamic>? syncParams}) async {
     final worker = SharedWorker(workerUri.toString().toJS);
     final handle = SyncWorkerHandle._(
-        database: database,
-        connector: connector,
-        crudThrottleTimeMs: crudThrottleTimeMs,
-        sendToWorker: worker.port,
-        worker: worker,
-        syncParams: syncParams);
+      database: database,
+      connector: connector,
+      crudThrottleTimeMs: crudThrottleTimeMs,
+      sendToWorker: worker.port,
+      worker: worker,
+      syncParams: syncParams,
+    );
 
     // Make sure that the worker is working, or throw immediately.
     await handle._channel.ping();

--- a/packages/powersync_core/lib/src/web/sync_worker_protocol.dart
+++ b/packages/powersync_core/lib/src/web/sync_worker_protocol.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:js_interop';
 
+import 'package:logging/logging.dart';
 import 'package:web/web.dart';
 
 import '../connector.dart';
@@ -197,8 +198,6 @@ extension type SerializedSyncStatus._(JSObject _) implements JSObject {
 }
 
 final class WorkerCommunicationChannel {
-  static final _logger = autoLogger;
-
   final Map<int, Completer<JSAny?>> _pendingRequests = {};
   int _nextRequestId = 0;
   bool _hasError = false;
@@ -210,6 +209,7 @@ final class WorkerCommunicationChannel {
       requestHandler;
   final StreamController<(SyncWorkerMessageType, JSAny)> _events =
       StreamController();
+  final Logger _logger;
 
   Stream<(SyncWorkerMessageType, JSAny)> get events => _events.stream;
 
@@ -217,7 +217,8 @@ final class WorkerCommunicationChannel {
     required this.port,
     required this.requestHandler,
     Stream<Event>? errors,
-  }) {
+    Logger? logger,
+  }) : _logger = logger ?? autoLogger {
     port.start();
     _incomingErrors = errors?.listen((event) {
       _hasError = true;


### PR DESCRIPTION
When we use a worker for the streaming sync implementation, we currently have an independent `autoLogger` for that. This makes it impossible for users to customize or disable the logs emitted by the worker.

By re-using the logger from the `PowerSyncDatabase` instead, users can customize the log levels. Closes https://github.com/powersync-ja/powersync.dart/issues/225.

Unfortunately this is hard to test without setting up integration tests as it requires the worker. The fix can be verified manually by applying the snippet suggested in #225 in an example project:

```diff
diff --git a/demos/supabase-todolist/lib/powersync.dart b/demos/supabase-todolist/lib/powersync.dart
index 166de1b..4e1cbf1 100644
--- a/demos/supabase-todolist/lib/powersync.dart
+++ b/demos/supabase-todolist/lib/powersync.dart
@@ -155,8 +155,13 @@ Future<String> getDatabasePath() async {
 
 Future<void> openDatabase() async {
   // Open the local database
+  hierarchicalLoggingEnabled = true;
+  final logger = Logger('PowerSyncLogger')..level = Level.OFF;
   db = PowerSyncDatabase(
-      schema: schema, path: await getDatabasePath(), logger: attachedLogger);
+    schema: schema,
+    path: await getDatabasePath(),
+    logger: logger,
+  );
   await db.initialize();
 
   await loadSupabase();
```