### PR TITLE
Prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,15 @@ Packages with dependency updates only:
 
 #### `powersync_core` - `v1.3.1`
 
- - http, creds, params
+- Use `package:http` instead of `package:fetch_client` on the web (since the former now uses fetch as well).
+- Allow disconnecting in the credentials callback of a connector.
+- Deprecate retry and CRUD upload durations as fields and independent parameters. Use the new `SyncOptions` class instead.
 
 #### `powersync` - `v1.13.1`
 
- - Bump "powersync" to `1.13.1`.
+- Use `package:http` instead of `package:fetch_client` on the web (since the former now uses fetch as well).
+- Allow disconnecting in the credentials callback of a connector.
+- Deprecate retry and CRUD upload durations as fields and independent parameters. Use the new `SyncOptions` class instead.
 
 #### `powersync_sqlcipher` - `v0.1.7`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,12 +33,14 @@ Packages with dependency updates only:
 - Use `package:http` instead of `package:fetch_client` on the web (since the former now uses fetch as well).
 - Allow disconnecting in the credentials callback of a connector.
 - Deprecate retry and CRUD upload durations as fields and independent parameters. Use the new `SyncOptions` class instead.
+- Fix sync progress report after a compaction or defragmentation on the sync service.
 
 #### `powersync` - `v1.13.1`
 
 - Use `package:http` instead of `package:fetch_client` on the web (since the former now uses fetch as well).
 - Allow disconnecting in the credentials callback of a connector.
 - Deprecate retry and CRUD upload durations as fields and independent parameters. Use the new `SyncOptions` class instead.
+- Fix sync progress report after a compaction or defragmentation on the sync service.
 
 #### `powersync_sqlcipher` - `v0.1.7`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,44 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2025-05-29
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`powersync_core` - `v1.3.1`](#powersync_core---v131)
+ - [`powersync` - `v1.13.1`](#powersync---v1131)
+ - [`powersync_sqlcipher` - `v0.1.7`](#powersync_sqlcipher---v017)
+ - [`powersync_attachments_helper` - `v0.6.18+8`](#powersync_attachments_helper---v06188)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `powersync_attachments_helper` - `v0.6.18+8`
+
+---
+
+#### `powersync_core` - `v1.3.1`
+
+ - http, creds, params
+
+#### `powersync` - `v1.13.1`
+
+ - Bump "powersync" to `1.13.1`.
+
+#### `powersync_sqlcipher` - `v0.1.7`
+
+ - Allow subclassing open factory for SQLCipher.
+
+
 ## 2025-05-07
 
 ### Changes

--- a/demos/benchmarks/pubspec.yaml
+++ b/demos/benchmarks/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.13.0
+  powersync: ^1.13.1
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.13.0
+  powersync: ^1.13.1
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/firebase-nodejs-todolist/pubspec.yaml
+++ b/demos/firebase-nodejs-todolist/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.13.0
+  powersync: ^1.13.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.13.0
+  powersync: ^1.13.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.13.0
+  powersync: ^1.13.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^2.0.2
   timeago: ^3.6.0
-  powersync: ^1.13.0
+  powersync: ^1.13.1
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist-drift/pubspec.yaml
+++ b/demos/supabase-todolist-drift/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.18+7
-  powersync: ^1.13.0
+  powersync_attachments_helper: ^0.6.18+8
+  powersync: ^1.13.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist-optional-sync/pubspec.yaml
+++ b/demos/supabase-todolist-optional-sync/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.13.0
+  powersync: ^1.13.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.18+7
-  powersync: ^1.13.0
+  powersync_attachments_helper: ^0.6.18+8
+  powersync: ^1.13.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-trello/pubspec.yaml
+++ b/demos/supabase-trello/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   random_name_generator: ^1.5.0
   flutter_dotenv: ^5.2.1
   logging: ^1.3.0
-  powersync: ^1.13.0
+  powersync: ^1.13.1
   sqlite_async: ^0.11.0
   path_provider: ^2.1.5
   supabase_flutter: ^2.8.3

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Use `package:http` instead of `package:fetch_client` on the web (since the former now uses fetch as well).
 - Allow disconnecting in the credentials callback of a connector.
 - Deprecate retry and CRUD upload durations as fields and independent parameters. Use the new `SyncOptions` class instead.
+- Fix sync progress report after a compaction or defragmentation on the sync service.
 
 ## 1.13.0
 

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.13.1
+
+ - Bump "powersync" to `1.13.1`.
+
 ## 1.13.0
 
 * Report real-time progress information about downloads through `SyncStatus.downloadProgress`.

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.13.1
 
- - Bump "powersync" to `1.13.1`.
+- Use `package:http` instead of `package:fetch_client` on the web (since the former now uses fetch as well).
+- Allow disconnecting in the credentials callback of a connector.
+- Deprecate retry and CRUD upload durations as fields and independent parameters. Use the new `SyncOptions` class instead.
 
 ## 1.13.0
 

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.13.0
+version: 1.13.1
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK. Sync Postgres, MongoDB or MySQL with SQLite in your Flutter app
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
 
   sqlite3_flutter_libs: ^0.5.23
-  powersync_core: ^1.3.0
+  powersync_core: ^1.3.1
   powersync_flutter_libs: ^0.4.8
   collection: ^1.17.0
 

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.18+8
+
+ - Update a dependency to the latest release.
+
 ## 0.6.18+7
 
  - Update a dependency to the latest release.

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.6.18+7
+version: 0.6.18+8
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync_core: ^1.3.0
+  powersync_core: ^1.3.1
   logging: ^1.2.0
   sqlite_async: ^0.11.0
   path_provider: ^2.0.13

--- a/packages/powersync_core/CHANGELOG.md
+++ b/packages/powersync_core/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.3.1
 
- - http, creds, params
+- Use `package:http` instead of `package:fetch_client` on the web (since the former now uses fetch as well).
+- Allow disconnecting in the credentials callback of a connector.
+- Deprecate retry and CRUD upload durations as fields and independent parameters. Use the new `SyncOptions` class instead.
 
 ## 1.3.0
 

--- a/packages/powersync_core/CHANGELOG.md
+++ b/packages/powersync_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.1
+
+ - http, creds, params
+
 ## 1.3.0
 
 * Report real-time progress information about downloads through `SyncStatus.downloadProgress`.

--- a/packages/powersync_core/CHANGELOG.md
+++ b/packages/powersync_core/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Use `package:http` instead of `package:fetch_client` on the web (since the former now uses fetch as well).
 - Allow disconnecting in the credentials callback of a connector.
 - Deprecate retry and CRUD upload durations as fields and independent parameters. Use the new `SyncOptions` class instead.
+- Fix sync progress report after a compaction or defragmentation on the sync service.
 
 ## 1.3.0
 

--- a/packages/powersync_core/lib/src/version.dart
+++ b/packages/powersync_core/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String libraryVersion = '1.3.0';
+const String libraryVersion = '1.3.1';

--- a/packages/powersync_core/pubspec.yaml
+++ b/packages/powersync_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync_core
-version: 1.3.0
+version: 1.3.1
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Dart SDK - sync engine for building local-first apps.

--- a/packages/powersync_core/test/watch_test.dart
+++ b/packages/powersync_core/test/watch_test.dart
@@ -83,9 +83,10 @@ void main() {
           lastCount = count;
         }
 
-        // The number of read queries must not be greater than the number of writes overall.
+        // The number of read queries must not be greater than the number of
+        //writes overall, plus one for an initial read.
         expect(numberOfQueries,
-            lessThanOrEqualTo(results.last.first['count'] as int));
+            lessThanOrEqualTo((results.last.first['count'] as int) + 1));
 
         DateTime? lastTime;
         for (var r in times) {

--- a/packages/powersync_sqlcipher/CHANGELOG.md
+++ b/packages/powersync_sqlcipher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.7
+
+ - Allow subclassing open factory for SQLCipher.
+
 ## 0.1.6
 
 * Report real-time progress information about downloads through `SyncStatus.downloadProgress`.

--- a/packages/powersync_sqlcipher/example/pubspec.yaml
+++ b/packages/powersync_sqlcipher/example/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 
   path: ^1.9.1
   path_provider: ^2.1.5
-  powersync_sqlcipher: ^0.1.6
+  powersync_sqlcipher: ^0.1.7
 
 dev_dependencies:
   flutter_test:

--- a/packages/powersync_sqlcipher/pubspec.yaml
+++ b/packages/powersync_sqlcipher/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync_sqlcipher
-version: 0.1.6
+version: 0.1.7
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - sync engine for building local-first apps.
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync_core: ^1.3.0
+  powersync_core: ^1.3.1
   powersync_flutter_libs: ^0.4.8
   sqlcipher_flutter_libs: ^0.6.4
   sqlite3_web: ^0.3.0


### PR DESCRIPTION
This prepares a release with these changes since the last one:

- Replace fetch client with regular `package:http`: https://github.com/powersync-ja/powersync.dart/pull/276
- Allow disconnecting in credentials callback: https://github.com/powersync-ja/powersync.dart/pull/279
- Refactor sync client and options: https://github.com/powersync-ja/powersync.dart/pull/281
- Allow subclassing SQLCipher factory: https://github.com/powersync-ja/powersync.dart/pull/284
- Fix progress around compactions and defragmentations: https://github.com/powersync-ja/powersync.dart/pull/287