### PR TITLE
Add missing auth configuration for npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,9 @@ jobs:
         with:
           run_install: false
           version: 10
+      - name: Add NPM auth
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{secrets.NPM_TOKEN}}" >> ~/.npmrc
       - name: Publish npm package with WASM files
         working-directory: packages/sqlite3_wasm_build
         run: |


### PR DESCRIPTION
Releasing the npm package for FlutterFlow [failed due to missing auth](https://github.com/powersync-ja/powersync.dart/actions/runs/13386172841). That release is not critical, but adding this step should fix subsequent releases.