### PR TITLE
Fix detecting changes in sync options

### DIFF
--- a/packages/powersync_core/lib/src/sync/options.dart
+++ b/packages/powersync_core/lib/src/sync/options.dart
@@ -47,9 +47,9 @@ extension type ResolvedSyncOptions(SyncOptions source) {
       params: other.params ?? params,
     );
 
-    final didChange = !_mapEquality.equals(other.params, params) ||
-        other.crudThrottleTime != crudThrottleTime ||
-        other.retryDelay != retryDelay;
+    final didChange = !_mapEquality.equals(newOptions.params, params) ||
+        newOptions.crudThrottleTime != crudThrottleTime ||
+        newOptions.retryDelay != retryDelay;
     return (ResolvedSyncOptions(newOptions), didChange);
   }
 

--- a/packages/powersync_core/test/sync/options_test.dart
+++ b/packages/powersync_core/test/sync/options_test.dart
@@ -1,0 +1,37 @@
+import 'package:powersync_core/src/sync/options.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('sync options', () {
+    test('can merge with changes', () {
+      final a = ResolvedSyncOptions(SyncOptions(
+        params: {'client': 'a'},
+        crudThrottleTime: const Duration(seconds: 1),
+      ));
+
+      final (b, didChange) = a.applyFrom(SyncOptions(
+        params: {'client': 'a'},
+        retryDelay: const Duration(seconds: 1),
+      ));
+
+      expect(b.params, {'client': 'a'});
+      expect(b.crudThrottleTime, const Duration(seconds: 1));
+      expect(b.retryDelay, const Duration(seconds: 1));
+      expect(didChange, isTrue);
+    });
+
+    test('can merge without changes', () {
+      final a = ResolvedSyncOptions(SyncOptions(
+        params: {'client': 'a'},
+        crudThrottleTime: const Duration(seconds: 1),
+      ));
+
+      final (_, didChange) = a.applyFrom(SyncOptions(
+        // This is the default, so no change from a
+        retryDelay: const Duration(seconds: 5),
+      ));
+
+      expect(didChange, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
The sync worker keeps the current resolved `ResolvedSyncOptions` in a field and calls `ResolvedSyncOptions.applyFrom` for new connections to see if the options have changed. That method is supposed to return a new options instance and a flag indicating whether the options have changed. The sync worker would restart the sync client with changed options if they did.

`applyFrom` used to compare the new options with the added options to determine whether the options have changed. It should compare the new options with the old options instead, which is fixed in this PR.

In practice this doesn't make a difference because two clients are supposed to send the same option, but one edge-case that is fixed here is that upgrading the sync worker and then downgrading the SDK could lead to a sync abort+reconnect every time a new tab is opened.