### PR TITLE
Option to use core exension for sync logic

### DIFF
--- a/packages/powersync_core/lib/src/database/core_version.dart
+++ b/packages/powersync_core/lib/src/database/core_version.dart
@@ -60,7 +60,7 @@ extension type const PowerSyncCoreVersion((int, int, int) _tuple) {
   // Note: When updating this, also update the download URL in
   // scripts/init_powersync_core_binary.dart and the version ref in
   // packages/sqlite3_wasm_build/build.sh
-  static const minimum = PowerSyncCoreVersion((0, 3, 14));
+  static const minimum = PowerSyncCoreVersion((0, 4, 0));
 
   /// The first version of the core extensions that this version of the Dart
   /// SDK doesn't support.

--- a/packages/powersync_core/lib/src/database/native/native_powersync_database.dart
+++ b/packages/powersync_core/lib/src/database/native/native_powersync_database.dart
@@ -120,7 +120,7 @@ class PowerSyncDatabaseImpl
   @internal
   Future<void> connectInternal({
     required PowerSyncBackendConnector connector,
-    required SyncOptions options,
+    required ResolvedSyncOptions options,
     required AbortController abort,
     required Zone asyncWorkZone,
   }) async {
@@ -135,7 +135,6 @@ class PowerSyncDatabaseImpl
     SendPort? initPort;
     final hasInitPort = Completer<void>();
     final receivedIsolateExit = Completer<void>();
-    final resolved = ResolvedSyncOptions(options);
 
     Future<void> waitForShutdown() async {
       // Only complete the abortion signal after the isolate shuts down. This
@@ -183,7 +182,7 @@ class PowerSyncDatabaseImpl
           final port = initPort = data[1] as SendPort;
           hasInitPort.complete();
           var crudStream = database
-              .onChange(['ps_crud'], throttle: resolved.crudThrottleTime);
+              .onChange(['ps_crud'], throttle: options.crudThrottleTime);
           crudUpdateSubscription = crudStream.listen((event) {
             port.send(['update']);
           });
@@ -245,7 +244,7 @@ class PowerSyncDatabaseImpl
       _PowerSyncDatabaseIsolateArgs(
         receiveMessages.sendPort,
         dbRef,
-        resolved,
+        options,
         crudMutex.shared,
         syncMutex.shared,
       ),

--- a/packages/powersync_core/lib/src/database/powersync_database_impl_stub.dart
+++ b/packages/powersync_core/lib/src/database/powersync_database_impl_stub.dart
@@ -115,7 +115,7 @@ class PowerSyncDatabaseImpl
     required PowerSyncBackendConnector connector,
     required AbortController abort,
     required Zone asyncWorkZone,
-    required SyncOptions options,
+    required ResolvedSyncOptions options,
   }) {
     throw UnimplementedError();
   }

--- a/packages/powersync_core/lib/src/database/powersync_db_mixin.dart
+++ b/packages/powersync_core/lib/src/database/powersync_db_mixin.dart
@@ -292,6 +292,8 @@ mixin PowerSyncDatabaseMixin implements SqliteConnection {
     final resolvedOptions = ResolvedSyncOptions.resolve(
       options,
       crudThrottleTime: crudThrottleTime,
+      // ignore: deprecated_member_use_from_same_package
+      retryDelay: retryDelay,
       params: params,
     );
 

--- a/packages/powersync_core/lib/src/database/powersync_db_mixin.dart
+++ b/packages/powersync_core/lib/src/database/powersync_db_mixin.dart
@@ -289,11 +289,10 @@ mixin PowerSyncDatabaseMixin implements SqliteConnection {
     // the lock for the connection.
     await initialize();
 
-    final resolvedOptions = SyncOptions(
-      crudThrottleTime: options?.crudThrottleTime ?? crudThrottleTime,
-      // ignore: deprecated_member_use_from_same_package
-      retryDelay: options?.retryDelay ?? retryDelay,
-      params: options?.params ?? params,
+    final resolvedOptions = ResolvedSyncOptions.resolve(
+      options,
+      crudThrottleTime: crudThrottleTime,
+      params: params,
     );
 
     // ignore: deprecated_member_use_from_same_package
@@ -362,7 +361,7 @@ mixin PowerSyncDatabaseMixin implements SqliteConnection {
   @internal
   Future<void> connectInternal({
     required PowerSyncBackendConnector connector,
-    required SyncOptions options,
+    required ResolvedSyncOptions options,
     required AbortController abort,
     required Zone asyncWorkZone,
   });

--- a/packages/powersync_core/lib/src/sync/bucket_storage.dart
+++ b/packages/powersync_core/lib/src/sync/bucket_storage.dart
@@ -20,8 +20,6 @@ typedef LocalOperationCounters = ({int atLast, int sinceLast});
 class BucketStorage {
   final SqliteConnection _internalDb;
   bool _hasCompletedSync = false;
-  bool _pendingBucketDeletes = false;
-  int _compactCounter = compactOperationInterval;
 
   BucketStorage(SqliteConnection db) : _internalDb = db {
     _init();
@@ -67,11 +65,8 @@ class BucketStorage {
   }
 
   Future<void> saveSyncData(SyncDataBatch batch) async {
-    var count = 0;
-
     await writeTransaction((tx) async {
       for (var b in batch.buckets) {
-        count += b.data.length;
         await _updateBucket2(
             tx,
             jsonEncode({
@@ -82,7 +77,6 @@ class BucketStorage {
       // We get major initial sync performance improvements with IndexedDB by
       // not flushing here.
     }, flush: false);
-    _compactCounter += count;
   }
 
   Future<void> _updateBucket2(SqliteWriteContext tx, String json) async {
@@ -103,8 +97,6 @@ class BucketStorage {
           ['delete_bucket', bucket]);
       // No need to flush - not directly visible to the user
     }, flush: false);
-
-    _pendingBucketDeletes = true;
   }
 
   Future<bool> hasCompletedSync() async {
@@ -153,8 +145,6 @@ class BucketStorage {
     if (!valid) {
       return SyncLocalDatabaseResult(ready: false);
     }
-
-    await forceCompact();
 
     return SyncLocalDatabaseResult(ready: true);
   }
@@ -224,52 +214,6 @@ UPDATE ps_buckets SET count_since_last = 0, count_at_last = ?1->name
           checkpointFailures:
               (result['failed_buckets'] as List).cast<String>());
     }
-  }
-
-  Future<void> forceCompact() async {
-    _compactCounter = compactOperationInterval;
-    _pendingBucketDeletes = true;
-
-    await autoCompact();
-  }
-
-  Future<void> autoCompact() async {
-    // This is a no-op since powersync-sqlite-core v0.3.0
-
-    // 1. Delete buckets
-    await _deletePendingBuckets();
-
-    // 2. Clear REMOVE operations, only keeping PUT ones
-    await _clearRemoveOps();
-  }
-
-  Future<void> _deletePendingBuckets() async {
-    // This is a no-op since powersync-sqlite-core v0.3.0
-    if (_pendingBucketDeletes) {
-      // Executed once after start-up, and again when there are pending deletes.
-      await writeTransaction((tx) async {
-        await tx.execute(
-            'INSERT INTO powersync_operations(op, data) VALUES (?, ?)',
-            ['delete_pending_buckets', '']);
-        // No need to flush - not directly visible to the user
-      }, flush: false);
-      _pendingBucketDeletes = false;
-    }
-  }
-
-  Future<void> _clearRemoveOps() async {
-    if (_compactCounter < compactOperationInterval) {
-      return;
-    }
-
-    // This is a no-op since powersync-sqlite-core v0.3.0
-    await writeTransaction((tx) async {
-      await tx.execute(
-          'INSERT INTO powersync_operations(op, data) VALUES (?, ?)',
-          ['clear_remove_ops', '']);
-      // No need to flush - not directly visible to the user
-    }, flush: false);
-    _compactCounter = 0;
   }
 
   void setTargetCheckpoint(Checkpoint checkpoint) {

--- a/packages/powersync_core/lib/src/sync/bucket_storage.dart
+++ b/packages/powersync_core/lib/src/sync/bucket_storage.dart
@@ -365,6 +365,22 @@ UPDATE ps_buckets SET count_since_last = 0, count_at_last = ?1->name
         });
   }
 
+  Future<String> control(String op, [Object? payload]) async {
+    return await writeTransaction(
+      (tx) async {
+        final [row] =
+            await tx.execute('SELECT powersync_control(?, ?)', [op, payload]);
+        return row.columnAt(0) as String;
+      },
+      // We flush when powersync_control yields an instruction to do so.
+      flush: false,
+    );
+  }
+
+  Future<void> flushFileSystem() async {
+    // Noop outside of web.
+  }
+
   /// Note: The asynchronous nature of this is due to this needing a global
   /// lock. The actual database operations are still synchronous, and it
   /// is assumed that multiple functions on this instance won't be called

--- a/packages/powersync_core/lib/src/sync/instruction.dart
+++ b/packages/powersync_core/lib/src/sync/instruction.dart
@@ -1,0 +1,147 @@
+import 'sync_status.dart';
+
+/// An internal instruction emitted by the sync client in the core extension in
+/// response to the Dart SDK passing sync data into the extension.
+sealed class Instruction {
+  factory Instruction.fromJson(Map<String, Object?> json) {
+    return switch (json) {
+      {'LogLine': final logLine} =>
+        LogLine.fromJson(logLine as Map<String, Object?>),
+      {'UpdateSyncStatus': final updateStatus} =>
+        UpdateSyncStatus.fromJson(updateStatus as Map<String, Object?>),
+      {'EstablishSyncStream': final establish} =>
+        EstablishSyncStream.fromJson(establish as Map<String, Object?>),
+      {'FetchCredentials': final creds} =>
+        FetchCredentials.fromJson(creds as Map<String, Object?>),
+      {'CloseSyncStream': _} => const CloseSyncStream(),
+      {'FlushFileSystem': _} => const FlushFileSystem(),
+      {'DidCompleteSync': _} => const DidCompleteSync(),
+      _ => UnknownSyncInstruction(json)
+    };
+  }
+}
+
+final class LogLine implements Instruction {
+  final String severity;
+  final String line;
+
+  LogLine({required this.severity, required this.line});
+
+  factory LogLine.fromJson(Map<String, Object?> json) {
+    return LogLine(
+      severity: json['severity'] as String,
+      line: json['line'] as String,
+    );
+  }
+}
+
+final class EstablishSyncStream implements Instruction {
+  final Map<String, Object?> request;
+
+  EstablishSyncStream(this.request);
+
+  factory EstablishSyncStream.fromJson(Map<String, Object?> json) {
+    return EstablishSyncStream(json['request'] as Map<String, Object?>);
+  }
+}
+
+final class UpdateSyncStatus implements Instruction {
+  final CoreSyncStatus status;
+
+  UpdateSyncStatus({required this.status});
+
+  factory UpdateSyncStatus.fromJson(Map<String, Object?> json) {
+    return UpdateSyncStatus(
+        status:
+            CoreSyncStatus.fromJson(json['status'] as Map<String, Object?>));
+  }
+}
+
+final class CoreSyncStatus {
+  final bool connected;
+  final bool connecting;
+  final List<SyncPriorityStatus> priorityStatus;
+  final DownloadProgress? downloading;
+
+  CoreSyncStatus({
+    required this.connected,
+    required this.connecting,
+    required this.priorityStatus,
+    required this.downloading,
+  });
+
+  factory CoreSyncStatus.fromJson(Map<String, Object?> json) {
+    return CoreSyncStatus(
+      connected: json['connected'] as bool,
+      connecting: json['connecting'] as bool,
+      priorityStatus: [
+        for (final entry in json['priority_status'] as List)
+          _priorityStatusFromJson(entry as Map<String, Object?>)
+      ],
+      downloading: switch (json['downloading']) {
+        null => null,
+        final raw as Map<String, Object?> => DownloadProgress.fromJson(raw),
+      },
+    );
+  }
+
+  static SyncPriorityStatus _priorityStatusFromJson(Map<String, Object?> json) {
+    return (
+      priority: BucketPriority(json['priority'] as int),
+      hasSynced: json['has_synced'] as bool?,
+      lastSyncedAt: switch (json['last_synced_at']) {
+        null => null,
+        final lastSyncedAt as int =>
+          DateTime.fromMillisecondsSinceEpoch(lastSyncedAt * 1000),
+      },
+    );
+  }
+}
+
+final class DownloadProgress {
+  final Map<String, BucketProgress> progress;
+
+  DownloadProgress(this.progress);
+
+  factory DownloadProgress.fromJson(Map<String, Object?> line) {
+    return DownloadProgress(line.map((k, v) =>
+        MapEntry(k, _bucketProgressFromJson(v as Map<String, Object?>))));
+  }
+
+  static BucketProgress _bucketProgressFromJson(Map<String, Object?> json) {
+    return (
+      priority: BucketPriority(json['priority'] as int),
+      atLast: json['at_last'] as int,
+      sinceLast: json['since_last'] as int,
+      targetCount: json['target_count'] as int,
+    );
+  }
+}
+
+final class FetchCredentials implements Instruction {
+  final bool didExpire;
+
+  FetchCredentials(this.didExpire);
+
+  factory FetchCredentials.fromJson(Map<String, Object?> line) {
+    return FetchCredentials(line['did_expire'] as bool);
+  }
+}
+
+final class CloseSyncStream implements Instruction {
+  const CloseSyncStream();
+}
+
+final class FlushFileSystem implements Instruction {
+  const FlushFileSystem();
+}
+
+final class DidCompleteSync implements Instruction {
+  const DidCompleteSync();
+}
+
+final class UnknownSyncInstruction implements Instruction {
+  final Map<String, Object?> source;
+
+  UnknownSyncInstruction(this.source);
+}

--- a/packages/powersync_core/lib/src/sync/instruction.dart
+++ b/packages/powersync_core/lib/src/sync/instruction.dart
@@ -99,13 +99,19 @@ final class CoreSyncStatus {
 }
 
 final class DownloadProgress {
-  final Map<String, BucketProgress> progress;
+  final Map<String, BucketProgress> buckets;
 
-  DownloadProgress(this.progress);
+  DownloadProgress(this.buckets);
 
   factory DownloadProgress.fromJson(Map<String, Object?> line) {
-    return DownloadProgress(line.map((k, v) =>
-        MapEntry(k, _bucketProgressFromJson(v as Map<String, Object?>))));
+    final rawBuckets = line['buckets'] as Map<String, Object?>;
+
+    return DownloadProgress(rawBuckets.map((k, v) {
+      return MapEntry(
+        k,
+        _bucketProgressFromJson(v as Map<String, Object?>),
+      );
+    }));
   }
 
   static BucketProgress _bucketProgressFromJson(Map<String, Object?> json) {

--- a/packages/powersync_core/lib/src/sync/mutable_sync_status.dart
+++ b/packages/powersync_core/lib/src/sync/mutable_sync_status.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 
 import 'package:collection/collection.dart';
-import 'package:powersync_core/src/sync/instruction.dart';
 
+import 'instruction.dart';
 import 'sync_status.dart';
 import 'bucket_storage.dart';
 import 'protocol.dart';

--- a/packages/powersync_core/lib/src/sync/mutable_sync_status.dart
+++ b/packages/powersync_core/lib/src/sync/mutable_sync_status.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:collection/collection.dart';
+import 'package:powersync_core/src/sync/instruction.dart';
 
 import 'sync_status.dart';
 import 'bucket_storage.dart';
@@ -77,6 +78,20 @@ final class MutableSyncStatus {
     if (downloadProgress case final previousProgress?) {
       downloadProgress = previousProgress.incrementDownloaded(batch);
     }
+  }
+
+  void applyFromCore(CoreSyncStatus status) {
+    connected = status.connected;
+    connecting = status.connecting;
+    downloading = status.downloading != null;
+    priorityStatusEntries = status.priorityStatus;
+    downloadProgress = switch (status.downloading) {
+      null => null,
+      final downloading => InternalSyncDownloadProgress(downloading.progress),
+    };
+    lastSyncedAt = status.priorityStatus
+        .firstWhereOrNull((s) => s.priority == BucketPriority.fullSyncPriority)
+        ?.lastSyncedAt;
   }
 
   SyncStatus immutableSnapshot() {

--- a/packages/powersync_core/lib/src/sync/mutable_sync_status.dart
+++ b/packages/powersync_core/lib/src/sync/mutable_sync_status.dart
@@ -87,7 +87,7 @@ final class MutableSyncStatus {
     priorityStatusEntries = status.priorityStatus;
     downloadProgress = switch (status.downloading) {
       null => null,
-      final downloading => InternalSyncDownloadProgress(downloading.progress),
+      final downloading => InternalSyncDownloadProgress(downloading.buckets),
     };
     lastSyncedAt = status.priorityStatus
         .firstWhereOrNull((s) => s.priority == BucketPriority.fullSyncPriority)

--- a/packages/powersync_core/lib/src/sync/options.dart
+++ b/packages/powersync_core/lib/src/sync/options.dart
@@ -24,11 +24,41 @@ final class SyncOptions {
   /// When set to null, PowerSync defaults to a delay of 5 seconds.
   final Duration? retryDelay;
 
+  /// The [SyncClientImplementation] to use.
+  final SyncClientImplementation syncImplementation;
+
   const SyncOptions({
     this.crudThrottleTime,
     this.retryDelay,
     this.params,
+    this.syncImplementation = SyncClientImplementation.defaultClient,
   });
+}
+
+/// The PowerSync SDK offers two different implementations for receiving sync
+/// lines: One handling most logic in Dart, and a newer one offloading that work
+/// to the native PowerSync extension.
+enum SyncClientImplementation {
+  /// A sync implementation that decodes and handles sync lines in Dart.
+  @Deprecated(
+    "Don't use SyncClientImplementation.dart directly, "
+    "use SyncClientImplementation.defaultClient instead.",
+  )
+  dart,
+
+  /// An experimental sync implementation that parses and handles sync lines in
+  /// the native PowerSync core extensions.
+  ///
+  /// This implementation can be more performant than the Dart implementation,
+  /// and supports receiving sync lines in a more efficient format.
+  ///
+  /// Note that this option is currently experimental.
+  @experimental
+  rust;
+
+  /// The default sync client implementation to use.
+  // ignore: deprecated_member_use_from_same_package
+  static const defaultClient = dart;
 }
 
 @internal

--- a/packages/powersync_core/lib/src/sync/options.dart
+++ b/packages/powersync_core/lib/src/sync/options.dart
@@ -36,6 +36,7 @@ final class SyncOptions {
 
   SyncOptions _copyWith({
     Duration? crudThrottleTime,
+    Duration? retryDelay,
     Map<String, dynamic>? params,
   }) {
     return SyncOptions(
@@ -78,10 +79,12 @@ extension type ResolvedSyncOptions(SyncOptions source) {
   factory ResolvedSyncOptions.resolve(
     SyncOptions? source, {
     Duration? crudThrottleTime,
+    Duration? retryDelay,
     Map<String, dynamic>? params,
   }) {
     return ResolvedSyncOptions((source ?? SyncOptions())._copyWith(
       crudThrottleTime: crudThrottleTime,
+      retryDelay: retryDelay,
       params: params,
     ));
   }

--- a/packages/powersync_core/lib/src/sync/options.dart
+++ b/packages/powersync_core/lib/src/sync/options.dart
@@ -33,6 +33,18 @@ final class SyncOptions {
     this.params,
     this.syncImplementation = SyncClientImplementation.defaultClient,
   });
+
+  SyncOptions _copyWith({
+    Duration? crudThrottleTime,
+    Map<String, dynamic>? params,
+  }) {
+    return SyncOptions(
+      crudThrottleTime: crudThrottleTime ?? this.crudThrottleTime,
+      retryDelay: retryDelay,
+      params: params ?? this.params,
+      syncImplementation: syncImplementation,
+    );
+  }
 }
 
 /// The PowerSync SDK offers two different implementations for receiving sync
@@ -63,6 +75,17 @@ enum SyncClientImplementation {
 
 @internal
 extension type ResolvedSyncOptions(SyncOptions source) {
+  factory ResolvedSyncOptions.resolve(
+    SyncOptions? source, {
+    Duration? crudThrottleTime,
+    Map<String, dynamic>? params,
+  }) {
+    return ResolvedSyncOptions((source ?? SyncOptions())._copyWith(
+      crudThrottleTime: crudThrottleTime,
+      params: params,
+    ));
+  }
+
   Duration get crudThrottleTime =>
       source.crudThrottleTime ?? const Duration(milliseconds: 10);
 

--- a/packages/powersync_core/lib/src/sync/streaming_sync.dart
+++ b/packages/powersync_core/lib/src/sync/streaming_sync.dart
@@ -594,7 +594,8 @@ final class _ActiveRustStreamingIteration {
 
   Future<void> syncIteration() async {
     try {
-      await _control('start', convert.json.encode(sync.options.params));
+      await _control(
+          'start', convert.json.encode({'parameters': sync.options.params}));
       assert(_completedStream.isCompleted, 'Should have started streaming');
       await _completedStream.future;
     } finally {

--- a/packages/powersync_core/lib/src/sync/streaming_sync.dart
+++ b/packages/powersync_core/lib/src/sync/streaming_sync.dart
@@ -248,7 +248,6 @@ class StreamingSyncImplementation implements StreamingSync {
       }
 
       assert(identical(_activeCrudUpload, completer));
-      _nonLineSyncEvents.add(const UploadCompleted());
       _activeCrudUpload = null;
       completer.complete();
     });

--- a/packages/powersync_core/lib/src/sync/sync_status.dart
+++ b/packages/powersync_core/lib/src/sync/sync_status.dart
@@ -191,6 +191,9 @@ extension type const BucketPriority._(int priorityNumber) {
   /// A [Comparator] instance suitable for comparing [BucketPriority] values.
   static int comparator(BucketPriority a, BucketPriority b) =>
       -a.priorityNumber.compareTo(b.priorityNumber);
+
+  /// The priority used by PowerSync to indicate that a full sync was completed.
+  static const fullSyncPriority = BucketPriority._(2147483647);
 }
 
 /// Partial information about the synchronization status for buckets within a

--- a/packages/powersync_core/lib/src/web/sync_worker.dart
+++ b/packages/powersync_core/lib/src/web/sync_worker.dart
@@ -80,6 +80,10 @@ class _ConnectedClient {
                 final encodedParams =>
                   jsonDecode(encodedParams) as Map<String, Object?>,
               },
+              syncImplementation: switch (request.implementationName) {
+                null => SyncClientImplementation.defaultClient,
+                final name => SyncClientImplementation.values.byName(name),
+              },
             );
 
             _runner = _worker.referenceSyncTask(

--- a/packages/powersync_core/lib/src/web/sync_worker_protocol.dart
+++ b/packages/powersync_core/lib/src/web/sync_worker_protocol.dart
@@ -69,7 +69,8 @@ extension type StartSynchronization._(JSObject _) implements JSObject {
     required String databaseName,
     required int crudThrottleTimeMs,
     required int requestId,
-    required int? retryDelayMs,
+    required int retryDelayMs,
+    required String implementationName,
     String? syncParamsEncoded,
   });
 
@@ -77,6 +78,7 @@ extension type StartSynchronization._(JSObject _) implements JSObject {
   external int get requestId;
   external int get crudThrottleTimeMs;
   external int? get retryDelayMs;
+  external String? get implementationName;
   external String? get syncParamsEncoded;
 }
 
@@ -417,6 +419,7 @@ final class WorkerCommunicationChannel {
         crudThrottleTimeMs: options.crudThrottleTime.inMilliseconds,
         retryDelayMs: options.retryDelay.inMilliseconds,
         requestId: id,
+        implementationName: options.source.syncImplementation.name,
         syncParamsEncoded: switch (options.source.params) {
           null => null,
           final params => jsonEncode(params),

--- a/packages/powersync_core/lib/src/web/web_bucket_storage.dart
+++ b/packages/powersync_core/lib/src/web/web_bucket_storage.dart
@@ -17,4 +17,9 @@ class WebBucketStorage extends BucketStorage {
     return _webDb.writeTransaction(callback,
         lockTimeout: lockTimeout, flush: flush);
   }
+
+  @override
+  Future<void> flushFileSystem() {
+    return _webDb.flush();
+  }
 }

--- a/packages/powersync_core/test/bucket_storage_test.dart
+++ b/packages/powersync_core/test/bucket_storage_test.dart
@@ -556,8 +556,6 @@ void main() {
           writeCheckpoint: '4',
           checksums: [checksum(bucket: 'bucket1', checksum: 7)]));
 
-      await bucketStorage.forceCompact();
-
       await syncLocalChecked(Checkpoint(
           lastOpId: '4',
           writeCheckpoint: '4',
@@ -604,8 +602,6 @@ void main() {
           writeCheckpoint: '4',
           checksums: [checksum(bucket: 'bucket1', checksum: 2147483642)]));
 
-      await bucketStorage.forceCompact();
-
       await syncLocalChecked(Checkpoint(
           lastOpId: '4',
           writeCheckpoint: '4',
@@ -644,8 +640,6 @@ void main() {
           lastOpId: '4',
           writeCheckpoint: '4',
           checksums: [checksum(bucket: 'bucket1', checksum: -3)]));
-
-      await bucketStorage.forceCompact();
 
       await syncLocalChecked(Checkpoint(
           lastOpId: '4',

--- a/packages/powersync_core/test/in_memory_sync_test.dart
+++ b/packages/powersync_core/test/in_memory_sync_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:async/async.dart';
 import 'package:logging/logging.dart';
@@ -176,7 +177,7 @@ void _declareTests(String name, SyncOptions options) {
                   'object_type': 'a',
                   'object_id': '1',
                   'checksum': 0,
-                  'data': {},
+                  'data': '{}',
                 }
               ],
             }
@@ -191,7 +192,7 @@ void _declareTests(String name, SyncOptions options) {
                   'object_type': 'b',
                   'object_id': '1',
                   'checksum': 0,
-                  'data': {},
+                  'data': '{}',
                 }
               ],
             }
@@ -233,7 +234,7 @@ void _declareTests(String name, SyncOptions options) {
               'data': [
                 {
                   'checksum': priority + 10,
-                  'data': {'name': 'test', 'email': 'email'},
+                  'data': json.encode({'name': 'test', 'email': 'email'}),
                   'op': 'PUT',
                   'op_id': '${operationId++}',
                   'object_id': 'prio$priority',
@@ -415,7 +416,7 @@ void _declareTests(String name, SyncOptions options) {
             'data': [
               {
                 'checksum': 0,
-                'data': {'name': 'from local', 'email': 'local@example.org'},
+                'data': json.encode({'name': 'from local', 'email': 'local@example.org'}),
                 'op': 'PUT',
                 'op_id': '1',
                 'object_id': '1',
@@ -423,7 +424,7 @@ void _declareTests(String name, SyncOptions options) {
               },
               {
                 'checksum': 0,
-                'data': {'name': 'additional', 'email': ''},
+                'data': json.encode({'name': 'additional', 'email': ''}),
                 'op': 'PUT',
                 'op_id': '2',
                 'object_id': '2',
@@ -481,7 +482,7 @@ void _declareTests(String name, SyncOptions options) {
                   'object_type': bucket,
                   'object_id': '$lastOpId',
                   'checksum': 0,
-                  'data': {},
+                  'data': '{}',
                 }
             ],
           }

--- a/packages/powersync_core/test/in_memory_sync_test.dart
+++ b/packages/powersync_core/test/in_memory_sync_test.dart
@@ -416,7 +416,8 @@ void _declareTests(String name, SyncOptions options) {
             'data': [
               {
                 'checksum': 0,
-                'data': json.encode({'name': 'from local', 'email': 'local@example.org'}),
+                'data': json.encode(
+                    {'name': 'from local', 'email': 'local@example.org'}),
                 'op': 'PUT',
                 'op_id': '1',
                 'object_id': '1',


### PR DESCRIPTION
This adds the `SyncOptions.syncImplementation` field to control which implementation is used for parsing and applying lines received from the sync service: Two options are available: `SyncClientImplementation.dart` (the existing implementation) and a new `SyncClientImplementation.rust`. For now, `dart` is still the default implementation. To allow us to eventually remove the Dart-based implementation without a breaking change, `SyncClientImplementation.dart` is already marked as deprecated (users should use `SyncClientImplementation.defaultClient` instead, which we can eventually point to `SyncClientImplementation.rust`).

The new implementation based on the core extension follows the same pattern used in our other SDKs: We send `start` to `powersync_control`, receive an instruction to start syncing and then forward sync lines into the extension. I'm running the `in_memory_sync_test`s with both implementations now, since that test file is testing most of the sync logic.

This PR only supports JSON / HTTP streams as a way to receive sync lines - I'll open a follow-up PR adding RSocket support.