### PR TITLE
Update `package:sqlite3` for wasm build

### DIFF
--- a/packages/sqlite3_wasm_build/build.sh
+++ b/packages/sqlite3_wasm_build/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-SQLITE_VERSION="2.7.6"
+SQLITE_VERSION="2.8.0"
 POWERSYNC_CORE_VERSION="0.4.2"
 SQLITE_PATH="sqlite3.dart"
 

--- a/packages/sqlite3_wasm_build/build.sh
+++ b/packages/sqlite3_wasm_build/build.sh
@@ -16,7 +16,6 @@ cd $SQLITE_PATH
 git apply ../patches/*
 
 cd "sqlite3/"
-dart pub get # We need the analyzer dependency resolved to extract required symbols
 
 cmake -Dwasi_sysroot=/opt/homebrew/share/wasi-sysroot \
     -Dclang=/opt/homebrew/opt/llvm/bin/clang\


### PR DESCRIPTION
This updates the sqlite version for the wasm build. That update also simplifies the build a bit, so we no longer need to run `pub get` during the build. 