### PR TITLE
Add new schema options

### DIFF
--- a/packages/powersync_core/lib/src/crud.dart
+++ b/packages/powersync_core/lib/src/crud.dart
@@ -73,7 +73,7 @@ class CrudEntry {
   /// An optional metadata string attached to this entry at the time the write
   /// has been issued.
   ///
-  /// For tables where [Table.includeMetadata] is enabled, a hidden `_metadata`
+  /// For tables where [Table.trackMetadata] is enabled, a hidden `_metadata`
   /// column is added to this table that can be used during updates to attach
   /// a hint to the update thas is preserved here.
   final String? metadata;
@@ -90,7 +90,7 @@ class CrudEntry {
   /// Old values before an update.
   ///
   /// This is only tracked for tables for which this has been enabled by setting
-  /// the [Table.includeOld].
+  /// the [Table.trackPreviousValues].
   final Map<String, dynamic>? oldData;
 
   CrudEntry(

--- a/packages/powersync_core/lib/src/crud.dart
+++ b/packages/powersync_core/lib/src/crud.dart
@@ -91,7 +91,7 @@ class CrudEntry {
   ///
   /// This is only tracked for tables for which this has been enabled by setting
   /// the [Table.trackPreviousValues].
-  final Map<String, dynamic>? oldData;
+  final Map<String, dynamic>? previousValues;
 
   CrudEntry(
     this.clientId,
@@ -100,7 +100,7 @@ class CrudEntry {
     this.id,
     this.transactionId,
     this.opData, {
-    this.oldData,
+    this.previousValues,
     this.metadata,
   });
 
@@ -113,7 +113,7 @@ class CrudEntry {
       data['id'] as String,
       row['tx_id'] as int,
       data['data'] as Map<String, Object?>?,
-      oldData: data['old'] as Map<String, Object?>?,
+      previousValues: data['old'] as Map<String, Object?>?,
       metadata: data['metadata'] as String?,
     );
   }
@@ -128,7 +128,7 @@ class CrudEntry {
       'tx_id': transactionId,
       'data': opData,
       'metadata': metadata,
-      'old': oldData,
+      'old': previousValues,
     };
   }
 

--- a/packages/powersync_core/lib/src/crud.dart
+++ b/packages/powersync_core/lib/src/crud.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'package:collection/collection.dart';
 import 'package:powersync_core/sqlite3_common.dart' as sqlite;
 
+import 'schema.dart';
+
 /// A batch of client-side changes.
 class CrudBatch {
   /// List of client-side changes.
@@ -68,6 +70,14 @@ class CrudEntry {
   /// ID of the changed row.
   final String id;
 
+  /// An optional metadata string attached to this entry at the time the write
+  /// has been issued.
+  ///
+  /// For tables where [Table.includeMetadata] is enabled, a hidden `_metadata`
+  /// column is added to this table that can be used during updates to attach
+  /// a hint to the update thas is preserved here.
+  final String? metadata;
+
   /// Data associated with the change.
   ///
   /// For PUT, this is contains all non-null columns of the row.
@@ -77,8 +87,22 @@ class CrudEntry {
   /// For DELETE, this is null.
   final Map<String, dynamic>? opData;
 
-  CrudEntry(this.clientId, this.op, this.table, this.id, this.transactionId,
-      this.opData);
+  /// Old values before an update.
+  ///
+  /// This is only tracked for tables for which this has been enabled by setting
+  /// the [Table.includeOld].
+  final Map<String, dynamic>? oldData;
+
+  CrudEntry(
+    this.clientId,
+    this.op,
+    this.table,
+    this.id,
+    this.transactionId,
+    this.opData, {
+    this.oldData,
+    this.metadata,
+  });
 
   factory CrudEntry.fromRow(sqlite.Row row) {
     final data = jsonDecode(row['data'] as String);
@@ -89,6 +113,8 @@ class CrudEntry {
       data['id'] as String,
       row['tx_id'] as int,
       data['data'] as Map<String, Object?>?,
+      oldData: data['old'] as Map<String, Object?>?,
+      metadata: data['metadata'] as String?,
     );
   }
 
@@ -100,7 +126,9 @@ class CrudEntry {
       'type': table,
       'id': id,
       'tx_id': transactionId,
-      'data': opData
+      'data': opData,
+      'metadata': metadata,
+      'old': oldData,
     };
   }
 

--- a/packages/powersync_core/lib/src/schema.dart
+++ b/packages/powersync_core/lib/src/schema.dart
@@ -35,7 +35,8 @@ final class TrackPreviousValuesOptions {
   /// A filter of column names for which updates should be tracked.
   ///
   /// When set to a non-null value, columns not included in this list will not
-  /// appear in [CrudEntry.oldData]. By default, all columns are included.
+  /// appear in [CrudEntry.previousValues]. By default, all columns are
+  /// included.
   final List<String>? columnFilter;
 
   /// Whether to only include old values when they were changed by an update,
@@ -64,7 +65,7 @@ class Table {
   /// through [CrudEntry.metadata].
   final bool trackMetadata;
 
-  /// Whether to track old values of columns for [CrudEntry.oldData].
+  /// Whether to track old values of columns for [CrudEntry.previousValues].
   ///
   /// See [TrackPreviousValuesOptions] for details.
   final TrackPreviousValuesOptions? trackPreviousValues;

--- a/packages/powersync_core/lib/src/schema.dart
+++ b/packages/powersync_core/lib/src/schema.dart
@@ -34,7 +34,7 @@ class Schema {
 final class IncludeOldOptions {
   /// A filter of column names for which updates should be tracked.
   ///
-  /// When set to a non-null value, olumns not included in this list will not
+  /// When set to a non-null value, columns not included in this list will not
   /// appear in [CrudEntry.oldData]. By default, all columns are included.
   final List<String>? columnFilter;
 

--- a/packages/powersync_core/lib/src/schema.dart
+++ b/packages/powersync_core/lib/src/schema.dart
@@ -29,7 +29,8 @@ class Schema {
 
 /// Options to include old values in [CrudEntry] for update statements.
 ///
-/// These options are enabled by passing it to a non-local [Table] constructor.
+/// These options are enabled by passing them to a non-local [Table]
+/// constructor.
 final class IncludeOldOptions {
   /// A filter of column names for which updates should be tracked.
   ///

--- a/packages/powersync_core/lib/src/schema.dart
+++ b/packages/powersync_core/lib/src/schema.dart
@@ -29,7 +29,7 @@ class Schema {
 
 /// Options to include old values in [CrudEntry] for update statements.
 ///
-/// This options are enabled by passing it to a non-local [Table] constructor.
+/// These options are enabled by passing it to a non-local [Table] constructor.
 final class IncludeOldOptions {
   /// A filter of column names for which updates should be tracked.
   ///

--- a/packages/powersync_core/test/crud_test.dart
+++ b/packages/powersync_core/test/crud_test.dart
@@ -276,7 +276,7 @@ void main() {
         Table(
           'lists',
           [Column.text('name')],
-          includeMetadata: true,
+          trackMetadata: true,
         )
       ]));
 
@@ -293,7 +293,7 @@ void main() {
         Table(
           'lists',
           [Column.text('name'), Column.text('content')],
-          includeOld: IncludeOldOptions(),
+          trackPreviousValues: TrackPreviousValuesOptions(),
         )
       ]));
 
@@ -312,7 +312,8 @@ void main() {
         Table(
           'lists',
           [Column.text('name'), Column.text('content')],
-          includeOld: IncludeOldOptions(columnFilter: ['name']),
+          trackPreviousValues:
+              TrackPreviousValuesOptions(columnFilter: ['name']),
         )
       ]));
 
@@ -332,7 +333,8 @@ void main() {
         Table(
           'lists',
           [Column.text('name'), Column.text('content')],
-          includeOld: IncludeOldOptions(onlyWhenChanged: true),
+          trackPreviousValues:
+              TrackPreviousValuesOptions(onlyWhenChanged: true),
         )
       ]));
 
@@ -351,7 +353,7 @@ void main() {
         Table(
           'lists',
           [Column.text('name')],
-          ignoreEmptyUpdate: true,
+          ignoreEmptyUpdates: true,
         )
       ]));
 

--- a/packages/powersync_core/test/crud_test.dart
+++ b/packages/powersync_core/test/crud_test.dart
@@ -304,7 +304,8 @@ void main() {
       await powersync.execute('UPDATE lists SET name = ?;', ['new name']);
 
       final batch = await powersync.getNextCrudTransaction();
-      expect(batch!.crud[0].oldData, {'name': 'entry', 'content': 'content'});
+      expect(batch!.crud[0].previousValues,
+          {'name': 'entry', 'content': 'content'});
     });
 
     test('include old values with column filter', () async {
@@ -325,7 +326,7 @@ void main() {
           ['new name', 'new content']);
 
       final batch = await powersync.getNextCrudTransaction();
-      expect(batch!.crud[0].oldData, {'name': 'name'});
+      expect(batch!.crud[0].previousValues, {'name': 'name'});
     });
 
     test('include old values when changed', () async {
@@ -345,7 +346,7 @@ void main() {
       await powersync.execute('UPDATE lists SET name = ?', ['new name']);
 
       final batch = await powersync.getNextCrudTransaction();
-      expect(batch!.crud[0].oldData, {'name': 'name'});
+      expect(batch!.crud[0].previousValues, {'name': 'name'});
     });
 
     test('ignore empty update', () async {

--- a/packages/powersync_core/test/crud_test.dart
+++ b/packages/powersync_core/test/crud_test.dart
@@ -139,6 +139,7 @@ void main() {
 
     test('INSERT-only tables', () async {
       await powersync.disconnectAndClear();
+      await powersync.close();
       powersync = await testUtils.setupPowerSync(
           path: path,
           schema: const Schema([
@@ -268,6 +269,97 @@ void main() {
           ]));
       await tx2.complete();
       expect(await powersync.getNextCrudTransaction(), equals(null));
+    });
+
+    test('include metadata', () async {
+      await powersync.updateSchema(Schema([
+        Table(
+          'lists',
+          [Column.text('name')],
+          includeMetadata: true,
+        )
+      ]));
+
+      await powersync.execute(
+          'INSERT INTO lists (id, name, _metadata) VALUES (uuid(), ?, ?)',
+          ['entry', 'so meta']);
+
+      final batch = await powersync.getNextCrudTransaction();
+      expect(batch!.crud[0].metadata, 'so meta');
+    });
+
+    test('include old values', () async {
+      await powersync.updateSchema(Schema([
+        Table(
+          'lists',
+          [Column.text('name'), Column.text('content')],
+          includeOld: IncludeOldOptions(),
+        )
+      ]));
+
+      await powersync.execute(
+          'INSERT INTO lists (id, name, content) VALUES (uuid(), ?, ?)',
+          ['entry', 'content']);
+      await powersync.execute('DELETE FROM ps_crud;');
+      await powersync.execute('UPDATE lists SET name = ?;', ['new name']);
+
+      final batch = await powersync.getNextCrudTransaction();
+      expect(batch!.crud[0].oldData, {'name': 'entry', 'content': 'content'});
+    });
+
+    test('include old values with column filter', () async {
+      await powersync.updateSchema(Schema([
+        Table(
+          'lists',
+          [Column.text('name'), Column.text('content')],
+          includeOld: IncludeOldOptions(columnFilter: ['name']),
+        )
+      ]));
+
+      await powersync.execute(
+          'INSERT INTO lists (id, name, content) VALUES (uuid(), ?, ?)',
+          ['name', 'content']);
+      await powersync.execute('DELETE FROM ps_crud;');
+      await powersync.execute('UPDATE lists SET name = ?, content = ?',
+          ['new name', 'new content']);
+
+      final batch = await powersync.getNextCrudTransaction();
+      expect(batch!.crud[0].oldData, {'name': 'name'});
+    });
+
+    test('include old values when changed', () async {
+      await powersync.updateSchema(Schema([
+        Table(
+          'lists',
+          [Column.text('name'), Column.text('content')],
+          includeOld: IncludeOldOptions(onlyWhenChanged: true),
+        )
+      ]));
+
+      await powersync.execute(
+          'INSERT INTO lists (id, name, content) VALUES (uuid(), ?, ?)',
+          ['name', 'content']);
+      await powersync.execute('DELETE FROM ps_crud;');
+      await powersync.execute('UPDATE lists SET name = ?', ['new name']);
+
+      final batch = await powersync.getNextCrudTransaction();
+      expect(batch!.crud[0].oldData, {'name': 'name'});
+    });
+
+    test('ignore empty update', () async {
+      await powersync.updateSchema(Schema([
+        Table(
+          'lists',
+          [Column.text('name')],
+          ignoreEmptyUpdate: true,
+        )
+      ]));
+
+      await powersync
+          .execute('INSERT INTO lists (id, name) VALUES (uuid(), ?)', ['name']);
+      await powersync.execute('DELETE FROM ps_crud;');
+      await powersync.execute('UPDATE lists SET name = ?;', ['name']);
+      expect(await powersync.getNextCrudTransaction(), isNull);
     });
   });
 }

--- a/packages/powersync_core/test/schema_test.dart
+++ b/packages/powersync_core/test/schema_test.dart
@@ -318,6 +318,26 @@ void main() {
       );
     });
 
+    test('local-only with metadata', () {
+      final table = Table('foo', [Column.text('bar')],
+          localOnly: true, includeMetadata: true);
+
+      expect(
+          table.validate,
+          throwsA(isA<AssertionError>().having((e) => e.message, 'emssage',
+              "Local-only tables can't track metadata")));
+    });
+
+    test('local-only with includeOld', () {
+      final table = Table('foo', [Column.text('bar')],
+          localOnly: true, includeOld: IncludeOldOptions());
+
+      expect(
+          table.validate,
+          throwsA(isA<AssertionError>().having((e) => e.message, 'emssage',
+              "Local-only tables can't track old values")));
+    });
+
     test('Schema without duplicate table names', () {
       final schema = Schema([
         Table('duplicate', [
@@ -362,13 +382,51 @@ void main() {
       ]);
 
       final json = table.toJson();
+      expect(json, {
+        'name': 'users',
+        'view_name': null,
+        'local_only': false,
+        'insert_only': false,
+        'columns': hasLength(2),
+        'indexes': hasLength(1),
+        'ignore_empty_update': false,
+        'include_metadata': false,
+      });
+    });
 
-      expect(json['name'], equals('users'));
-      expect(json['view_name'], isNull);
-      expect(json['local_only'], isFalse);
-      expect(json['insert_only'], isFalse);
-      expect(json['columns'].length, equals(2));
-      expect(json['indexes'].length, equals(1));
+    test('handles options', () {
+      expect(Table('foo', [], includeMetadata: true).toJson(),
+          containsPair('include_metadata', isTrue));
+
+      expect(Table('foo', [], ignoreEmptyUpdate: true).toJson(),
+          containsPair('ignore_empty_update', isTrue));
+
+      expect(
+        Table('foo', [], includeOld: IncludeOldOptions()).toJson(),
+        allOf(
+          containsPair('include_old', isTrue),
+          containsPair('include_old_only_when_changed', isFalse),
+        ),
+      );
+
+      expect(
+        Table('foo', [],
+                includeOld: IncludeOldOptions(columnFilter: ['foo', 'bar']))
+            .toJson(),
+        allOf(
+          containsPair('include_old', ['foo', 'bar']),
+          containsPair('include_old_only_when_changed', isFalse),
+        ),
+      );
+
+      expect(
+        Table('foo', [], includeOld: IncludeOldOptions(onlyWhenChanged: true))
+            .toJson(),
+        allOf(
+          containsPair('include_old', isTrue),
+          containsPair('include_old_only_when_changed', isTrue),
+        ),
+      );
     });
   });
 }

--- a/packages/powersync_core/test/schema_test.dart
+++ b/packages/powersync_core/test/schema_test.dart
@@ -320,7 +320,7 @@ void main() {
 
     test('local-only with metadata', () {
       final table = Table('foo', [Column.text('bar')],
-          localOnly: true, includeMetadata: true);
+          localOnly: true, trackMetadata: true);
 
       expect(
           table.validate,
@@ -328,9 +328,9 @@ void main() {
               "Local-only tables can't track metadata")));
     });
 
-    test('local-only with includeOld', () {
+    test('local-only with trackPreviousValues', () {
       final table = Table('foo', [Column.text('bar')],
-          localOnly: true, includeOld: IncludeOldOptions());
+          localOnly: true, trackPreviousValues: TrackPreviousValuesOptions());
 
       expect(
           table.validate,
@@ -395,14 +395,15 @@ void main() {
     });
 
     test('handles options', () {
-      expect(Table('foo', [], includeMetadata: true).toJson(),
+      expect(Table('foo', [], trackMetadata: true).toJson(),
           containsPair('include_metadata', isTrue));
 
-      expect(Table('foo', [], ignoreEmptyUpdate: true).toJson(),
+      expect(Table('foo', [], ignoreEmptyUpdates: true).toJson(),
           containsPair('ignore_empty_update', isTrue));
 
       expect(
-        Table('foo', [], includeOld: IncludeOldOptions()).toJson(),
+        Table('foo', [], trackPreviousValues: TrackPreviousValuesOptions())
+            .toJson(),
         allOf(
           containsPair('include_old', isTrue),
           containsPair('include_old_only_when_changed', isFalse),
@@ -411,7 +412,8 @@ void main() {
 
       expect(
         Table('foo', [],
-                includeOld: IncludeOldOptions(columnFilter: ['foo', 'bar']))
+                trackPreviousValues:
+                    TrackPreviousValuesOptions(columnFilter: ['foo', 'bar']))
             .toJson(),
         allOf(
           containsPair('include_old', ['foo', 'bar']),
@@ -420,7 +422,9 @@ void main() {
       );
 
       expect(
-        Table('foo', [], includeOld: IncludeOldOptions(onlyWhenChanged: true))
+        Table('foo', [],
+                trackPreviousValues:
+                    TrackPreviousValuesOptions(onlyWhenChanged: true))
             .toJson(),
         allOf(
           containsPair('include_old', isTrue),


### PR DESCRIPTION
This exposes the new table options introduced in version 0.3.13 of the core extension, namely:

- `include_old` (either a boolean or an array of column names): Adds an `old` entry to the `ps_crud.data` JSON object that includes old values for updates.
 - `include_old_only_when_changed`: Skip unchanged values from updates.
- `include_metadata`: Adds a `_metadata` column that can be written to for updates. It's reported through `CrudEntry.metadata` afterwards.
- `ignore_empty_update`: Don't create `ps_crud` entries for `UPDATE` statements that didn't change any values. 

Most of this feature is tested in the core extension, this adds a few simple tests ensuring we forward options correctly.