### PR TITLE
Rust client: Request sync lines as BSON

### DIFF
--- a/packages/powersync_core/lib/src/sync/stream_utils.dart
+++ b/packages/powersync_core/lib/src/sync/stream_utils.dart
@@ -1,6 +1,12 @@
 import 'dart:async';
 
 import 'dart:convert' as convert;
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:typed_data/typed_buffers.dart';
+
+import '../exceptions.dart';
 
 /// Inject a broadcast stream into a normal stream.
 Stream<T> addBroadcast<T>(Stream<T> a, Stream<T> broadcast) {
@@ -75,6 +81,11 @@ extension ByteStreamToLines on Stream<List<int>> {
     final textInput = transform(convert.utf8.decoder);
     return textInput.transform(const convert.LineSplitter());
   }
+
+  /// Splits this stream into BSON documents without parsing them.
+  Stream<Uint8List> get bsonDocuments {
+    return Stream.eventTransformed(this, _BsonSplittingSink.new);
+  }
 }
 
 extension StreamToJson on Stream<String> {
@@ -98,4 +109,92 @@ void resumeAll(List<StreamSubscription<void>> subscriptions) {
 Future<void> cancelAll(List<StreamSubscription<void>> subscriptions) async {
   final futures = subscriptions.map((sub) => sub.cancel());
   await Future.wait(futures);
+}
+
+/// An [EventSink] that takes raw bytes as inputs, buffers them internally by
+/// reading a 4-byte length prefix for each message and then emits them as
+/// chunks.
+final class _BsonSplittingSink implements EventSink<List<int>> {
+  final EventSink<Uint8List> _downstream;
+
+  final length = ByteData(4);
+  int remainingBytes = 4;
+
+  Uint8Buffer? pendingBuffer;
+
+  _BsonSplittingSink(this._downstream);
+
+  @override
+  void add(List<int> data) {
+    var i = 0;
+    while (i < data.length) {
+      final availableInData = data.length - i;
+
+      if (pendingBuffer case final pending?) {
+        // We're in the middle of reading a document
+        final bytesToRead = min(availableInData, remainingBytes);
+        pending.addAll(data, i, i + bytesToRead);
+        i += bytesToRead;
+        remainingBytes -= bytesToRead;
+        assert(remainingBytes >= 0);
+
+        if (remainingBytes == 0) {
+          _downstream.add(pending.buffer
+              .asUint8List(pending.offsetInBytes, pending.lengthInBytes));
+
+          // Prepare reading another document, starting with its length
+          pendingBuffer = null;
+          remainingBytes = 4;
+        }
+      } else {
+        final bytesToRead = min(availableInData, remainingBytes);
+        final lengthAsUint8List = length.buffer.asUint8List();
+
+        lengthAsUint8List.setRange(
+          4 - remainingBytes,
+          4 - remainingBytes + bytesToRead,
+          data,
+          i,
+        );
+        i += bytesToRead;
+        remainingBytes -= bytesToRead;
+        assert(remainingBytes >= 0);
+
+        if (remainingBytes == 0) {
+          // Transition from reading length header to reading document.
+          // Subtracting 4 because the length of the header is included in the
+          // length.
+          remainingBytes = length.getInt32(0, Endian.little) - 4;
+          if (remainingBytes < 5) {
+            _downstream.addError(
+              PowerSyncProtocolException(
+                  'Invalid length for bson: $remainingBytes'),
+              StackTrace.current,
+            );
+          }
+
+          pendingBuffer = Uint8Buffer()..addAll(lengthAsUint8List);
+        }
+      }
+    }
+
+    assert(i == data.length);
+  }
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {
+    _downstream.addError(error, stackTrace);
+  }
+
+  @override
+  void close() {
+    if (pendingBuffer != null || remainingBytes != 4) {
+      _downstream.addError(
+        PowerSyncProtocolException('Pending data when stream was closed'),
+        StackTrace.current,
+      );
+    }
+
+    _downstream.close();
+  }
 }

--- a/packages/powersync_core/pubspec.yaml
+++ b/packages/powersync_core/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   pub_semver: ^2.0.0
   pubspec_parse: ^1.3.0
   path: ^1.8.0
+  typed_data: ^1.4.0
 
 dev_dependencies:
   lints: ^5.1.1
@@ -38,6 +39,7 @@ dev_dependencies:
   shelf_static: ^1.1.2
   stream_channel: ^2.1.2
   fake_async: ^1.3.3
+  bson: ^5.0.7
 
 platforms:
   android:

--- a/packages/powersync_core/test/in_memory_sync_test.dart
+++ b/packages/powersync_core/test/in_memory_sync_test.dart
@@ -19,20 +19,33 @@ void main() {
   _declareTests(
     'dart sync client',
     SyncOptions(
-        // ignore: deprecated_member_use_from_same_package
-        syncImplementation: SyncClientImplementation.dart,
-        retryDelay: Duration(milliseconds: 200)),
+      // ignore: deprecated_member_use_from_same_package
+      syncImplementation: SyncClientImplementation.dart,
+      retryDelay: Duration(milliseconds: 200),
+    ),
+    false,
   );
 
-  _declareTests(
-    'rust sync client',
-    SyncOptions(
-        syncImplementation: SyncClientImplementation.rust,
-        retryDelay: Duration(milliseconds: 200)),
-  );
+  group('rust sync client', () {
+    _declareTests(
+      'json',
+      SyncOptions(
+          syncImplementation: SyncClientImplementation.rust,
+          retryDelay: Duration(milliseconds: 200)),
+      false,
+    );
+
+    _declareTests(
+      'bson',
+      SyncOptions(
+          syncImplementation: SyncClientImplementation.rust,
+          retryDelay: Duration(milliseconds: 200)),
+      true,
+    );
+  });
 }
 
-void _declareTests(String name, SyncOptions options) {
+void _declareTests(String name, SyncOptions options, bool bson) {
   final ignoredLogger = Logger.detached('powersync.test')..level = Level.OFF;
 
   group(name, () {
@@ -74,7 +87,7 @@ void _declareTests(String name, SyncOptions options) {
     setUp(() async {
       logger = Logger.detached('powersync.active')..level = Level.ALL;
       credentialsCallbackCount = 0;
-      syncService = MockSyncService();
+      syncService = MockSyncService(useBson: bson);
 
       factory = await testUtils.testFactory();
       (raw, database) = await factory.openInMemoryDatabase();


### PR DESCRIPTION
This relies on https://github.com/powersync-ja/powersync-service/pull/310 and requests sync lines in a binary format when the Rust client is used.

We still support the sync service responding with text lines, but the response handling now supports splitting the BSON stream and sends that as a preference to ensure we can handle binary data. This makes the Dart SDK ready for binary data without relying on RSocket, which is poorly supported on Dart.

I've tested this with the sync service from the linked PR, and I've also expanded all sync unit tests to include the binary stream. I've also tested this PR with an old sync service, and `main` with the new sync service to make sure content negotiation works like it's supposed to.