### PR TITLE
Fix http error parsing

### DIFF
--- a/packages/powersync_core/lib/src/exceptions.dart
+++ b/packages/powersync_core/lib/src/exceptions.dart
@@ -42,7 +42,7 @@ class SyncResponseException implements Exception {
       final details = _stringOrFirst(decoded['error']?['details']) ?? body;
       final message = '${response.reasonPhrase ?? "Request failed"}: $details';
       return SyncResponseException(response.statusCode, message);
-    } on Error catch (_) {
+    } on Exception catch (_) {
       return SyncResponseException(
         response.statusCode,
         response.reasonPhrase ?? "Request failed",
@@ -58,12 +58,7 @@ class SyncResponseException implements Exception {
       final details = _stringOrFirst(decoded['error']?['details']) ?? body;
       final message = '${response.reasonPhrase ?? "Request failed"}: $details';
       return SyncResponseException(response.statusCode, message);
-    } on FormatException catch (_) {
-      return SyncResponseException(
-        response.statusCode,
-        response.reasonPhrase ?? "Request failed",
-      );
-    } on Error catch (_) {
+    } on Exception catch (_) {
       return SyncResponseException(
         response.statusCode,
         response.reasonPhrase ?? "Request failed",


### PR DESCRIPTION
We should catch Exception, not Error. This resulted in errors like this:

```
FormatException: Unexpected character (at character 1)
<html>
^
```

With this change, we're getting the expected exception:
```
SyncResponseException: 503 Service Unavailable
```
