### PR TITLE
Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,49 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2025-03-03
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`powersync_core` - `v1.2.0`](#powersync_core---v120)
+ - [`powersync_flutter_libs` - `v0.4.6`](#powersync_flutter_libs---v046)
+ - [`powersync` - `v1.12.0`](#powersync---v1120)
+ - [`powersync_sqlcipher` - `v0.1.5`](#powersync_sqlcipher---v015)
+ - [`powersync_attachments_helper` - `v0.6.18+2`](#powersync_attachments_helper---v06182)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `powersync_attachments_helper` - `v0.6.18+2`
+
+---
+
+#### `powersync_core` - `v1.2.0`
+
+ - Support bucket priorities and partial syncs.
+
+#### `powersync_flutter_libs` - `v0.4.6`
+
+ - Bump version of core extension to 0.3.11
+
+#### `powersync` - `v1.12.0`
+
+ - Support bucket priorities and partial syncs.
+
+#### `powersync_sqlcipher` - `v0.1.5`
+
+ - Support bucket priorities and partial syncs.
+
+
 ## 2025-02-17
 
 ### Changes

--- a/demos/benchmarks/pubspec.yaml
+++ b/demos/benchmarks/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.11.3
+  powersync: ^1.12.0
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.11.3
+  powersync: ^1.12.0
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/firebase-nodejs-todolist/pubspec.yaml
+++ b/demos/firebase-nodejs-todolist/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.11.3
+  powersync: ^1.12.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.11.3
+  powersync: ^1.12.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.11.3
+  powersync: ^1.12.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^2.0.2
   timeago: ^3.6.0
-  powersync: ^1.11.3
+  powersync: ^1.12.0
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist-drift/pubspec.yaml
+++ b/demos/supabase-todolist-drift/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.18+1
-  powersync: ^1.11.3
+  powersync_attachments_helper: ^0.6.18+2
+  powersync: ^1.12.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist-optional-sync/pubspec.yaml
+++ b/demos/supabase-todolist-optional-sync/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.11.3
+  powersync: ^1.12.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist/lib/widgets/todo_list_page.dart
+++ b/demos/supabase-todolist/lib/widgets/todo_list_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:powersync_flutter_demo/models/todo_item.dart';
+import 'package:powersync_flutter_demo/powersync.dart';
 
 import './status_app_bar.dart';
 import './todo_item_dialog.dart';
@@ -81,8 +82,9 @@ class TodoListWidgetState extends State<TodoListWidget> {
   Widget build(BuildContext context) {
     return StreamBuilder(
       stream: TodoList.watchSyncStatus().map((e) => e.hasSynced),
+      initialData: db.currentStatus.hasSynced,
       builder: (context, snapshot) {
-        if (snapshot.data ?? false) {
+        if (snapshot.data != true) {
           return const Text('Busy with sync');
         }
 

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.18+1
-  powersync: ^1.11.3
+  powersync_attachments_helper: ^0.6.18+2
+  powersync: ^1.12.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-trello/pubspec.yaml
+++ b/demos/supabase-trello/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   random_name_generator: ^1.5.0
   flutter_dotenv: ^5.2.1
   logging: ^1.3.0
-  powersync: ^1.11.3
+  powersync: ^1.12.0
   sqlite_async: ^0.11.0
   path_provider: ^2.1.5
   supabase_flutter: ^2.8.3

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.12.0
+
+ - Support bucket priorities and partial syncs.
+
 ## 1.11.3
 
  - Update a dependency to the latest release.

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.11.3
+version: 1.12.0
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - sync engine for building local-first apps.
@@ -12,8 +12,8 @@ dependencies:
     sdk: flutter
 
   sqlite3_flutter_libs: ^0.5.23
-  powersync_core: ^1.1.3
-  powersync_flutter_libs: ^0.4.5
+  powersync_core: ^1.2.0
+  powersync_flutter_libs: ^0.4.6
   collection: ^1.17.0
 
 dev_dependencies:

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.18+2
+
+ - Update a dependency to the latest release.
+
 ## 0.6.18+1
 
  - Update a dependency to the latest release.

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.6.18+1
+version: 0.6.18+2
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync_core: ^1.1.3
+  powersync_core: ^1.2.0
   logging: ^1.2.0
   sqlite_async: ^0.11.0
   path_provider: ^2.0.13

--- a/packages/powersync_core/CHANGELOG.md
+++ b/packages/powersync_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+ - Support bucket priorities and partial syncs.
+
 ## 1.1.3
 
  - Add explicit casts in sync service, avoiding possible issues with dart2js optimizations.

--- a/packages/powersync_core/lib/src/setup_web.dart
+++ b/packages/powersync_core/lib/src/setup_web.dart
@@ -73,7 +73,7 @@ Future<void> downloadWebAssets(List<String> arguments,
 
     if (powerSyncVersion >= firstPowerSyncVersionWithOwnWasm) {
       final wasmUrl =
-          'https://github.com/powersync-ja/powersync.dart/releases/download/powersync-$powersyncTag/$wasmFileName';
+          'https://github.com/powersync-ja/powersync.dart/releases/download/$powersyncTag/$wasmFileName';
 
       await downloadFile(httpClient, wasmUrl, wasmPath);
     } else {

--- a/packages/powersync_core/lib/src/sync_status.dart
+++ b/packages/powersync_core/lib/src/sync_status.dart
@@ -151,7 +151,9 @@ final class SyncStatus {
     return "SyncStatus<connected: $connected connecting: $connecting downloading: $downloading uploading: $uploading lastSyncedAt: $lastSyncedAt, hasSynced: $hasSynced, error: $anyError>";
   }
 
-  static const _statusEquality = ListEquality<SyncPriorityStatus>();
+  // This should be a ListEquality<SyncPriorityStatus>, but that appears to
+  // cause weird type errors with DDC (but only after hot reloads?!)
+  static const _statusEquality = ListEquality<Object?>();
 }
 
 /// The priority of a PowerSync bucket.

--- a/packages/powersync_core/lib/src/version.dart
+++ b/packages/powersync_core/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String libraryVersion = '1.1.3';
+const String libraryVersion = '1.2.0';

--- a/packages/powersync_core/lib/src/web/sync_worker_protocol.dart
+++ b/packages/powersync_core/lib/src/web/sync_worker_protocol.dart
@@ -203,7 +203,9 @@ extension type SerializedSyncStatus._(JSObject _) implements JSObject {
       hasSynced: hasSynced,
       uploadError: uploadError,
       downloadError: downloadError,
-      priorityStatusEntries: priorityStatusEntries?.toDart.map((e) {
+      priorityStatusEntries: <SyncPriorityStatus>[
+        if (priorityStatusEntries case final jsEntries?)
+          ...jsEntries.toDart.map((e) {
             final [rawPriority, rawSynced, rawHasSynced, ...] =
                 (e as JSArray).toDart;
             final syncedMillis = (rawSynced as JSNumber?)?.toDartInt;
@@ -215,8 +217,8 @@ extension type SerializedSyncStatus._(JSObject _) implements JSObject {
                   : null,
               hasSynced: (rawHasSynced as JSBoolean?)?.toDart,
             );
-          }).toList() ??
-          const [],
+          })
+      ],
     );
   }
 }

--- a/packages/powersync_core/pubspec.yaml
+++ b/packages/powersync_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync_core
-version: 1.1.3
+version: 1.2.0
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Dart SDK - sync engine for building local-first apps.

--- a/packages/powersync_flutter_libs/CHANGELOG.md
+++ b/packages/powersync_flutter_libs/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.6
+
+ - Bump version of core extension to 0.3.11
+
 ## 0.4.5
 
  - Update core extension to 0.3.10 in preparation for bucket priorities.

--- a/packages/powersync_flutter_libs/pubspec.yaml
+++ b/packages/powersync_flutter_libs/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_flutter_libs
 description: PowerSync core binaries for the PowerSync Flutter SDK. Needs to be included for Flutter apps.
-version: 0.4.5
+version: 0.4.6
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 

--- a/packages/powersync_sqlcipher/CHANGELOG.md
+++ b/packages/powersync_sqlcipher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.5
+
+ - Support bucket priorities and partial syncs.
+
 ## 0.1.4+1
 
  - Update a dependency to the latest release.

--- a/packages/powersync_sqlcipher/pubspec.yaml
+++ b/packages/powersync_sqlcipher/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync_sqlcipher
-version: 0.1.4+1
+version: 0.1.5
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - sync engine for building local-first apps.
@@ -12,8 +12,8 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync_core: ^1.1.3
-  powersync_flutter_libs: ^0.4.5
+  powersync_core: ^1.2.0
+  powersync_flutter_libs: ^0.4.6
   sqlcipher_flutter_libs: ^0.6.4
   sqlite3_web: ^0.3.0
 


### PR DESCRIPTION
First, I've fixed a weird issue we had when running demos with the DDC compiler through `flutter run`. After a hot reloads, we got weird type errors because the list of partial priority entries suddenly had an unexpected type. Given that it only happens after reloads and only on the web, I'll call this a compiler bug. I was unable to reproduce it in a smaller project, but I found a workaround that is applied here (making the `ListEquality` instance for `SyncStatus` more broad than necessary, and avoiding a constant list of entries when reading priority entries from workers).
I've also fixed a regression I've introduced in the supabase todolist example that showed the "Busy with sync" message precisely when it wasn't supposed to show...

Apart from that, this adds a minor version bump to `powersync_core`, `powersync` and `powersync_sqlcipher` to release those packages with support for bucket priorities.