### PR TITLE
Fix deadlock on immediate connect call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2025-04-24
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`powersync_core` - `v1.2.4`](#powersync_core---v124)
+ - [`powersync_attachments_helper` - `v0.6.18+6`](#powersync_attachments_helper---v06186)
+ - [`powersync_sqlcipher` - `v0.1.5+4`](#powersync_sqlcipher---v0154)
+ - [`powersync` - `v1.12.4`](#powersync---v1124)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `powersync_attachments_helper` - `v0.6.18+6`
+ - `powersync_sqlcipher` - `v0.1.5+4`
+ - `powersync` - `v1.12.4`
+
+---
+
+#### `powersync_core` - `v1.2.4`
+
+ - Fix deadlock when `connect()` is called immediately after opening a database.
+
+
 ## 2025-04-22
 
 ### Changes

--- a/demos/benchmarks/pubspec.yaml
+++ b/demos/benchmarks/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.12.3
+  powersync: ^1.12.4
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.12.3
+  powersync: ^1.12.4
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/firebase-nodejs-todolist/pubspec.yaml
+++ b/demos/firebase-nodejs-todolist/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.12.3
+  powersync: ^1.12.4
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.12.3
+  powersync: ^1.12.4
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.12.3
+  powersync: ^1.12.4
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^2.0.2
   timeago: ^3.6.0
-  powersync: ^1.12.3
+  powersync: ^1.12.4
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist-drift/pubspec.yaml
+++ b/demos/supabase-todolist-drift/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.18+5
-  powersync: ^1.12.3
+  powersync_attachments_helper: ^0.6.18+6
+  powersync: ^1.12.4
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist-optional-sync/pubspec.yaml
+++ b/demos/supabase-todolist-optional-sync/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.12.3
+  powersync: ^1.12.4
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.18+5
-  powersync: ^1.12.3
+  powersync_attachments_helper: ^0.6.18+6
+  powersync: ^1.12.4
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-trello/pubspec.yaml
+++ b/demos/supabase-trello/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   random_name_generator: ^1.5.0
   flutter_dotenv: ^5.2.1
   logging: ^1.3.0
-  powersync: ^1.12.3
+  powersync: ^1.12.4
   sqlite_async: ^0.11.0
   path_provider: ^2.1.5
   supabase_flutter: ^2.8.3

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.12.4
+
+ - Update a dependency to the latest release.
+
 ## 1.12.3
 
 This updates `powersync_core` to version `1.2.3`, which includes these changes:

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.12.3
+version: 1.12.4
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK. Sync Postgres, MongoDB or MySQL with SQLite in your Flutter app
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
 
   sqlite3_flutter_libs: ^0.5.23
-  powersync_core: ^1.2.3
+  powersync_core: ^1.2.4
   powersync_flutter_libs: ^0.4.7
   collection: ^1.17.0
 

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.18+6
+
+ - Update a dependency to the latest release.
+
 ## 0.6.18+5
 
  - Update a dependency to the latest release.

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.6.18+5
+version: 0.6.18+6
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync_core: ^1.2.3
+  powersync_core: ^1.2.4
   logging: ^1.2.0
   sqlite_async: ^0.11.0
   path_provider: ^2.0.13

--- a/packages/powersync_core/CHANGELOG.md
+++ b/packages/powersync_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.4
+
+ - Fix deadlock when `connect()` is called immediately after opening a database.
+
 ## 1.2.3
 
  - Introduce locks to avoid duplicate sync streams when multiple instances of the same database are opened.

--- a/packages/powersync_core/lib/src/database/native/native_powersync_database.dart
+++ b/packages/powersync_core/lib/src/database/native/native_powersync_database.dart
@@ -122,7 +122,6 @@ class PowerSyncDatabaseImpl
     required AbortController abort,
     Map<String, dynamic>? params,
   }) async {
-    await initialize();
     final dbRef = database.isolateConnectionFactory();
 
     bool triedSpawningIsolate = false;

--- a/packages/powersync_core/lib/src/database/powersync_db_mixin.dart
+++ b/packages/powersync_core/lib/src/database/powersync_db_mixin.dart
@@ -264,6 +264,11 @@ mixin PowerSyncDatabaseMixin implements SqliteConnection {
     Duration crudThrottleTime = const Duration(milliseconds: 10),
     Map<String, dynamic>? params,
   }) async {
+    // The initialization process acquires a sync connect lock (through
+    // updateSchema), so ensure the database is ready before we try to acquire
+    // the lock for the connection.
+    await initialize();
+
     clientParams = params;
     var thisConnectAborter = AbortController();
 

--- a/packages/powersync_core/lib/src/database/web/web_powersync_database.dart
+++ b/packages/powersync_core/lib/src/database/web/web_powersync_database.dart
@@ -118,8 +118,6 @@ class PowerSyncDatabaseImpl
     required AbortController abort,
     Map<String, dynamic>? params,
   }) async {
-    await initialize();
-
     final crudStream =
         database.onChange(['ps_crud'], throttle: crudThrottleTime);
 

--- a/packages/powersync_core/lib/src/version.dart
+++ b/packages/powersync_core/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String libraryVersion = '1.2.3';
+const String libraryVersion = '1.2.4';

--- a/packages/powersync_core/pubspec.yaml
+++ b/packages/powersync_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync_core
-version: 1.2.3
+version: 1.2.4
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Dart SDK - sync engine for building local-first apps.

--- a/packages/powersync_core/test/streaming_sync_test.dart
+++ b/packages/powersync_core/test/streaming_sync_test.dart
@@ -61,6 +61,25 @@ void main() {
       server.close();
     });
 
+    test('can connect as initial operation', () async {
+      final server = await createServer();
+      final ignoreLogger = Logger.detached('powersync.test');
+
+      final pdb = await testUtils.setupPowerSync(
+          path: path, logger: ignoreLogger, initialize: false);
+      pdb.retryDelay = Duration(milliseconds: 5000);
+
+      await pdb.connect(connector: TestConnector(() async {
+        return PowerSyncCredentials(endpoint: server.endpoint, token: 'token');
+      }));
+
+      await expectLater(
+        pdb.statusStream,
+        emitsThrough(
+            isA<SyncStatus>().having((e) => e.connected, 'connected', isTrue)),
+      );
+    });
+
     test('full powersync reconnect', () async {
       // Test repeatedly creating new PowerSync connections, then disconnect
       // and close the connection.

--- a/packages/powersync_core/test/utils/abstract_test_utils.dart
+++ b/packages/powersync_core/test/utils/abstract_test_utils.dart
@@ -94,12 +94,18 @@ abstract class AbstractTestUtils {
       SqliteOptions options = const SqliteOptions.defaults()});
 
   /// Creates a SqliteDatabaseConnection
-  Future<PowerSyncDatabase> setupPowerSync(
-      {String? path, Schema? schema, Logger? logger}) async {
+  Future<PowerSyncDatabase> setupPowerSync({
+    String? path,
+    Schema? schema,
+    Logger? logger,
+    bool initialize = true,
+  }) async {
     final db = PowerSyncDatabase.withFactory(await testFactory(path: path),
         schema: schema ?? defaultSchema,
         logger: logger ?? _makeTestLogger(name: _testName));
-    await db.initialize();
+    if (initialize) {
+      await db.initialize();
+    }
     addTearDown(db.close);
     return db;
   }

--- a/packages/powersync_core/test/utils/web_test_utils.dart
+++ b/packages/powersync_core/test/utils/web_test_utils.dart
@@ -76,9 +76,13 @@ class TestUtils extends AbstractTestUtils {
 
   @override
   Future<PowerSyncDatabase> setupPowerSync(
-      {String? path, Schema? schema, Logger? logger}) async {
+      {String? path,
+      Schema? schema,
+      Logger? logger,
+      bool initialize = true}) async {
     await _isInitialized;
-    return super.setupPowerSync(path: path, schema: schema, logger: logger);
+    return super.setupPowerSync(
+        path: path, schema: schema, logger: logger, initialize: initialize);
   }
 
   @override

--- a/packages/powersync_sqlcipher/CHANGELOG.md
+++ b/packages/powersync_sqlcipher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.5+4
+
+ - Update a dependency to the latest release.
+
 ## 0.1.5+3
 
 This updates `powersync_core` to version `1.2.3`, which includes these changes:

--- a/packages/powersync_sqlcipher/pubspec.yaml
+++ b/packages/powersync_sqlcipher/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync_sqlcipher
-version: 0.1.5+3
+version: 0.1.5+4
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - sync engine for building local-first apps.
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync_core: ^1.2.3
+  powersync_core: ^1.2.4
   powersync_flutter_libs: ^0.4.7
   sqlcipher_flutter_libs: ^0.6.4
   sqlite3_web: ^0.3.0


### PR DESCRIPTION
In the `connectInternal()` method used to establish a connection to the sync service, we await `initialize()`. That can be a problem when `connect()` is the first call on the database, because writing the schema also acquires the lock used to guard `connectInternal()`.

This fixes the issue by awaiting `initialize()` in `connect()`, before acquiring the sync connect lock and calling `initialize()`. I've also added a test calling `connect()` immediately after opening the database to validate this.

This is the second time I get to fix this [exact regression](https://github.com/powersync-ja/powersync-kotlin/pull/170), yikes 😬 At least in Kotlin we've not seen too many concurrency issues after that though...