### PR TITLE
Prepare minor release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,44 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2025-07-17
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`powersync_core` - `v1.5.0`](#powersync_core---v150)
+ - [`powersync` - `v1.15.0`](#powersync---v1150)
+ - [`powersync_sqlcipher` - `v0.1.10`](#powersync_sqlcipher---v0110)
+ - [`powersync_flutter_libs` - `v0.4.10`](#powersync_flutter_libs---v0410)
+ - [`powersync_attachments_helper` - `v0.6.18+11`](#powersync_attachments_helper---v061811)
+
+Packages with dependency updates only:
+
+> Packages listed below depend on other packages in this workspace that have had changes. Their versions have been incremented to bump the minimum dependency versions of the packages they depend upon in this project.
+
+ - `powersync_attachments_helper` - `v0.6.18+11`
+
+---
+
+#### `powersync_flutter_libs` - `v0.4.10`.
+
+ - Update the PowerSync core extension to `0.4.2`.
+
+#### `powersync_core` - `v1.5.0`
+#### `powersync` - `v1.15.0`
+#### `powersync_sqlcipher` - `v0.1.10`
+
+ - Add support for [raw tables](https://docs.powersync.com/usage/use-case-examples/raw-tables), which are user-managed
+   regular SQLite tables instead of the JSON-based views managed by PowerSync.
+
+
 ## 2025-07-07
 
 ### Changes

--- a/demos/benchmarks/pubspec.yaml
+++ b/demos/benchmarks/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.14.1
+  powersync: ^1.15.0
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.14.1
+  powersync: ^1.15.0
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/firebase-nodejs-todolist/pubspec.yaml
+++ b/demos/firebase-nodejs-todolist/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.14.1
+  powersync: ^1.15.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.14.1
+  powersync: ^1.15.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.14.1
+  powersync: ^1.15.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^2.0.2
   timeago: ^3.6.0
-  powersync: ^1.14.1
+  powersync: ^1.15.0
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist-drift/pubspec.yaml
+++ b/demos/supabase-todolist-drift/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.18+10
-  powersync: ^1.14.1
+  powersync_attachments_helper: ^0.6.18+11
+  powersync: ^1.15.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist-optional-sync/pubspec.yaml
+++ b/demos/supabase-todolist-optional-sync/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.14.1
+  powersync: ^1.15.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.18+10
-  powersync: ^1.14.1
+  powersync_attachments_helper: ^0.6.18+11
+  powersync: ^1.15.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-trello/pubspec.yaml
+++ b/demos/supabase-trello/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   random_name_generator: ^1.5.0
   flutter_dotenv: ^5.2.1
   logging: ^1.3.0
-  powersync: ^1.14.1
+  powersync: ^1.15.0
   sqlite_async: ^0.11.0
   path_provider: ^2.1.5
   supabase_flutter: ^2.8.3

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.15.0
+
+ - Update the PowerSync core extension to `0.4.2`.
+ - Add support for [raw tables](https://docs.powersync.com/usage/use-case-examples/raw-tables), which are user-managed
+   regular SQLite tables instead of the JSON-based views managed by PowerSync.
+
 ## 1.14.1
 
  - Rust client: Fix uploading local writs after reconnect.

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.14.1
+version: 1.15.0
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK. Sync Postgres, MongoDB or MySQL with SQLite in your Flutter app
@@ -12,8 +12,8 @@ dependencies:
     sdk: flutter
 
   sqlite3_flutter_libs: ^0.5.23
-  powersync_core: ^1.4.1
-  powersync_flutter_libs: ^0.4.9
+  powersync_core: ^1.5.0
+  powersync_flutter_libs: ^0.4.10
   collection: ^1.17.0
 
 dev_dependencies:

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.18+11
+
+ - Update a dependency to the latest release.
+
 ## 0.6.18+10
 
  - Update a dependency to the latest release.

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.6.18+10
+version: 0.6.18+11
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 environment:
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync_core: ^1.4.1
+  powersync_core: ^1.5.0
   logging: ^1.2.0
   sqlite_async: ^0.11.0
   path_provider: ^2.0.13

--- a/packages/powersync_core/CHANGELOG.md
+++ b/packages/powersync_core/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.5.0
+
+ - Update the PowerSync core extension to `0.4.2`.
+ - Add support for [raw tables](https://docs.powersync.com/usage/use-case-examples/raw-tables), which are user-managed
+   regular SQLite tables instead of the JSON-based views managed by PowerSync.
+
 ## 1.4.1
 
  - Rust client: Fix uploading local writes after reconnect.

--- a/packages/powersync_core/lib/src/version.dart
+++ b/packages/powersync_core/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String libraryVersion = '1.4.1';
+const String libraryVersion = '1.5.0';

--- a/packages/powersync_core/pubspec.yaml
+++ b/packages/powersync_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync_core
-version: 1.4.1
+version: 1.5.0
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Dart SDK - sync engine for building local-first apps.

--- a/packages/powersync_flutter_libs/CHANGELOG.md
+++ b/packages/powersync_flutter_libs/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.10
+
+ - Update PowerSync core extension to version 0.4.2.
+
 ## 0.4.9
 
  - Update PowerSync core extension to version 0.4.0.

--- a/packages/powersync_flutter_libs/pubspec.yaml
+++ b/packages/powersync_flutter_libs/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_flutter_libs
 description: PowerSync core binaries for the PowerSync Flutter SDK. Needs to be included for Flutter apps.
-version: 0.4.9
+version: 0.4.10
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 

--- a/packages/powersync_sqlcipher/CHANGELOG.md
+++ b/packages/powersync_sqlcipher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.10
+
+ - raw tables
+
 ## 0.1.9
 
  - Rust client: Fix uploading local writes after reconnect.

--- a/packages/powersync_sqlcipher/example/pubspec.yaml
+++ b/packages/powersync_sqlcipher/example/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 
   path: ^1.9.1
   path_provider: ^2.1.5
-  powersync_sqlcipher: ^0.1.9
+  powersync_sqlcipher: ^0.1.10
 
 dev_dependencies:
   flutter_test:

--- a/packages/powersync_sqlcipher/pubspec.yaml
+++ b/packages/powersync_sqlcipher/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync_sqlcipher
-version: 0.1.9
+version: 0.1.10
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - sync engine for building local-first apps.
@@ -12,8 +12,8 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync_core: ^1.4.1
-  powersync_flutter_libs: ^0.4.9
+  powersync_core: ^1.5.0
+  powersync_flutter_libs: ^0.4.10
   sqlcipher_flutter_libs: ^0.6.4
   sqlite3_web: ^0.3.0
 


### PR DESCRIPTION
This prepares a release for the following packages:

 - powersync_core@1.5.0
 - powersync@1.15.0
 - powersync_sqlcipher@0.1.10
 - powersync_attachments_helper@0.6.18+11
 - powersync_flutter_libs@0.4.10

The only changes are updating the core extension version and introducing experimental support for raw tables.