### PR TITLE
Add test for update streams with simplified table name

### DIFF
--- a/packages/powersync_core/lib/src/powersync_update_notification.dart
+++ b/packages/powersync_core/lib/src/powersync_update_notification.dart
@@ -45,8 +45,7 @@ class PowerSyncUpdateNotification extends UpdateNotification {
 Set<String> _friendlyTableNames(Iterable<String> originalTables) {
   Set<String> tables = {};
   for (var table in originalTables) {
-    var friendlyName = friendlyTableName(table);
-    if (friendlyName != null) {
+    if (friendlyTableName(table) case final friendlyName?) {
       tables.add(friendlyName);
     } else if (!table.startsWith('ps_')) {
       tables.add(table);

--- a/packages/powersync_core/lib/src/schema_logic.dart
+++ b/packages/powersync_core/lib/src/schema_logic.dart
@@ -21,8 +21,14 @@ Future<void> updateSchemaInIsolate(
 }
 
 String? friendlyTableName(String table) {
-  final re = RegExp(r"^ps_data__(.+)$");
-  final re2 = RegExp(r"^ps_data_local__(.+)$");
-  final match = re.firstMatch(table) ?? re2.firstMatch(table);
-  return match?.group(1);
+  const prefix1 = 'ps_data__';
+  const prefix2 = 'ps_data_local__';
+
+  if (table.startsWith(prefix2)) {
+    return table.substring(prefix2.length);
+  } else if (table.startsWith(prefix1)) {
+    return table.substring(prefix1.length);
+  } else {
+    return null;
+  }
 }

--- a/packages/powersync_core/test/watch_test.dart
+++ b/packages/powersync_core/test/watch_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'package:async/async.dart';
 import 'package:powersync_core/powersync_core.dart';
 import 'package:sqlite_async/sqlite_async.dart';
 import 'package:test/test.dart';
@@ -137,6 +138,29 @@ void main() {
             UpdateNotification.single('assets'),
             UpdateNotification.single('assets')
           ]));
+    });
+
+    test('emits update events with friendly names', () async {
+      final powersync = await testUtils.setupPowerSync(
+        path: path,
+        schema: Schema([
+          Table.localOnly('users', [
+            Column.text('name'),
+          ]),
+          Table('assets', [
+            Column.text('name'),
+          ]),
+        ]),
+      );
+
+      final updates = StreamQueue(powersync.updates);
+      await powersync
+          .execute('INSERT INTO users (id, name) VALUES (uuid(), ?)', ['test']);
+      await expectLater(updates, emits(UpdateNotification({'users'})));
+
+      await powersync.execute(
+          'INSERT INTO assets (id, name) VALUES (uuid(), ?)', ['test']);
+      await expectLater(updates, emits(UpdateNotification({'assets'})));
     });
   });
 }


### PR DESCRIPTION
This adds a test ensuring that `PowerSyncDatabase.updates` transforms update notifications to the friendly table name. It also simplifies the `friendlyTableName` to use a simple prefix match instead of a regex.