### PR TITLE
Fix broken token invalidation on web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2025-03-11
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`powersync_core` - `v1.2.2`](#powersync_core---v122)
+ - [`powersync_attachments_helper` - `v0.6.18+4`](#powersync_attachments_helper---v06184)
+ - [`powersync_sqlcipher` - `v0.1.5+2`](#powersync_sqlcipher---v0152)
+ - [`powersync` - `v1.12.2`](#powersync---v1122)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `powersync_attachments_helper` - `v0.6.18+4`
+ - `powersync_sqlcipher` - `v0.1.5+2`
+ - `powersync` - `v1.12.2`
+
+---
+
+#### `powersync_core` - `v1.2.2`
+
+ - Fix handling token invalidation on the web.
+
+
 ## 2025-03-06
 
 ### Changes

--- a/demos/benchmarks/pubspec.yaml
+++ b/demos/benchmarks/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.12.1
+  powersync: ^1.12.2
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.12.1
+  powersync: ^1.12.2
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/firebase-nodejs-todolist/pubspec.yaml
+++ b/demos/firebase-nodejs-todolist/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.12.1
+  powersync: ^1.12.2
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.12.1
+  powersync: ^1.12.2
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.12.1
+  powersync: ^1.12.2
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^2.0.2
   timeago: ^3.6.0
-  powersync: ^1.12.1
+  powersync: ^1.12.2
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist-drift/pubspec.yaml
+++ b/demos/supabase-todolist-drift/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.18+3
-  powersync: ^1.12.1
+  powersync_attachments_helper: ^0.6.18+4
+  powersync: ^1.12.2
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist-optional-sync/pubspec.yaml
+++ b/demos/supabase-todolist-optional-sync/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.12.1
+  powersync: ^1.12.2
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.18+3
-  powersync: ^1.12.1
+  powersync_attachments_helper: ^0.6.18+4
+  powersync: ^1.12.2
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-trello/pubspec.yaml
+++ b/demos/supabase-trello/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   random_name_generator: ^1.5.0
   flutter_dotenv: ^5.2.1
   logging: ^1.3.0
-  powersync: ^1.12.1
+  powersync: ^1.12.2
   sqlite_async: ^0.11.0
   path_provider: ^2.1.5
   supabase_flutter: ^2.8.3

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.12.2
+
+ - Update a dependency to the latest release.
+
 ## 1.12.1
 
  - Update a dependency to the latest release.

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.12.1
+version: 1.12.2
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - sync engine for building local-first apps.
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
 
   sqlite3_flutter_libs: ^0.5.23
-  powersync_core: ^1.2.1
+  powersync_core: ^1.2.2
   powersync_flutter_libs: ^0.4.7
   collection: ^1.17.0
 

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.18+4
+
+ - Update a dependency to the latest release.
+
 ## 0.6.18+3
 
  - Update a dependency to the latest release.

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.6.18+3
+version: 0.6.18+4
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync_core: ^1.2.1
+  powersync_core: ^1.2.2
   logging: ^1.2.0
   sqlite_async: ^0.11.0
   path_provider: ^2.0.13

--- a/packages/powersync_core/CHANGELOG.md
+++ b/packages/powersync_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.2
+
+ - Fix handling token invalidation on the web.
+
 ## 1.2.1
 
  - Raise minimum version of core extension to 0.3.11.

--- a/packages/powersync_core/lib/src/database/web/web_powersync_database.dart
+++ b/packages/powersync_core/lib/src/database/web/web_powersync_database.dart
@@ -162,7 +162,7 @@ class PowerSyncDatabaseImpl
       sync = StreamingSyncImplementation(
         adapter: storage,
         credentialsCallback: connector.getCredentialsCached,
-        invalidCredentialsCallback: connector.fetchCredentials,
+        invalidCredentialsCallback: connector.prefetchCredentials,
         uploadCrud: () => connector.uploadData(this),
         crudUpdateTriggerStream: crudStream,
         retryDelay: Duration(seconds: 3),

--- a/packages/powersync_core/lib/src/version.dart
+++ b/packages/powersync_core/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String libraryVersion = '1.2.1';
+const String libraryVersion = '1.2.2';

--- a/packages/powersync_core/lib/src/web/sync_controller.dart
+++ b/packages/powersync_core/lib/src/web/sync_controller.dart
@@ -48,7 +48,7 @@ class SyncWorkerHandle implements StreamingSync {
             await connector.uploadData(database);
             return (JSObject(), null);
           case SyncWorkerMessageType.invalidCredentialsCallback:
-            final credentials = await connector.fetchCredentials();
+            final credentials = await connector.prefetchCredentials();
             return (
               credentials != null
                   ? SerializedCredentials.from(credentials)

--- a/packages/powersync_core/pubspec.yaml
+++ b/packages/powersync_core/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   # but right now we need a minimum of v2.4.6.
   sqlite3: ^2.4.6
   # We implement a database controller, which is an interface of sqlite3_web.
-  sqlite3_web: ^0.3.0
+  sqlite3_web: ^0.3.1
   universal_io: ^2.0.0
   meta: ^1.0.0
   http: ^1.1.0

--- a/packages/powersync_core/pubspec.yaml
+++ b/packages/powersync_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync_core
-version: 1.2.1
+version: 1.2.2
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Dart SDK - sync engine for building local-first apps.

--- a/packages/powersync_sqlcipher/CHANGELOG.md
+++ b/packages/powersync_sqlcipher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.5+2
+
+ - Update a dependency to the latest release.
+
 ## 0.1.5+1
 
  - Update a dependency to the latest release.

--- a/packages/powersync_sqlcipher/pubspec.yaml
+++ b/packages/powersync_sqlcipher/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync_sqlcipher
-version: 0.1.5+1
+version: 0.1.5+2
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - sync engine for building local-first apps.
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync_core: ^1.2.1
+  powersync_core: ^1.2.2
   powersync_flutter_libs: ^0.4.7
   sqlcipher_flutter_libs: ^0.6.4
   sqlite3_web: ^0.3.0


### PR DESCRIPTION
This fixes the issue [reported here](https://discord.com/channels/1138230179878154300/1344044450191773746). When the sync service calls `invalidCredentialsCallback`, the app should fetch new credentials which are then cached by the connector. For this, we need to call `prefetchCredentials`. `fetchCredentials`, the method we used to call, obtains credentials without saving them.

We were already calling `prefetchCredentials` on native platforms, but the web implementation was broken and never refreshed the token. This caused us to keep using the expired token, entering an infinite loop of 401 errors.