### PR TITLE
Update lints and dependencies in released packages

### DIFF
--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -5,6 +5,7 @@ repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - sync engine for building local-first apps.
 environment:
   sdk: ^3.4.0
+
 dependencies:
   # Needed because of sqlite3_flutter_libs
   flutter:
@@ -17,8 +18,9 @@ dependencies:
   pubspec_parse: ^1.3.0
   args: ^2.5.0
   pub_semver: ^2.1.4
+
 dev_dependencies:
-  lints: ^3.0.0
+  lints: ^5.1.0
   path: ^1.8.3
   path_provider: ^2.0.13
 

--- a/packages/powersync_attachments_helper/analysis_options.yaml
+++ b/packages/powersync_attachments_helper/analysis_options.yaml
@@ -11,7 +11,7 @@
 # (the recommended set includes the core lints).
 # The core lints are also what is used by pub.dev for scoring packages.
 
-include: package:lints/recommended.yaml
+include: package:flutter_lints/flutter.yaml
 
 # Uncomment the following section to specify additional rules.
 

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   path_provider: ^2.0.13
 
 dev_dependencies:
-  lints: ^3.0.0
+  flutter_lints: ^5.0.0
   test: ^1.25.2
 
 platforms:

--- a/packages/powersync_core/pubspec.yaml
+++ b/packages/powersync_core/pubspec.yaml
@@ -20,14 +20,12 @@ dependencies:
   logging: ^1.1.1
   collection: ^1.17.0
   fetch_client: ^1.1.2
-  js: ^0.7.0
   web: ^1.0.0
+
 dev_dependencies:
-  dcli: ^4.0.0
-  lints: ^3.0.0
+  lints: ^5.1.1
   test: ^1.25.0
   test_api: ^0.7.0
-  path_provider: ^2.0.13
   shelf: ^1.4.1
   shelf_router: ^1.1.4
   shelf_static: ^1.1.2

--- a/packages/powersync_core/test/connected_test.dart
+++ b/packages/powersync_core/test/connected_test.dart
@@ -1,4 +1,6 @@
 @TestOn('!browser')
+library;
+
 // This test uses a local server which is possible to control in Web via hybrid main,
 // but this makes the test significantly more complex.
 import 'dart:async';

--- a/packages/powersync_core/test/performance_native_test.dart
+++ b/packages/powersync_core/test/performance_native_test.dart
@@ -1,4 +1,6 @@
 @TestOn('!browser')
+library;
+
 import 'package:powersync_core/powersync_core.dart';
 import 'package:test/test.dart';
 

--- a/packages/powersync_core/test/powersync_native_test.dart
+++ b/packages/powersync_core/test/powersync_native_test.dart
@@ -1,4 +1,6 @@
 @TestOn('!browser')
+library;
+
 import 'dart:async';
 import 'dart:math';
 

--- a/packages/powersync_core/test/server/worker_server.dart
+++ b/packages/powersync_core/test/server/worker_server.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:dcli/dcli.dart';
 import 'package:path/path.dart' as p;
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as io;
@@ -9,8 +8,7 @@ import 'package:stream_channel/stream_channel.dart';
 import 'asset_server.dart';
 
 Future<void> hybridMain(StreamChannel<Object?> channel) async {
-  final assetsDirectory = p
-      .normalize(p.join(DartScript.self.pathToScriptDirectory, '../../assets'));
+  final assetsDirectory = p.normalize('assets');
 
   // Copy sqlite3.wasm file expected by the worker
   final sqliteOutputPath = p.join(assetsDirectory, 'sqlite3.wasm');

--- a/packages/powersync_core/test/stream_test.dart
+++ b/packages/powersync_core/test/stream_test.dart
@@ -1,4 +1,6 @@
 @TestOn('!browser')
+library;
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/packages/powersync_core/test/streaming_sync_test.dart
+++ b/packages/powersync_core/test/streaming_sync_test.dart
@@ -1,4 +1,6 @@
 @TestOn('!browser')
+library;
+
 // TODO setup hybrid server
 import 'dart:async';
 import 'dart:math';

--- a/packages/powersync_core/test/upload_test.dart
+++ b/packages/powersync_core/test/upload_test.dart
@@ -1,4 +1,5 @@
 @TestOn('!browser')
+library;
 
 import 'package:powersync_core/powersync_core.dart';
 import 'package:test/test.dart';

--- a/packages/powersync_core/test/utils/web_test_utils.dart
+++ b/packages/powersync_core/test/utils/web_test_utils.dart
@@ -1,12 +1,12 @@
 import 'dart:async';
-import 'dart:html';
+import 'dart:js_interop';
 
-import 'package:js/js.dart';
 import 'package:logging/logging.dart';
 import 'package:powersync_core/powersync_core.dart';
 import 'package:sqlite_async/sqlite3_common.dart';
 import 'package:sqlite_async/sqlite_async.dart';
 import 'package:test/test.dart';
+import 'package:web/web.dart' show Blob, BlobPropertyBag;
 import 'abstract_test_utils.dart';
 
 @JS('URL.createObjectURL')
@@ -29,8 +29,9 @@ class TestUtils extends AbstractTestUtils {
     // Cross origin workers are not supported, but we can supply a Blob
     final workerUriSource = 'http://localhost:$port/powersync_db.worker.js';
 
-    final blob = Blob(<String>['importScripts("$workerUriSource");'],
-        'application/javascript');
+    final blob = Blob(
+        <JSString>['importScripts("$workerUriSource");'.toJS].toJS,
+        BlobPropertyBag(type: 'application/javascript'));
     workerUri = _createObjectURL(blob);
   }
 

--- a/packages/powersync_core/test/watch_test.dart
+++ b/packages/powersync_core/test/watch_test.dart
@@ -1,5 +1,3 @@
-library;
-
 import 'dart:async';
 import 'dart:math';
 

--- a/packages/powersync_flutter_libs/lib/powersync_flutter_libs.dart
+++ b/packages/powersync_flutter_libs/lib/powersync_flutter_libs.dart
@@ -1,4 +1,4 @@
 /// PowerSync Flutter Libs.
 ///
 /// This provides binary files for the [PowerSync SQLite Rust Core](https://github.com/powersync-ja/powersync-sqlite-core)
-library powersync_flutter_libs;
+library;

--- a/packages/powersync_flutter_libs/pubspec.yaml
+++ b/packages/powersync_flutter_libs/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^3.0.0
+  flutter_lints: ^5.0.0
 
 flutter:
   plugin:

--- a/packages/powersync_sqlcipher/pubspec.yaml
+++ b/packages/powersync_sqlcipher/pubspec.yaml
@@ -15,10 +15,11 @@ dependencies:
   powersync_core: ^1.1.1
   powersync_flutter_libs: ^0.4.4
   sqlcipher_flutter_libs: ^0.6.4
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^3.0.0
+  flutter_lints: ^5.0.0
   test_api: ^0.7.0
   path: ^1.8.3
   path_provider: ^2.0.13


### PR DESCRIPTION
In `package:powersync_core`, migrate away from `package:dcli` and `package:js` so that we're compatible with the latest version of all dependencies.
Apart from that, this updates `package:lints` and fixes the new analysis warnings.