### PR TITLE
Warn on duplicate database instances

### DIFF
--- a/packages/powersync_core/lib/src/database/active_instances.dart
+++ b/packages/powersync_core/lib/src/database/active_instances.dart
@@ -1,0 +1,40 @@
+import 'package:meta/meta.dart';
+import 'package:sqlite_async/sqlite_async.dart';
+
+/// A collection of PowerSync database instances that are using the same
+/// underlying SQLite database.
+///
+/// We expect that each group will only ever have one database because we
+/// encourage users to manage their databases as singletons. So, we print a
+/// warning when two databases are part of the same group.
+///
+/// This can only detect two database instances being opened on the same
+/// isolate, we can't provide these checks acros isolates. Since most users
+/// aren't opening databases on background isolates though, this still guards
+/// against most misuses.
+@internal
+final class ActiveDatabaseGroup {
+  int refCount = 0;
+
+  /// Use to prevent multiple connections from being opened concurrently
+  final Mutex syncConnectMutex = Mutex();
+  final String identifier;
+
+  ActiveDatabaseGroup._(this.identifier);
+
+  void close() {
+    if (--refCount == 0) {
+      final removedGroup = _activeGroups.remove(identifier);
+      assert(removedGroup == this);
+    }
+  }
+
+  static final Map<String, ActiveDatabaseGroup> _activeGroups = {};
+
+  static ActiveDatabaseGroup referenceDatabase(String identifier) {
+    final group = _activeGroups.putIfAbsent(
+        identifier, () => ActiveDatabaseGroup._(identifier));
+    group.refCount++;
+    return group;
+  }
+}

--- a/packages/powersync_core/lib/src/database/powersync_database.dart
+++ b/packages/powersync_core/lib/src/database/powersync_database.dart
@@ -73,6 +73,6 @@ abstract class PowerSyncDatabase
       required SqliteDatabase database,
       Logger? loggers}) {
     return PowerSyncDatabaseImpl.withDatabase(
-        schema: schema, database: database);
+        schema: schema, database: database, logger: loggers);
   }
 }

--- a/packages/powersync_core/lib/src/database/powersync_database_impl_stub.dart
+++ b/packages/powersync_core/lib/src/database/powersync_database_impl_stub.dart
@@ -80,7 +80,7 @@ class PowerSyncDatabaseImpl
   factory PowerSyncDatabaseImpl.withDatabase(
       {required Schema schema,
       required SqliteDatabase database,
-      Logger? loggers}) {
+      Logger? logger}) {
     throw UnimplementedError();
   }
 

--- a/packages/powersync_core/lib/src/database/web/web_powersync_database.dart
+++ b/packages/powersync_core/lib/src/database/web/web_powersync_database.dart
@@ -37,8 +37,6 @@ class PowerSyncDatabaseImpl
   @override
   SqliteDatabase database;
 
-  late final DefaultSqliteOpenFactory openFactory;
-
   @override
   @protected
   late Future<void> isInitialized;
@@ -95,8 +93,7 @@ class PowerSyncDatabaseImpl
       Logger? logger}) {
     final db = SqliteDatabase.withFactory(openFactory, maxReaders: 1);
     return PowerSyncDatabaseImpl.withDatabase(
-        schema: schema, logger: logger, database: db)
-      ..openFactory = openFactory;
+        schema: schema, logger: logger, database: db);
   }
 
   /// Open a PowerSyncDatabase on an existing [SqliteDatabase].

--- a/packages/powersync_core/lib/src/web/sync_controller.dart
+++ b/packages/powersync_core/lib/src/web/sync_controller.dart
@@ -115,6 +115,6 @@ class SyncWorkerHandle implements StreamingSync {
   @override
   Future<void> streamingSync() async {
     await _channel.startSynchronization(
-        database.openFactory.path, crudThrottleTimeMs, syncParams);
+        database.database.openFactory.path, crudThrottleTimeMs, syncParams);
   }
 }

--- a/packages/powersync_core/test/in_memory_sync_test.dart
+++ b/packages/powersync_core/test/in_memory_sync_test.dart
@@ -15,6 +15,8 @@ import 'utils/in_memory_http.dart';
 import 'utils/test_utils_impl.dart';
 
 void main() {
+  final ignoredLogger = Logger.detached('powersync.test')..level = Level.OFF;
+
   group('in-memory sync tests', () {
     late final testUtils = TestUtils();
 
@@ -100,7 +102,8 @@ void main() {
       await expectLater(
           status, emits(isSyncStatus(downloading: false, hasSynced: true)));
 
-      final independentDb = factory.wrapRaw(raw);
+      final independentDb = factory.wrapRaw(raw, logger: ignoredLogger);
+      addTearDown(independentDb.close);
       // Even though this database doesn't have a sync client attached to it,
       // is should reconstruct hasSynced from the database.
       await independentDb.initialize();
@@ -272,7 +275,8 @@ void main() {
         await database.waitForFirstSync(priority: BucketPriority(1));
         expect(database.currentStatus.hasSynced, isFalse);
 
-        final independentDb = factory.wrapRaw(raw);
+        final independentDb = factory.wrapRaw(raw, logger: ignoredLogger);
+        addTearDown(independentDb.close);
         await independentDb.initialize();
         expect(independentDb.currentStatus.hasSynced, isFalse);
         // Completing a sync for prio 1 implies a completed sync for prio 0

--- a/packages/powersync_core/test/utils/abstract_test_utils.dart
+++ b/packages/powersync_core/test/utils/abstract_test_utils.dart
@@ -5,6 +5,7 @@ import 'package:powersync_core/src/bucket_storage.dart';
 import 'package:powersync_core/src/streaming_sync.dart';
 import 'package:sqlite_async/sqlite3_common.dart';
 import 'package:sqlite_async/sqlite_async.dart';
+import 'package:test/test.dart';
 import 'package:test_api/src/backend/invoker.dart';
 
 const schema = Schema([
@@ -63,11 +64,15 @@ abstract mixin class TestPowerSyncFactory implements PowerSyncOpenFactory {
     return (raw, wrapRaw(raw));
   }
 
-  PowerSyncDatabase wrapRaw(CommonDatabase raw) {
+  PowerSyncDatabase wrapRaw(
+    CommonDatabase raw, {
+    Logger? logger,
+  }) {
     return PowerSyncDatabase.withDatabase(
       schema: schema,
       database: SqliteDatabase.singleConnection(
           SqliteConnection.synchronousWrapper(raw)),
+      loggers: logger,
     );
   }
 }
@@ -95,6 +100,7 @@ abstract class AbstractTestUtils {
         schema: schema ?? defaultSchema,
         logger: logger ?? _makeTestLogger(name: _testName));
     await db.initialize();
+    addTearDown(db.close);
     return db;
   }
 

--- a/packages/powersync_core/test/utils/native_test_utils.dart
+++ b/packages/powersync_core/test/utils/native_test_utils.dart
@@ -19,7 +19,8 @@ class TestOpenFactory extends PowerSyncOpenFactory with TestPowerSyncFactory {
       return DynamicLibrary.open('libsqlite3.so.0');
     });
     sqlite_open.open.overrideFor(sqlite_open.OperatingSystem.macOS, () {
-      return DynamicLibrary.open('libsqlite3.dylib');
+      return DynamicLibrary.open(
+          '/opt/homebrew/opt/sqlite/lib/libsqlite3.dylib');
     });
   }
 

--- a/packages/powersync_core/test/utils/web_test_utils.dart
+++ b/packages/powersync_core/test/utils/web_test_utils.dart
@@ -78,7 +78,7 @@ class TestUtils extends AbstractTestUtils {
   Future<PowerSyncDatabase> setupPowerSync(
       {String? path, Schema? schema, Logger? logger}) async {
     await _isInitialized;
-    return super.setupPowerSync(path: path, schema: schema);
+    return super.setupPowerSync(path: path, schema: schema, logger: logger);
   }
 
   @override


### PR DESCRIPTION
Opening two PowerSync databases at the same path can cause all kinds of issues, the two most prominent being:

- "Database is locked" errors due to two concurrent writers.
- Excessive sync downloads due to two clients being active at the same time without coordination.

This ports the `ActiveDatabaseGroup` check we have in the Kotlin SDK to Dart, warning on the database logger when two instances of a database at the same path are active at the same time.

This alone doesn't give us perfect safety, because the static field is local to the each isolate. So opening a second PowerSync database (... and connecting it) on a background isolate would not be caught by this, but that's a fairly rare case and this check fixes most issues.