### PR TITLE
Fix typo in method parameter: loggers -> logger

### DIFF
--- a/packages/powersync_core/lib/src/database/powersync_database.dart
+++ b/packages/powersync_core/lib/src/database/powersync_database.dart
@@ -68,11 +68,16 @@ abstract class PowerSyncDatabase
   /// Migrations are run on the database when this constructor is called.
   ///
   /// [logger] defaults to [autoLogger], which logs to the console in debug builds.
-  factory PowerSyncDatabase.withDatabase(
-      {required Schema schema,
-      required SqliteDatabase database,
-      Logger? loggers}) {
+  factory PowerSyncDatabase.withDatabase({
+    required Schema schema,
+    required SqliteDatabase database,
+    Logger? logger,
+    @Deprecated("Use [logger] instead") Logger? loggers,
+  }) {
     return PowerSyncDatabaseImpl.withDatabase(
-        schema: schema, database: database, logger: loggers);
+      schema: schema,
+      database: database,
+      logger: loggers ?? logger,
+    );
   }
 }

--- a/packages/powersync_core/test/utils/abstract_test_utils.dart
+++ b/packages/powersync_core/test/utils/abstract_test_utils.dart
@@ -74,7 +74,7 @@ abstract mixin class TestPowerSyncFactory implements PowerSyncOpenFactory {
       schema: schema,
       database: SqliteDatabase.singleConnection(
           SqliteConnection.synchronousWrapper(raw)),
-      loggers: logger,
+      logger: logger,
     );
   }
 }


### PR DESCRIPTION
`PowerSyncDatabase.withDatabase` was declaring `loggers` instead of `logger`. This changes it while keeping the wrong one as deprecated to avoid breaking.