### PR TITLE
Allow disconnecting in `fetchCredentials` callback

### DIFF
--- a/packages/powersync_core/lib/src/abort_controller.dart
+++ b/packages/powersync_core/lib/src/abort_controller.dart
@@ -25,7 +25,7 @@ class AbortController {
       _abortRequested.complete();
     }
 
-    await _abortCompleter.future;
+    await onCompletion;
   }
 
   /// Signal that an abort has completed.

--- a/packages/powersync_core/lib/src/database/powersync_database_impl_stub.dart
+++ b/packages/powersync_core/lib/src/database/powersync_database_impl_stub.dart
@@ -114,6 +114,7 @@ class PowerSyncDatabaseImpl
       {required PowerSyncBackendConnector connector,
       required Duration crudThrottleTime,
       required AbortController abort,
+      required Zone asyncWorkZone,
       Map<String, dynamic>? params}) {
     throw UnimplementedError();
   }

--- a/packages/powersync_core/lib/src/database/powersync_db_mixin.dart
+++ b/packages/powersync_core/lib/src/database/powersync_db_mixin.dart
@@ -282,6 +282,7 @@ mixin PowerSyncDatabaseMixin implements SqliteConnection {
 
     clientParams = params;
     var thisConnectAborter = AbortController();
+    final zone = Zone.current;
 
     late void Function() retryHandler;
 
@@ -296,6 +297,9 @@ mixin PowerSyncDatabaseMixin implements SqliteConnection {
         crudThrottleTime: crudThrottleTime,
         params: params,
         abort: thisConnectAborter,
+        // Run follow-up async tasks in the parent zone, a new one is introduced
+        // while we hold the lock (and async tasks won't hold the sync lock).
+        asyncWorkZone: zone,
       );
 
       thisConnectAborter.onCompletion.whenComplete(retryHandler);
@@ -347,6 +351,7 @@ mixin PowerSyncDatabaseMixin implements SqliteConnection {
     required PowerSyncBackendConnector connector,
     required Duration crudThrottleTime,
     required AbortController abort,
+    required Zone asyncWorkZone,
     Map<String, dynamic>? params,
   });
 

--- a/packages/powersync_core/lib/src/database/powersync_db_mixin.dart
+++ b/packages/powersync_core/lib/src/database/powersync_db_mixin.dart
@@ -372,7 +372,7 @@ mixin PowerSyncDatabaseMixin implements SqliteConnection {
         _abortActiveSync = null;
       } else {
         /// Wait for the abort to complete. Continue updating the sync status after completed
-        await disconnector.onAbort;
+        await disconnector.onCompletion;
       }
     }
   }

--- a/packages/powersync_core/lib/src/database/web/web_powersync_database.dart
+++ b/packages/powersync_core/lib/src/database/web/web_powersync_database.dart
@@ -116,6 +116,7 @@ class PowerSyncDatabaseImpl
     required PowerSyncBackendConnector connector,
     required Duration crudThrottleTime,
     required AbortController abort,
+    required Zone asyncWorkZone,
     Map<String, dynamic>? params,
   }) async {
     final crudStream =

--- a/packages/powersync_core/test/utils/abstract_test_utils.dart
+++ b/packages/powersync_core/test/utils/abstract_test_utils.dart
@@ -125,21 +125,21 @@ abstract class AbstractTestUtils {
 }
 
 class TestConnector extends PowerSyncBackendConnector {
-  final Future<PowerSyncCredentials> Function() _fetchCredentials;
-  final Future<void> Function(PowerSyncDatabase)? _uploadData;
+  Future<PowerSyncCredentials> Function() fetchCredentialsCallback;
+  Future<void> Function(PowerSyncDatabase)? uploadDataCallback;
 
-  TestConnector(this._fetchCredentials,
+  TestConnector(this.fetchCredentialsCallback,
       {Future<void> Function(PowerSyncDatabase)? uploadData})
-      : _uploadData = uploadData;
+      : uploadDataCallback = uploadData;
 
   @override
   Future<PowerSyncCredentials?> fetchCredentials() {
-    return _fetchCredentials();
+    return fetchCredentialsCallback();
   }
 
   @override
   Future<void> uploadData(PowerSyncDatabase database) async {
-    await _uploadData?.call(database);
+    await uploadDataCallback?.call(database);
   }
 }
 


### PR DESCRIPTION
To prevent duplicate concurrent sync connections, we guard `connect()` and `disconnect()` calls in mutexes. And since the mutex implementation is not reentrant, there's a check ensuring another call to `.lock()` throws if it comes from an async zone that already holds the mutex.

By design, async zones are quite sticky: Every callback we register in that zone will also run in the same zone. So when we call `connectInternal` on the native database, all message handlers from the isolate are handled in the zone originally establishing the connection.

This means that these callbacks can't call `disconnect()`, which is unfortunate because the lock is not actually held at that point. This fixes that issue by passing the zone originally calling `connect()` which is then used to run callbacks.
This allows calling `disconnect()` in response to tokens expiring and `fetchCredentials` being called (as long as that call is not awaited - `disconnect()` will await the abortion which is then blocked on the `disconnect()` call itself).

Closes https://github.com/powersync-ja/powersync.dart/issues/278.