### PR TITLE
Relax fileExtension requirement in attachmentQueue

### DIFF
--- a/demos/supabase-todolist-drift/lib/attachments/queue.dart
+++ b/demos/supabase-todolist-drift/lib/attachments/queue.dart
@@ -68,7 +68,7 @@ class PhotoAttachmentQueue extends AbstractAttachmentQueue {
   }
 
   @override
-  StreamSubscription<void> watchIds({String fileExtension = 'jpg'}) {
+  StreamSubscription<void> watchIds({String? fileExtension}) {
     log.info('Watching photos in $todosTable...');
     return db.watch('''
       SELECT photo_id FROM $todosTable

--- a/demos/supabase-todolist/lib/attachments/queue.dart
+++ b/demos/supabase-todolist/lib/attachments/queue.dart
@@ -68,7 +68,7 @@ class PhotoAttachmentQueue extends AbstractAttachmentQueue {
   }
 
   @override
-  StreamSubscription<void> watchIds({String fileExtension = 'jpg'}) {
+  StreamSubscription<void> watchIds({String? fileExtension}) {
     log.info('Watching photos in $todosTable...');
     return db.watch('''
       SELECT photo_id FROM $todosTable

--- a/packages/powersync_attachments_helper/README.md
+++ b/packages/powersync_attachments_helper/README.md
@@ -62,7 +62,7 @@ class PhotoAttachmentQueue extends AbstractAttachmentQueue {
   // This watcher will handle adding items to the queue based on
   // a users table element receiving a photoId
   @override
-  StreamSubscription<void> watchIds({String fileExtension = 'jpg'}) {
+  StreamSubscription<void> watchIds({String? fileExtension}) {
     return db.watch('''
       SELECT photo_id FROM users
       WHERE photo_id IS NOT NULL

--- a/packages/powersync_attachments_helper/example/getting_started.dart
+++ b/packages/powersync_attachments_helper/example/getting_started.dart
@@ -46,7 +46,7 @@ class PhotoAttachmentQueue extends AbstractAttachmentQueue {
   }
 
   @override
-  StreamSubscription<void> watchIds({String fileExtension = 'jpg'}) {
+  StreamSubscription<void> watchIds({String? fileExtension}) {
     return db.watch('''
       SELECT photo_id FROM users
       WHERE photo_id IS NOT NULL

--- a/packages/powersync_attachments_helper/lib/src/attachments_queue.dart
+++ b/packages/powersync_attachments_helper/lib/src/attachments_queue.dart
@@ -59,7 +59,7 @@ abstract class AbstractAttachmentQueue {
 
   /// Create watcher to get list of ID's from a table to be used for syncing in the attachment queue.
   /// Set the file extension if you are using a different file type
-  StreamSubscription<void> watchIds({String fileExtension = 'jpg'});
+  StreamSubscription<void> watchIds({String? fileExtension});
 
   /// Create a function to save files using the attachment queue
   Future<Attachment> saveFile(String fileId, int size);
@@ -82,7 +82,7 @@ abstract class AbstractAttachmentQueue {
       }
     }
 
-    watchIds();
+    watchIds(fileExtension: 'jpg');
     syncingService.watchAttachments();
     syncingService.startPeriodicSync(intervalInMinutes);
 

--- a/packages/powersync_attachments_helper/lib/src/attachments_queue.dart
+++ b/packages/powersync_attachments_helper/lib/src/attachments_queue.dart
@@ -41,6 +41,10 @@ abstract class AbstractAttachmentQueue {
   /// when the attachment queue is initialized.
   List<String>? subdirectories;
 
+  /// File extension to be used for the attachments queue
+  /// Can be left null if no extension is used or if extension is part of the filename
+  String? fileExtension;
+
   AbstractAttachmentQueue(
       {required this.db,
       required this.remoteStorage,
@@ -49,7 +53,8 @@ abstract class AbstractAttachmentQueue {
       this.onDownloadError,
       this.onUploadError,
       this.intervalInMinutes = 5,
-      this.subdirectories}) {
+      this.subdirectories,
+      this.fileExtension}) {
     attachmentsService = AttachmentsService(
         db, localStorage, attachmentDirectoryName, attachmentsQueueTableName);
     syncingService = SyncingService(
@@ -82,7 +87,7 @@ abstract class AbstractAttachmentQueue {
       }
     }
 
-    watchIds(fileExtension: 'jpg');
+    watchIds(fileExtension: fileExtension);
     syncingService.watchAttachments();
     syncingService.startPeriodicSync(intervalInMinutes);
 

--- a/packages/powersync_attachments_helper/lib/src/local_storage_adapter.dart
+++ b/packages/powersync_attachments_helper/lib/src/local_storage_adapter.dart
@@ -5,6 +5,7 @@ import 'package:path_provider/path_provider.dart';
 /// Storage adapter for local storage
 class LocalStorageAdapter {
   Future<File> saveFile(String fileUri, Uint8List data) async {
+    await makeDir(fileUri);
     final file = File(fileUri);
     return await file.writeAsBytes(data);
   }
@@ -36,6 +37,7 @@ class LocalStorageAdapter {
   }
 
   Future<void> copyFile(String sourceUri, String targetUri) async {
+    await makeDir(targetUri);
     File file = File(sourceUri);
     await file.copy(targetUri);
   }

--- a/packages/powersync_attachments_helper/lib/src/syncing_service.dart
+++ b/packages/powersync_attachments_helper/lib/src/syncing_service.dart
@@ -165,11 +165,12 @@ class SyncingService {
   }
 
   /// Process ID's to be included in the attachment queue.
-  Future<void> processIds(List<String> ids, String fileExtension) async {
+  Future<void> processIds(List<String> ids, String? fileExtension) async {
     List<Attachment> attachments = List.empty(growable: true);
 
     for (String id in ids) {
-      String path = await getLocalUri('$id.$fileExtension');
+      String filename = fileExtension != null ? '$id.$fileExtension' : id;
+      String path = await getLocalUri(filename);
       File file = File(path);
       bool fileExists = await file.exists();
 
@@ -180,7 +181,7 @@ class SyncingService {
       log.info('Adding $id to queue');
       attachments.add(Attachment(
           id: id,
-          filename: '$id.$fileExtension',
+          filename: filename,
           state: AttachmentState.queuedDownload.index));
     }
 


### PR DESCRIPTION
Hello powersync team 👋

This PR fixes #268 and updates the watchIds method in the Attachments helper to make the fileExtension parameter optional. This enables support for storing files with different extensions in the same attachmentQueue, which is useful in cases where:

- The extension is already part of the filename (e.g., managed directly in the storage bucket like Supabase).
- The developer wants more flexibility in handling mixed file types under a unified queue.

Motivation: Currently, the API assumes a single extension per queue, which limits use cases that involve multiple file types. Making fileExtension optional opens up broader usage while maintaining backward compatibility.

⚠️ This includes a breaking change. And along that, I'm wondering if it shouldn't be pushed further to be able to specify a Map<String, String?> for <filename, extension?> in the whatchIds to allow even more flexibility and usecases. 

This change was inspired by this [Discord thread](https://discord.com/channels/1138230179878154300/1362146693457379572).

WDYT? Looking forward to feedback!

PS: There is also a change about ensuring directory creation. In my usecase, I'm using Teams' ids as subdirectory so it's fully dynamic and my filename is like the following: 
`{teamId}/{attachmentType}/{attachmentId}.{attachmentExtension}`. 