### PR TITLE
Use new error response format to parse errors

### DIFF
--- a/packages/powersync_core/lib/src/exceptions.dart
+++ b/packages/powersync_core/lib/src/exceptions.dart
@@ -102,7 +102,7 @@ class SyncResponseException implements Exception {
 
     if (details is String) {
       fullDescription
-        ..write(' ')
+        ..write(', ')
         ..write(details);
     }
 

--- a/packages/powersync_core/test/exceptions_test.dart
+++ b/packages/powersync_core/test/exceptions_test.dart
@@ -26,6 +26,17 @@ void main() {
           'Request failed: PSYNC_S2106(AuthorizationError): Authentication required');
     });
 
+    test('with description', () {
+      const errorResponse =
+          '{"error":{"code":"PSYNC_S2106","status":401,"description":"Authentication required","name":"AuthorizationError", "details": "Missing authorization header"}}';
+
+      final exc =
+          SyncResponseException.fromResponse(Response(errorResponse, 401));
+      expect(exc.statusCode, 401);
+      expect(exc.description,
+          'Request failed: PSYNC_S2106(AuthorizationError): Authentication required, Missing authorization header');
+    });
+
     test('malformed', () {
       const malformed =
           '{"message":"Route GET:/foo/bar not found","error":"Not Found","statusCode":404}';


### PR DESCRIPTION
We currently try to extract `$.errors.details` as a description from error responses, a field that is [optional and doesn't include much of the error](https://github.com/powersync-ja/powersync-service/blob/1aafdaf0710d7ddda36f54b70cd1f62856b73d63/packages/service-errors/src/errors.ts#L16). These limited error messages make it harder than necessary to debug service issues from the client.

This PR changes that logic to include more fields, like the PowerSync error code and description.
