### PR TITLE
Prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,44 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2025-06-19
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`powersync_core` - `v1.4.0`](#powersync_core---v140)
+ - [`powersync` - `v1.14.0`](#powersync---v1140)
+ - [`powersync_sqlcipher` - `v0.1.8`](#powersync_sqlcipher---v018)
+ - [`powersync_attachments_helper` - `v0.6.18+9`](#powersync_attachments_helper---v06189)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `powersync_attachments_helper` - `v0.6.18+9`
+
+---
+
+#### `powersync_core` - `v1.4.0`
+
+ - Support new Rust-based sync implementation.
+
+#### `powersync` - `v1.14.0`
+
+ - Support new Rust-based sync implementation.
+
+#### `powersync_sqlcipher` - `v0.1.8`
+
+ - Support new Rust-based sync implementation.
+
+
 ## 2025-05-29
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,16 +30,32 @@ Packages with dependency updates only:
 
 #### `powersync_core` - `v1.4.0`
 
- - Support new Rust-based sync implementation.
-
 #### `powersync` - `v1.14.0`
-
- - Support new Rust-based sync implementation.
 
 #### `powersync_sqlcipher` - `v0.1.8`
 
- - Support new Rust-based sync implementation.
+Add a new sync client implementation written in Rust instead of Dart. While
+this client is still experimental, we intend to make it the default in the 
+future. The main benefit of this client is faster sync performance, but 
+upcoming features will also require this client.
+We encourage interested users to try it out by passing `SyncOptions` to the
+`connect` method:
 
+```dart
+database.connect(
+  connector: YourConnector(),
+  options: const SyncOptions(
+    syncImplementation: SyncClientImplementation.rust,
+  ),
+);
+```
+
+Switching between the clients can be done at any time without compatibility
+issues. If you run into issues with the new client, please reach out to us!
+
+#### `powersync_flutter_libs` - `v0.4.9`
+
+ - Update PowerSync core extension to version 0.4.0.
 
 ## 2025-05-29
 

--- a/demos/benchmarks/pubspec.yaml
+++ b/demos/benchmarks/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.13.1
+  powersync: ^1.14.0
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.13.1
+  powersync: ^1.14.0
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/firebase-nodejs-todolist/pubspec.yaml
+++ b/demos/firebase-nodejs-todolist/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.13.1
+  powersync: ^1.14.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.13.1
+  powersync: ^1.14.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.13.1
+  powersync: ^1.14.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^2.0.2
   timeago: ^3.6.0
-  powersync: ^1.13.1
+  powersync: ^1.14.0
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist-drift/pubspec.yaml
+++ b/demos/supabase-todolist-drift/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.18+8
-  powersync: ^1.13.1
+  powersync_attachments_helper: ^0.6.18+9
+  powersync: ^1.14.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist-optional-sync/pubspec.yaml
+++ b/demos/supabase-todolist-optional-sync/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.13.1
+  powersync: ^1.14.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist/lib/powersync.dart
+++ b/demos/supabase-todolist/lib/powersync.dart
@@ -153,6 +153,8 @@ Future<String> getDatabasePath() async {
   return join(dir.path, dbFilename);
 }
 
+const options = SyncOptions(syncImplementation: SyncClientImplementation.rust);
+
 Future<void> openDatabase() async {
   // Open the local database
   db = PowerSyncDatabase(
@@ -167,7 +169,7 @@ Future<void> openDatabase() async {
     // If the user is already logged in, connect immediately.
     // Otherwise, connect once logged in.
     currentConnector = SupabaseConnector();
-    db.connect(connector: currentConnector);
+    db.connect(connector: currentConnector, options: options);
   }
 
   Supabase.instance.client.auth.onAuthStateChange.listen((data) async {
@@ -175,7 +177,7 @@ Future<void> openDatabase() async {
     if (event == AuthChangeEvent.signedIn) {
       // Connect to PowerSync when the user is signed in
       currentConnector = SupabaseConnector();
-      db.connect(connector: currentConnector!);
+      db.connect(connector: currentConnector!, options: options);
     } else if (event == AuthChangeEvent.signedOut) {
       // Implicit sign out - disconnect, but don't delete data
       currentConnector = null;

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.18+8
-  powersync: ^1.13.1
+  powersync_attachments_helper: ^0.6.18+9
+  powersync: ^1.14.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-trello/pubspec.yaml
+++ b/demos/supabase-trello/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   random_name_generator: ^1.5.0
   flutter_dotenv: ^5.2.1
   logging: ^1.3.0
-  powersync: ^1.13.1
+  powersync: ^1.14.0
   sqlite_async: ^0.11.0
   path_provider: ^2.1.5
   supabase_flutter: ^2.8.3

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,6 +1,23 @@
 ## 1.14.0
 
- - Support new Rust-based sync implementation.
+Add a new sync client implementation written in Rust instead of Dart. While
+this client is still experimental, we intend to make it the default in the 
+future. The main benefit of this client is faster sync performance, but 
+upcoming features will also require this client.
+We encourage interested users to try it out by passing `SyncOptions` to the
+`connect` method:
+
+```dart
+database.connect(
+  connector: YourConnector(),
+  options: const SyncOptions(
+    syncImplementation: SyncClientImplementation.rust,
+  ),
+);
+```
+
+Switching between the clients can be done at any time without compatibility
+issues. If you run into issues with the new client, please reach out to us!
 
 ## 1.13.1
 

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.14.0
+
+ - Support new Rust-based sync implementation.
+
 ## 1.13.1
 
 - Use `package:http` instead of `package:fetch_client` on the web (since the former now uses fetch as well).

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 
   sqlite3_flutter_libs: ^0.5.23
   powersync_core: ^1.4.0
-  powersync_flutter_libs: ^0.4.8
+  powersync_flutter_libs: ^0.4.9
   collection: ^1.17.0
 
 dev_dependencies:

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.13.1
+version: 1.14.0
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK. Sync Postgres, MongoDB or MySQL with SQLite in your Flutter app
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
 
   sqlite3_flutter_libs: ^0.5.23
-  powersync_core: ^1.3.1
+  powersync_core: ^1.4.0
   powersync_flutter_libs: ^0.4.8
   collection: ^1.17.0
 

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.18+9
+
+ - Update a dependency to the latest release.
+
 ## 0.6.18+8
 
  - Update a dependency to the latest release.

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.6.18+8
+version: 0.6.18+9
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync_core: ^1.3.1
+  powersync_core: ^1.4.0
   logging: ^1.2.0
   sqlite_async: ^0.11.0
   path_provider: ^2.0.13

--- a/packages/powersync_core/CHANGELOG.md
+++ b/packages/powersync_core/CHANGELOG.md
@@ -1,6 +1,23 @@
 ## 1.4.0
 
- - Support new Rust-based sync implementation.
+Add a new sync client implementation written in Rust instead of Dart. While
+this client is still experimental, we intend to make it the default in the 
+future. The main benefit of this client is faster sync performance, but 
+upcoming features will also require this client.
+We encourage interested users to try it out by passing `SyncOptions` to the
+`connect` method:
+
+```dart
+database.connect(
+  connector: YourConnector(),
+  options: const SyncOptions(
+    syncImplementation: SyncClientImplementation.rust,
+  ),
+);
+```
+
+Switching between the clients can be done at any time without compatibility
+issues. If you run into issues with the new client, please reach out to us!
 
 ## 1.3.1
 

--- a/packages/powersync_core/CHANGELOG.md
+++ b/packages/powersync_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.0
+
+ - Support new Rust-based sync implementation.
+
 ## 1.3.1
 
 - Use `package:http` instead of `package:fetch_client` on the web (since the former now uses fetch as well).

--- a/packages/powersync_core/lib/src/version.dart
+++ b/packages/powersync_core/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String libraryVersion = '1.3.1';
+const String libraryVersion = '1.4.0';

--- a/packages/powersync_core/pubspec.yaml
+++ b/packages/powersync_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync_core
-version: 1.3.1
+version: 1.4.0
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Dart SDK - sync engine for building local-first apps.

--- a/packages/powersync_flutter_libs/CHANGELOG.md
+++ b/packages/powersync_flutter_libs/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.9
+
+ - Update PowerSync core extension to version 0.4.0.
+
 ## 0.4.8
 
  - Update PowerSync core extension to version 0.3.14.

--- a/packages/powersync_flutter_libs/pubspec.yaml
+++ b/packages/powersync_flutter_libs/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_flutter_libs
 description: PowerSync core binaries for the PowerSync Flutter SDK. Needs to be included for Flutter apps.
-version: 0.4.8
+version: 0.4.9
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 

--- a/packages/powersync_sqlcipher/CHANGELOG.md
+++ b/packages/powersync_sqlcipher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.8
+
+ - Support new Rust-based sync implementation.
+
 ## 0.1.7
 
  - Allow subclassing open factory for SQLCipher.

--- a/packages/powersync_sqlcipher/CHANGELOG.md
+++ b/packages/powersync_sqlcipher/CHANGELOG.md
@@ -1,6 +1,23 @@
 ## 0.1.8
 
- - Support new Rust-based sync implementation.
+Add a new sync client implementation written in Rust instead of Dart. While
+this client is still experimental, we intend to make it the default in the 
+future. The main benefit of this client is faster sync performance, but 
+upcoming features will also require this client.
+We encourage interested users to try it out by passing `SyncOptions` to the
+`connect` method:
+
+```dart
+database.connect(
+  connector: YourConnector(),
+  options: const SyncOptions(
+    syncImplementation: SyncClientImplementation.rust,
+  ),
+);
+```
+
+Switching between the clients can be done at any time without compatibility
+issues. If you run into issues with the new client, please reach out to us!
 
 ## 0.1.7
 

--- a/packages/powersync_sqlcipher/example/pubspec.yaml
+++ b/packages/powersync_sqlcipher/example/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 
   path: ^1.9.1
   path_provider: ^2.1.5
-  powersync_sqlcipher: ^0.1.7
+  powersync_sqlcipher: ^0.1.8
 
 dev_dependencies:
   flutter_test:

--- a/packages/powersync_sqlcipher/pubspec.yaml
+++ b/packages/powersync_sqlcipher/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync_sqlcipher
-version: 0.1.7
+version: 0.1.8
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - sync engine for building local-first apps.
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync_core: ^1.3.1
+  powersync_core: ^1.4.0
   powersync_flutter_libs: ^0.4.8
   sqlcipher_flutter_libs: ^0.6.4
   sqlite3_web: ^0.3.0

--- a/packages/powersync_sqlcipher/pubspec.yaml
+++ b/packages/powersync_sqlcipher/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
 
   powersync_core: ^1.4.0
-  powersync_flutter_libs: ^0.4.8
+  powersync_flutter_libs: ^0.4.9
   sqlcipher_flutter_libs: ^0.6.4
   sqlite3_web: ^0.3.0
 


### PR DESCRIPTION
This prepares a minor release for `powersync_core`, `powersync` and `powersync_sqlcipher` (as well as a patch release for `powersync_flutter_libs`). The only changes are to update the core extension version and enabling the new sync client.