### PR TITLE
Prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,16 +30,14 @@ Packages with dependency updates only:
 ---
 
 #### `powersync_core` - `v1.3.0`
-
- - __todo__
-
 #### `powersync` - `v1.13.0`
-
- - __todo__
-
 #### `powersync_sqlcipher` - `v0.1.6`
 
- - __todo__
+* Report real-time progress information about downloads through `SyncStatus.downloadProgress`.
+* Add `trackPreviousValues` option on `Table` which sets `CrudEntry.previousValues` to previous values on updates.
+* Add `trackMetadata` option on `Table` which adds a `_metadata` column that can be used for updates.
+  The configured metadata is available through `CrudEntry.metadata`.
+* Add `ignoreEmptyUpdates` option which skips creating CRUD entries for updates that don't change any values.
 
 #### `powersync_flutter_libs` - `v0.4.8`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,49 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2025-05-07
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`powersync_core` - `v1.3.0`](#powersync_core---v130)
+ - [`powersync` - `v1.13.0`](#powersync---v1130)
+ - [`powersync_sqlcipher` - `v0.1.6`](#powersync_sqlcipher---v016)
+ - [`powersync_flutter_libs` - `v0.4.8`](#powersync_flutter_libs---v048)
+ - [`powersync_attachments_helper` - `v0.6.18+7`](#powersync_attachments_helper---v06187)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `powersync_attachments_helper` - `v0.6.18+7`
+
+---
+
+#### `powersync_core` - `v1.3.0`
+
+ - __todo__
+
+#### `powersync` - `v1.13.0`
+
+ - __todo__
+
+#### `powersync_sqlcipher` - `v0.1.6`
+
+ - __todo__
+
+#### `powersync_flutter_libs` - `v0.4.8`
+
+ - Update PowerSync core extension to version 0.3.14.
+
+
 ## 2025-04-24
 
 ### Changes

--- a/demos/benchmarks/pubspec.lock
+++ b/demos/benchmarks/pubspec.lock
@@ -297,21 +297,21 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.11.2"
+    version: "1.12.4"
   powersync_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_core"
       relative: true
     source: path
-    version: "1.1.2"
+    version: "1.2.4"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.4"
+    version: "0.4.7"
   pub_semver:
     dependency: transitive
     description:
@@ -369,10 +369,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_web
-      sha256: "870f287c2375117af1f769893c5ea0941882ee820444af5c3dcceec3b217aab1"
+      sha256: "967e076442f7e1233bd7241ca61f3efe4c7fc168dac0f38411bdb3bdf471eb3c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   sqlite_async:
     dependency: "direct main"
     description:

--- a/demos/benchmarks/pubspec.lock
+++ b/demos/benchmarks/pubspec.lock
@@ -297,21 +297,21 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.12.4"
+    version: "1.13.0"
   powersync_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_core"
       relative: true
     source: path
-    version: "1.2.4"
+    version: "1.3.0"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.7"
+    version: "0.4.8"
   pub_semver:
     dependency: transitive
     description:

--- a/demos/benchmarks/pubspec.yaml
+++ b/demos/benchmarks/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.12.4
+  powersync: ^1.13.0
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/django-todolist/pubspec.lock
+++ b/demos/django-todolist/pubspec.lock
@@ -310,21 +310,21 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.12.4"
+    version: "1.13.0"
   powersync_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_core"
       relative: true
     source: path
-    version: "1.2.4"
+    version: "1.3.0"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.7"
+    version: "0.4.8"
   pub_semver:
     dependency: transitive
     description:

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.12.4
+  powersync: ^1.13.0
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/firebase-nodejs-todolist/pubspec.lock
+++ b/demos/firebase-nodejs-todolist/pubspec.lock
@@ -446,21 +446,21 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.11.2"
+    version: "1.12.4"
   powersync_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_core"
       relative: true
     source: path
-    version: "1.1.2"
+    version: "1.2.4"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.4"
+    version: "0.4.7"
   pub_semver:
     dependency: transitive
     description:
@@ -598,10 +598,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_web
-      sha256: "870f287c2375117af1f769893c5ea0941882ee820444af5c3dcceec3b217aab1"
+      sha256: "967e076442f7e1233bd7241ca61f3efe4c7fc168dac0f38411bdb3bdf471eb3c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   sqlite_async:
     dependency: transitive
     description:

--- a/demos/firebase-nodejs-todolist/pubspec.lock
+++ b/demos/firebase-nodejs-todolist/pubspec.lock
@@ -446,21 +446,21 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.12.4"
+    version: "1.13.0"
   powersync_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_core"
       relative: true
     source: path
-    version: "1.2.4"
+    version: "1.3.0"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.7"
+    version: "0.4.8"
   pub_semver:
     dependency: transitive
     description:

--- a/demos/firebase-nodejs-todolist/pubspec.yaml
+++ b/demos/firebase-nodejs-todolist/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.12.4
+  powersync: ^1.13.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-anonymous-auth/pubspec.lock
+++ b/demos/supabase-anonymous-auth/pubspec.lock
@@ -390,21 +390,21 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.11.2"
+    version: "1.12.4"
   powersync_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_core"
       relative: true
     source: path
-    version: "1.1.2"
+    version: "1.2.4"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.4"
+    version: "0.4.7"
   pub_semver:
     dependency: transitive
     description:
@@ -542,10 +542,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_web
-      sha256: "870f287c2375117af1f769893c5ea0941882ee820444af5c3dcceec3b217aab1"
+      sha256: "967e076442f7e1233bd7241ca61f3efe4c7fc168dac0f38411bdb3bdf471eb3c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   sqlite_async:
     dependency: "direct main"
     description:

--- a/demos/supabase-anonymous-auth/pubspec.lock
+++ b/demos/supabase-anonymous-auth/pubspec.lock
@@ -390,21 +390,21 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.12.4"
+    version: "1.13.0"
   powersync_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_core"
       relative: true
     source: path
-    version: "1.2.4"
+    version: "1.3.0"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.7"
+    version: "0.4.8"
   pub_semver:
     dependency: transitive
     description:

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.12.4
+  powersync: ^1.13.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.lock
+++ b/demos/supabase-edge-function-auth/pubspec.lock
@@ -390,21 +390,21 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.11.2"
+    version: "1.12.4"
   powersync_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_core"
       relative: true
     source: path
-    version: "1.1.2"
+    version: "1.2.4"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.4"
+    version: "0.4.7"
   pub_semver:
     dependency: transitive
     description:
@@ -542,10 +542,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_web
-      sha256: "870f287c2375117af1f769893c5ea0941882ee820444af5c3dcceec3b217aab1"
+      sha256: "967e076442f7e1233bd7241ca61f3efe4c7fc168dac0f38411bdb3bdf471eb3c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   sqlite_async:
     dependency: "direct main"
     description:

--- a/demos/supabase-edge-function-auth/pubspec.lock
+++ b/demos/supabase-edge-function-auth/pubspec.lock
@@ -390,21 +390,21 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.12.4"
+    version: "1.13.0"
   powersync_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_core"
       relative: true
     source: path
-    version: "1.2.4"
+    version: "1.3.0"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.7"
+    version: "0.4.8"
   pub_semver:
     dependency: transitive
     description:

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.12.4
+  powersync: ^1.13.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.lock
+++ b/demos/supabase-simple-chat/pubspec.lock
@@ -406,21 +406,21 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.12.4"
+    version: "1.13.0"
   powersync_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_core"
       relative: true
     source: path
-    version: "1.2.4"
+    version: "1.3.0"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.7"
+    version: "0.4.8"
   pub_semver:
     dependency: transitive
     description:

--- a/demos/supabase-simple-chat/pubspec.lock
+++ b/demos/supabase-simple-chat/pubspec.lock
@@ -406,21 +406,21 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.11.2"
+    version: "1.12.4"
   powersync_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_core"
       relative: true
     source: path
-    version: "1.1.2"
+    version: "1.2.4"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.4"
+    version: "0.4.7"
   pub_semver:
     dependency: transitive
     description:
@@ -558,10 +558,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_web
-      sha256: "870f287c2375117af1f769893c5ea0941882ee820444af5c3dcceec3b217aab1"
+      sha256: "967e076442f7e1233bd7241ca61f3efe4c7fc168dac0f38411bdb3bdf471eb3c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   sqlite_async:
     dependency: transitive
     description:

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^2.0.2
   timeago: ^3.6.0
-  powersync: ^1.12.4
+  powersync: ^1.13.0
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist-drift/pubspec.lock
+++ b/demos/supabase-todolist-drift/pubspec.lock
@@ -758,28 +758,28 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.12.4"
+    version: "1.13.0"
   powersync_attachments_helper:
     dependency: "direct main"
     description:
       path: "../../packages/powersync_attachments_helper"
       relative: true
     source: path
-    version: "0.6.18+6"
+    version: "0.6.18+7"
   powersync_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_core"
       relative: true
     source: path
-    version: "1.2.4"
+    version: "1.3.0"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.7"
+    version: "0.4.8"
   pub_semver:
     dependency: transitive
     description:

--- a/demos/supabase-todolist-drift/pubspec.lock
+++ b/demos/supabase-todolist-drift/pubspec.lock
@@ -758,21 +758,21 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.12.2"
+    version: "1.12.4"
   powersync_attachments_helper:
     dependency: "direct main"
     description:
       path: "../../packages/powersync_attachments_helper"
       relative: true
     source: path
-    version: "0.6.18+4"
+    version: "0.6.18+6"
   powersync_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_core"
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.2.4"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:

--- a/demos/supabase-todolist-drift/pubspec.yaml
+++ b/demos/supabase-todolist-drift/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.18+6
-  powersync: ^1.12.4
+  powersync_attachments_helper: ^0.6.18+7
+  powersync: ^1.13.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist-optional-sync/pubspec.lock
+++ b/demos/supabase-todolist-optional-sync/pubspec.lock
@@ -470,21 +470,21 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.11.2"
+    version: "1.12.4"
   powersync_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_core"
       relative: true
     source: path
-    version: "1.1.2"
+    version: "1.2.4"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.4"
+    version: "0.4.7"
   pub_semver:
     dependency: transitive
     description:
@@ -622,10 +622,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_web
-      sha256: "870f287c2375117af1f769893c5ea0941882ee820444af5c3dcceec3b217aab1"
+      sha256: "967e076442f7e1233bd7241ca61f3efe4c7fc168dac0f38411bdb3bdf471eb3c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   sqlite_async:
     dependency: "direct main"
     description:

--- a/demos/supabase-todolist-optional-sync/pubspec.lock
+++ b/demos/supabase-todolist-optional-sync/pubspec.lock
@@ -470,21 +470,21 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.12.4"
+    version: "1.13.0"
   powersync_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_core"
       relative: true
     source: path
-    version: "1.2.4"
+    version: "1.3.0"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.7"
+    version: "0.4.8"
   pub_semver:
     dependency: transitive
     description:

--- a/demos/supabase-todolist-optional-sync/pubspec.yaml
+++ b/demos/supabase-todolist-optional-sync/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.12.4
+  powersync: ^1.13.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -478,28 +478,28 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.12.4"
+    version: "1.13.0"
   powersync_attachments_helper:
     dependency: "direct main"
     description:
       path: "../../packages/powersync_attachments_helper"
       relative: true
     source: path
-    version: "0.6.18+6"
+    version: "0.6.18+7"
   powersync_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_core"
       relative: true
     source: path
-    version: "1.2.4"
+    version: "1.3.0"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.7"
+    version: "0.4.8"
   pub_semver:
     dependency: transitive
     description:

--- a/demos/supabase-todolist/pubspec.lock
+++ b/demos/supabase-todolist/pubspec.lock
@@ -478,28 +478,28 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.11.3"
+    version: "1.12.4"
   powersync_attachments_helper:
     dependency: "direct main"
     description:
       path: "../../packages/powersync_attachments_helper"
       relative: true
     source: path
-    version: "0.6.18+1"
+    version: "0.6.18+6"
   powersync_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_core"
       relative: true
     source: path
-    version: "1.1.3"
+    version: "1.2.4"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.5"
+    version: "0.4.7"
   pub_semver:
     dependency: transitive
     description:
@@ -637,10 +637,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_web
-      sha256: "870f287c2375117af1f769893c5ea0941882ee820444af5c3dcceec3b217aab1"
+      sha256: "967e076442f7e1233bd7241ca61f3efe4c7fc168dac0f38411bdb3bdf471eb3c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   sqlite_async:
     dependency: "direct main"
     description:

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.18+6
-  powersync: ^1.12.4
+  powersync_attachments_helper: ^0.6.18+7
+  powersync: ^1.13.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-trello/pubspec.lock
+++ b/demos/supabase-trello/pubspec.lock
@@ -558,21 +558,21 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.11.2"
+    version: "1.12.4"
   powersync_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_core"
       relative: true
     source: path
-    version: "1.1.2"
+    version: "1.2.4"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.4"
+    version: "0.4.7"
   provider:
     dependency: "direct main"
     description:
@@ -726,10 +726,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_web
-      sha256: "870f287c2375117af1f769893c5ea0941882ee820444af5c3dcceec3b217aab1"
+      sha256: "967e076442f7e1233bd7241ca61f3efe4c7fc168dac0f38411bdb3bdf471eb3c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   sqlite_async:
     dependency: "direct main"
     description:

--- a/demos/supabase-trello/pubspec.lock
+++ b/demos/supabase-trello/pubspec.lock
@@ -558,21 +558,21 @@ packages:
       path: "../../packages/powersync"
       relative: true
     source: path
-    version: "1.12.4"
+    version: "1.13.0"
   powersync_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_core"
       relative: true
     source: path
-    version: "1.2.4"
+    version: "1.3.0"
   powersync_flutter_libs:
     dependency: "direct overridden"
     description:
       path: "../../packages/powersync_flutter_libs"
       relative: true
     source: path
-    version: "0.4.7"
+    version: "0.4.8"
   provider:
     dependency: "direct main"
     description:

--- a/demos/supabase-trello/pubspec.yaml
+++ b/demos/supabase-trello/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   random_name_generator: ^1.5.0
   flutter_dotenv: ^5.2.1
   logging: ^1.3.0
-  powersync: ^1.12.4
+  powersync: ^1.13.0
   sqlite_async: ^0.11.0
   path_provider: ^2.1.5
   supabase_flutter: ^2.8.3

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 1.13.0
 
- - __todo__
+* Report real-time progress information about downloads through `SyncStatus.downloadProgress`.
+* Add `trackPreviousValues` option on `Table` which sets `CrudEntry.previousValues` to previous values on updates.
+* Add `trackMetadata` option on `Table` which adds a `_metadata` column that can be used for updates.
+  The configured metadata is available through `CrudEntry.metadata`.
+* Add `ignoreEmptyUpdates` option which skips creating CRUD entries for updates that don't change any values.
 
 ## 1.12.4
 

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.13.0
+
+ - __todo__
+
 ## 1.12.4
 
  - Update a dependency to the latest release.

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.12.4
+version: 1.13.0
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK. Sync Postgres, MongoDB or MySQL with SQLite in your Flutter app
@@ -14,8 +14,8 @@ dependencies:
   sqlite3_flutter_libs: ^0.5.23
   # We use an exact version dependency on our workspace packages becaus melos
   # will update this package when these are updated.
-  powersync_core: 1.2.4
-  powersync_flutter_libs: 0.4.7
+  powersync_core: 1.3.0
+  powersync_flutter_libs: 0.4.8
   collection: ^1.17.0
 
 dev_dependencies:

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -12,10 +12,8 @@ dependencies:
     sdk: flutter
 
   sqlite3_flutter_libs: ^0.5.23
-  # We use an exact version dependency on our workspace packages because melos
-  # will update this package when these are updated.
-  powersync_core: 1.3.0
-  powersync_flutter_libs: 0.4.8
+  powersync_core: ^1.3.0
+  powersync_flutter_libs: ^0.4.8
   collection: ^1.17.0
 
 dev_dependencies:

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -12,8 +12,10 @@ dependencies:
     sdk: flutter
 
   sqlite3_flutter_libs: ^0.5.23
-  powersync_core: ^1.2.4
-  powersync_flutter_libs: ^0.4.7
+  # We use an exact version dependency on our workspace packages becaus melos
+  # will update this package when these are updated.
+  powersync_core: 1.2.4
+  powersync_flutter_libs: 0.4.7
   collection: ^1.17.0
 
 dev_dependencies:

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
 
   sqlite3_flutter_libs: ^0.5.23
-  # We use an exact version dependency on our workspace packages becaus melos
+  # We use an exact version dependency on our workspace packages because melos
   # will update this package when these are updated.
   powersync_core: 1.3.0
   powersync_flutter_libs: 0.4.8

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.18+7
+
+ - Update a dependency to the latest release.
+
 ## 0.6.18+6
 
  - Update a dependency to the latest release.

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.6.18+6
+version: 0.6.18+7
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync_core: ^1.2.4
+  powersync_core: ^1.3.0
   logging: ^1.2.0
   sqlite_async: ^0.11.0
   path_provider: ^2.0.13

--- a/packages/powersync_core/CHANGELOG.md
+++ b/packages/powersync_core/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 1.3.0
 
- - __todo__
+* Report real-time progress information about downloads through `SyncStatus.downloadProgress`.
+* Add `trackPreviousValues` option on `Table` which sets `CrudEntry.previousValues` to previous values on updates.
+* Add `trackMetadata` option on `Table` which adds a `_metadata` column that can be used for updates.
+  The configured metadata is available through `CrudEntry.metadata`.
+* Add `ignoreEmptyUpdates` option which skips creating CRUD entries for updates that don't change any values.
 
 ## 1.2.4
 

--- a/packages/powersync_core/CHANGELOG.md
+++ b/packages/powersync_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+ - __todo__
+
 ## 1.2.4
 
  - Fix deadlock when `connect()` is called immediately after opening a database.

--- a/packages/powersync_core/lib/src/version.dart
+++ b/packages/powersync_core/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String libraryVersion = '1.2.4';
+const String libraryVersion = '1.3.0';

--- a/packages/powersync_core/pubspec.yaml
+++ b/packages/powersync_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync_core
-version: 1.2.4
+version: 1.3.0
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Dart SDK - sync engine for building local-first apps.

--- a/packages/powersync_flutter_libs/CHANGELOG.md
+++ b/packages/powersync_flutter_libs/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.8
+
+ - Update PowerSync core extension to version 0.3.14.
+
 ## 0.4.7
 
  - Update core extension to 0.3.12.

--- a/packages/powersync_flutter_libs/pubspec.yaml
+++ b/packages/powersync_flutter_libs/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_flutter_libs
 description: PowerSync core binaries for the PowerSync Flutter SDK. Needs to be included for Flutter apps.
-version: 0.4.7
+version: 0.4.8
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 

--- a/packages/powersync_sqlcipher/CHANGELOG.md
+++ b/packages/powersync_sqlcipher/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 0.1.6
 
- - __todo__
+* Report real-time progress information about downloads through `SyncStatus.downloadProgress`.
+* Add `trackPreviousValues` option on `Table` which sets `CrudEntry.previousValues` to previous values on updates.
+* Add `trackMetadata` option on `Table` which adds a `_metadata` column that can be used for updates.
+  The configured metadata is available through `CrudEntry.metadata`.
+* Add `ignoreEmptyUpdates` option which skips creating CRUD entries for updates that don't change any values.
 
 ## 0.1.5+4
 

--- a/packages/powersync_sqlcipher/CHANGELOG.md
+++ b/packages/powersync_sqlcipher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.6
+
+ - __todo__
+
 ## 0.1.5+4
 
  - Update a dependency to the latest release.

--- a/packages/powersync_sqlcipher/pubspec.yaml
+++ b/packages/powersync_sqlcipher/pubspec.yaml
@@ -12,8 +12,10 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync_core: ^1.2.4
-  powersync_flutter_libs: ^0.4.7
+  # We use an exact version dependency on our workspace packages becaus melos
+  # will update this package when these are updated.
+  powersync_core: 1.2.4
+  powersync_flutter_libs: 0.4.7
   sqlcipher_flutter_libs: ^0.6.4
   sqlite3_web: ^0.3.0
 

--- a/packages/powersync_sqlcipher/pubspec.yaml
+++ b/packages/powersync_sqlcipher/pubspec.yaml
@@ -12,10 +12,8 @@ dependencies:
   flutter:
     sdk: flutter
 
-  # We use an exact version dependency on our workspace packages because melos
-  # will update this package when these are updated.
-  powersync_core: 1.3.0
-  powersync_flutter_libs: 0.4.8
+  powersync_core: ^1.3.0
+  powersync_flutter_libs: ^0.4.8
   sqlcipher_flutter_libs: ^0.6.4
   sqlite3_web: ^0.3.0
 

--- a/packages/powersync_sqlcipher/pubspec.yaml
+++ b/packages/powersync_sqlcipher/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  # We use an exact version dependency on our workspace packages becaus melos
+  # We use an exact version dependency on our workspace packages because melos
   # will update this package when these are updated.
   powersync_core: 1.3.0
   powersync_flutter_libs: 0.4.8

--- a/packages/powersync_sqlcipher/pubspec.yaml
+++ b/packages/powersync_sqlcipher/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync_sqlcipher
-version: 0.1.5+4
+version: 0.1.6
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - sync engine for building local-first apps.
@@ -14,8 +14,8 @@ dependencies:
 
   # We use an exact version dependency on our workspace packages becaus melos
   # will update this package when these are updated.
-  powersync_core: 1.2.4
-  powersync_flutter_libs: 0.4.7
+  powersync_core: 1.3.0
+  powersync_flutter_libs: 0.4.8
   sqlcipher_flutter_libs: ^0.6.4
   sqlite3_web: ^0.3.0
 


### PR DESCRIPTION
This prepares a minor release of the PowerSync SDK for Dart. ~~I have changed the `powersync` and `powersync_sqlcipher` packages to use an exact version dependency on `powersync_core`. In the future, this means that downgrading the user-facing package will also downgrade the `powersync_core` version.~~ Actually that seems to break the `dart pub lish --dry-run` check, so let's keep that as-is for now until there's a workaround for that.

Changes this the last release are:

- Sync progress
- New schema options (tracking metadata, previous values and the option to skip creating CRUD entries for empty updates)
