### PR TITLE
Update sqlite packages

### DIFF
--- a/demos/benchmarks/ios/Podfile.lock
+++ b/demos/benchmarks/ios/Podfile.lock
@@ -3,10 +3,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.4.2)
+  - powersync-sqlite-core (0.4.4)
   - powersync_flutter_libs (0.0.1):
     - Flutter
-    - powersync-sqlite-core (~> 0.4.2)
+    - powersync-sqlite-core (~> 0.4.4)
   - sqlite3 (3.49.2):
     - sqlite3/common (= 3.49.2)
   - sqlite3/common (3.49.2)
@@ -54,8 +54,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  powersync-sqlite-core: a58efd88833861f0a8bb636c171bdf0ed55c9801
-  powersync_flutter_libs: 881187a07f70ecabaf802fce45b186485464d618
+  powersync-sqlite-core: 954b7c4f068e21e6e759a7f487f0d7da4062e858
+  powersync_flutter_libs: ecbd37268a3705351178a05c81434592f0dcc6e5
   sqlite3: 3c950dc86011117c307eb0b28c4a7bb449dce9f1
   sqlite3_flutter_libs: f6acaa2172e6bb3e2e70c771661905080e8ebcf2
 

--- a/demos/benchmarks/macos/Podfile.lock
+++ b/demos/benchmarks/macos/Podfile.lock
@@ -3,10 +3,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.4.2)
+  - powersync-sqlite-core (0.4.4)
   - powersync_flutter_libs (0.0.1):
     - FlutterMacOS
-    - powersync-sqlite-core (~> 0.4.2)
+    - powersync-sqlite-core (~> 0.4.4)
   - sqlite3 (3.49.2):
     - sqlite3/common (= 3.49.2)
   - sqlite3/common (3.49.2)
@@ -54,8 +54,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  powersync-sqlite-core: a58efd88833861f0a8bb636c171bdf0ed55c9801
-  powersync_flutter_libs: fa885a30ceb636655741eee2ff5282d0500fa96b
+  powersync-sqlite-core: 954b7c4f068e21e6e759a7f487f0d7da4062e858
+  powersync_flutter_libs: e8debf4b25a998c233cf7992d17cd49b407c56d1
   sqlite3: 3c950dc86011117c307eb0b28c4a7bb449dce9f1
   sqlite3_flutter_libs: f6acaa2172e6bb3e2e70c771661905080e8ebcf2
 

--- a/demos/benchmarks/pubspec.yaml
+++ b/demos/benchmarks/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   path: ^1.8.3
   logging: ^1.2.0
   universal_io: ^2.2.2
-  sqlite_async: ^0.11.0
+  sqlite_async: ^0.12.0
   http: ^1.2.2
 
 dev_dependencies:

--- a/demos/django-todolist/ios/Podfile.lock
+++ b/demos/django-todolist/ios/Podfile.lock
@@ -3,10 +3,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.4.2)
+  - powersync-sqlite-core (0.4.4)
   - powersync_flutter_libs (0.0.1):
     - Flutter
-    - powersync-sqlite-core (~> 0.4.2)
+    - powersync-sqlite-core (~> 0.4.4)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -60,8 +60,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  powersync-sqlite-core: a58efd88833861f0a8bb636c171bdf0ed55c9801
-  powersync_flutter_libs: 881187a07f70ecabaf802fce45b186485464d618
+  powersync-sqlite-core: 954b7c4f068e21e6e759a7f487f0d7da4062e858
+  powersync_flutter_libs: ecbd37268a3705351178a05c81434592f0dcc6e5
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqlite3: 3c950dc86011117c307eb0b28c4a7bb449dce9f1
   sqlite3_flutter_libs: f6acaa2172e6bb3e2e70c771661905080e8ebcf2

--- a/demos/django-todolist/macos/Podfile.lock
+++ b/demos/django-todolist/macos/Podfile.lock
@@ -3,10 +3,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.4.2)
+  - powersync-sqlite-core (0.4.4)
   - powersync_flutter_libs (0.0.1):
     - FlutterMacOS
-    - powersync-sqlite-core (~> 0.4.2)
+    - powersync-sqlite-core (~> 0.4.4)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -60,8 +60,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  powersync-sqlite-core: a58efd88833861f0a8bb636c171bdf0ed55c9801
-  powersync_flutter_libs: fa885a30ceb636655741eee2ff5282d0500fa96b
+  powersync-sqlite-core: 954b7c4f068e21e6e759a7f487f0d7da4062e858
+  powersync_flutter_libs: e8debf4b25a998c233cf7992d17cd49b407c56d1
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqlite3: 3c950dc86011117c307eb0b28c4a7bb449dce9f1
   sqlite3_flutter_libs: f6acaa2172e6bb3e2e70c771661905080e8ebcf2

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.11.0
+  sqlite_async: ^0.12.0
   http: ^1.2.1
   shared_preferences: ^2.2.3
 

--- a/demos/firebase-nodejs-todolist/ios/Podfile.lock
+++ b/demos/firebase-nodejs-todolist/ios/Podfile.lock
@@ -58,10 +58,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.4.2)
+  - powersync-sqlite-core (0.4.4)
   - powersync_flutter_libs (0.0.1):
     - Flutter
-    - powersync-sqlite-core (~> 0.4.2)
+    - powersync-sqlite-core (~> 0.4.4)
   - RecaptchaInterop (101.0.0)
   - shared_preferences_foundation (0.0.1):
     - Flutter
@@ -152,8 +152,8 @@ SPEC CHECKSUMS:
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   GTMSessionFetcher: fc75fc972958dceedee61cb662ae1da7a83a91cf
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  powersync-sqlite-core: a58efd88833861f0a8bb636c171bdf0ed55c9801
-  powersync_flutter_libs: 881187a07f70ecabaf802fce45b186485464d618
+  powersync-sqlite-core: 954b7c4f068e21e6e759a7f487f0d7da4062e858
+  powersync_flutter_libs: ecbd37268a3705351178a05c81434592f0dcc6e5
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqlite3: 3c950dc86011117c307eb0b28c4a7bb449dce9f1

--- a/demos/supabase-anonymous-auth/ios/Podfile.lock
+++ b/demos/supabase-anonymous-auth/ios/Podfile.lock
@@ -5,10 +5,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.4.2)
+  - powersync-sqlite-core (0.4.4)
   - powersync_flutter_libs (0.0.1):
     - Flutter
-    - powersync-sqlite-core (~> 0.4.2)
+    - powersync-sqlite-core (~> 0.4.4)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -71,8 +71,8 @@ SPEC CHECKSUMS:
   app_links: 76b66b60cc809390ca1ad69bfd66b998d2387ac7
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  powersync-sqlite-core: a58efd88833861f0a8bb636c171bdf0ed55c9801
-  powersync_flutter_libs: 881187a07f70ecabaf802fce45b186485464d618
+  powersync-sqlite-core: 954b7c4f068e21e6e759a7f487f0d7da4062e858
+  powersync_flutter_libs: ecbd37268a3705351178a05c81434592f0dcc6e5
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqlite3: 3c950dc86011117c307eb0b28c4a7bb449dce9f1
   sqlite3_flutter_libs: f6acaa2172e6bb3e2e70c771661905080e8ebcf2

--- a/demos/supabase-anonymous-auth/macos/Podfile.lock
+++ b/demos/supabase-anonymous-auth/macos/Podfile.lock
@@ -5,10 +5,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.4.2)
+  - powersync-sqlite-core (0.4.4)
   - powersync_flutter_libs (0.0.1):
     - FlutterMacOS
-    - powersync-sqlite-core (~> 0.4.2)
+    - powersync-sqlite-core (~> 0.4.4)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -71,8 +71,8 @@ SPEC CHECKSUMS:
   app_links: afe860c55c7ef176cea7fb630a2b7d7736de591d
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  powersync-sqlite-core: a58efd88833861f0a8bb636c171bdf0ed55c9801
-  powersync_flutter_libs: fa885a30ceb636655741eee2ff5282d0500fa96b
+  powersync-sqlite-core: 954b7c4f068e21e6e759a7f487f0d7da4062e858
+  powersync_flutter_libs: e8debf4b25a998c233cf7992d17cd49b407c56d1
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqlite3: 3c950dc86011117c307eb0b28c4a7bb449dce9f1
   sqlite3_flutter_libs: f6acaa2172e6bb3e2e70c771661905080e8ebcf2

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   supabase_flutter: ^2.0.2
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.11.0
+  sqlite_async: ^0.12.0
   universal_io: ^2.2.2
 
 dev_dependencies:

--- a/demos/supabase-edge-function-auth/ios/Podfile.lock
+++ b/demos/supabase-edge-function-auth/ios/Podfile.lock
@@ -5,10 +5,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.4.2)
+  - powersync-sqlite-core (0.4.4)
   - powersync_flutter_libs (0.0.1):
     - Flutter
-    - powersync-sqlite-core (~> 0.4.2)
+    - powersync-sqlite-core (~> 0.4.4)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -71,8 +71,8 @@ SPEC CHECKSUMS:
   app_links: 76b66b60cc809390ca1ad69bfd66b998d2387ac7
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  powersync-sqlite-core: a58efd88833861f0a8bb636c171bdf0ed55c9801
-  powersync_flutter_libs: 881187a07f70ecabaf802fce45b186485464d618
+  powersync-sqlite-core: 954b7c4f068e21e6e759a7f487f0d7da4062e858
+  powersync_flutter_libs: ecbd37268a3705351178a05c81434592f0dcc6e5
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqlite3: 3c950dc86011117c307eb0b28c4a7bb449dce9f1
   sqlite3_flutter_libs: f6acaa2172e6bb3e2e70c771661905080e8ebcf2

--- a/demos/supabase-edge-function-auth/macos/Podfile.lock
+++ b/demos/supabase-edge-function-auth/macos/Podfile.lock
@@ -5,10 +5,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.4.2)
+  - powersync-sqlite-core (0.4.4)
   - powersync_flutter_libs (0.0.1):
     - FlutterMacOS
-    - powersync-sqlite-core (~> 0.4.2)
+    - powersync-sqlite-core (~> 0.4.4)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -71,8 +71,8 @@ SPEC CHECKSUMS:
   app_links: afe860c55c7ef176cea7fb630a2b7d7736de591d
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  powersync-sqlite-core: a58efd88833861f0a8bb636c171bdf0ed55c9801
-  powersync_flutter_libs: fa885a30ceb636655741eee2ff5282d0500fa96b
+  powersync-sqlite-core: 954b7c4f068e21e6e759a7f487f0d7da4062e858
+  powersync_flutter_libs: e8debf4b25a998c233cf7992d17cd49b407c56d1
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqlite3: 3c950dc86011117c307eb0b28c4a7bb449dce9f1
   sqlite3_flutter_libs: f6acaa2172e6bb3e2e70c771661905080e8ebcf2

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   supabase_flutter: ^2.0.2
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.11.0
+  sqlite_async: ^0.12.0
   universal_io: ^2.2.2
 
 dev_dependencies:

--- a/demos/supabase-simple-chat/ios/Podfile.lock
+++ b/demos/supabase-simple-chat/ios/Podfile.lock
@@ -5,10 +5,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.4.2)
+  - powersync-sqlite-core (0.4.4)
   - powersync_flutter_libs (0.0.1):
     - Flutter
-    - powersync-sqlite-core (~> 0.4.2)
+    - powersync-sqlite-core (~> 0.4.4)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -71,8 +71,8 @@ SPEC CHECKSUMS:
   app_links: 76b66b60cc809390ca1ad69bfd66b998d2387ac7
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  powersync-sqlite-core: a58efd88833861f0a8bb636c171bdf0ed55c9801
-  powersync_flutter_libs: 881187a07f70ecabaf802fce45b186485464d618
+  powersync-sqlite-core: 954b7c4f068e21e6e759a7f487f0d7da4062e858
+  powersync_flutter_libs: ecbd37268a3705351178a05c81434592f0dcc6e5
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqlite3: 3c950dc86011117c307eb0b28c4a7bb449dce9f1
   sqlite3_flutter_libs: f6acaa2172e6bb3e2e70c771661905080e8ebcf2

--- a/demos/supabase-simple-chat/macos/Podfile.lock
+++ b/demos/supabase-simple-chat/macos/Podfile.lock
@@ -5,10 +5,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.4.2)
+  - powersync-sqlite-core (0.4.4)
   - powersync_flutter_libs (0.0.1):
     - FlutterMacOS
-    - powersync-sqlite-core (~> 0.4.2)
+    - powersync-sqlite-core (~> 0.4.4)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -71,8 +71,8 @@ SPEC CHECKSUMS:
   app_links: afe860c55c7ef176cea7fb630a2b7d7736de591d
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  powersync-sqlite-core: a58efd88833861f0a8bb636c171bdf0ed55c9801
-  powersync_flutter_libs: fa885a30ceb636655741eee2ff5282d0500fa96b
+  powersync-sqlite-core: 954b7c4f068e21e6e759a7f487f0d7da4062e858
+  powersync_flutter_libs: e8debf4b25a998c233cf7992d17cd49b407c56d1
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqlite3: 3c950dc86011117c307eb0b28c4a7bb449dce9f1
   sqlite3_flutter_libs: f6acaa2172e6bb3e2e70c771661905080e8ebcf2

--- a/demos/supabase-todolist-drift/ios/Podfile.lock
+++ b/demos/supabase-todolist-drift/ios/Podfile.lock
@@ -7,10 +7,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.4.2)
+  - powersync-sqlite-core (0.4.4)
   - powersync_flutter_libs (0.0.1):
     - Flutter
-    - powersync-sqlite-core (~> 0.4.2)
+    - powersync-sqlite-core (~> 0.4.4)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -77,8 +77,8 @@ SPEC CHECKSUMS:
   camera_avfoundation: be3be85408cd4126f250386828e9b1dfa40ab436
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  powersync-sqlite-core: a58efd88833861f0a8bb636c171bdf0ed55c9801
-  powersync_flutter_libs: 881187a07f70ecabaf802fce45b186485464d618
+  powersync-sqlite-core: 954b7c4f068e21e6e759a7f487f0d7da4062e858
+  powersync_flutter_libs: ecbd37268a3705351178a05c81434592f0dcc6e5
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqlite3: 3c950dc86011117c307eb0b28c4a7bb449dce9f1
   sqlite3_flutter_libs: f6acaa2172e6bb3e2e70c771661905080e8ebcf2

--- a/demos/supabase-todolist-drift/macos/Podfile.lock
+++ b/demos/supabase-todolist-drift/macos/Podfile.lock
@@ -5,10 +5,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.4.2)
+  - powersync-sqlite-core (0.4.4)
   - powersync_flutter_libs (0.0.1):
     - FlutterMacOS
-    - powersync-sqlite-core (~> 0.4.2)
+    - powersync-sqlite-core (~> 0.4.4)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -71,8 +71,8 @@ SPEC CHECKSUMS:
   app_links: afe860c55c7ef176cea7fb630a2b7d7736de591d
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  powersync-sqlite-core: a58efd88833861f0a8bb636c171bdf0ed55c9801
-  powersync_flutter_libs: fa885a30ceb636655741eee2ff5282d0500fa96b
+  powersync-sqlite-core: 954b7c4f068e21e6e759a7f487f0d7da4062e858
+  powersync_flutter_libs: e8debf4b25a998c233cf7992d17cd49b407c56d1
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqlite3: 3c950dc86011117c307eb0b28c4a7bb449dce9f1
   sqlite3_flutter_libs: f6acaa2172e6bb3e2e70c771661905080e8ebcf2

--- a/demos/supabase-todolist-drift/pubspec.yaml
+++ b/demos/supabase-todolist-drift/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   camera: ^0.10.5+7
   image: ^4.1.3
   universal_io: ^2.2.2
-  sqlite_async: ^0.11.0
+  sqlite_async: ^0.12.0
   drift: ^2.20.2
   drift_sqlite_async: ^0.2.0
   riverpod_annotation: ^2.6.1

--- a/demos/supabase-todolist-optional-sync/ios/Podfile.lock
+++ b/demos/supabase-todolist-optional-sync/ios/Podfile.lock
@@ -7,10 +7,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.4.2)
+  - powersync-sqlite-core (0.4.4)
   - powersync_flutter_libs (0.0.1):
     - Flutter
-    - powersync-sqlite-core (~> 0.4.2)
+    - powersync-sqlite-core (~> 0.4.4)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -77,8 +77,8 @@ SPEC CHECKSUMS:
   camera_avfoundation: be3be85408cd4126f250386828e9b1dfa40ab436
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  powersync-sqlite-core: a58efd88833861f0a8bb636c171bdf0ed55c9801
-  powersync_flutter_libs: 881187a07f70ecabaf802fce45b186485464d618
+  powersync-sqlite-core: 954b7c4f068e21e6e759a7f487f0d7da4062e858
+  powersync_flutter_libs: ecbd37268a3705351178a05c81434592f0dcc6e5
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqlite3: 3c950dc86011117c307eb0b28c4a7bb449dce9f1
   sqlite3_flutter_libs: f6acaa2172e6bb3e2e70c771661905080e8ebcf2

--- a/demos/supabase-todolist-optional-sync/macos/Podfile.lock
+++ b/demos/supabase-todolist-optional-sync/macos/Podfile.lock
@@ -5,10 +5,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.4.2)
+  - powersync-sqlite-core (0.4.4)
   - powersync_flutter_libs (0.0.1):
     - FlutterMacOS
-    - powersync-sqlite-core (~> 0.4.2)
+    - powersync-sqlite-core (~> 0.4.4)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -71,8 +71,8 @@ SPEC CHECKSUMS:
   app_links: afe860c55c7ef176cea7fb630a2b7d7736de591d
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  powersync-sqlite-core: a58efd88833861f0a8bb636c171bdf0ed55c9801
-  powersync_flutter_libs: fa885a30ceb636655741eee2ff5282d0500fa96b
+  powersync-sqlite-core: 954b7c4f068e21e6e759a7f487f0d7da4062e858
+  powersync_flutter_libs: e8debf4b25a998c233cf7992d17cd49b407c56d1
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqlite3: 3c950dc86011117c307eb0b28c4a7bb449dce9f1
   sqlite3_flutter_libs: f6acaa2172e6bb3e2e70c771661905080e8ebcf2

--- a/demos/supabase-todolist-optional-sync/pubspec.yaml
+++ b/demos/supabase-todolist-optional-sync/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   camera: ^0.10.5+7
   image: ^4.1.3
   universal_io: ^2.2.2
-  sqlite_async: ^0.11.0
+  sqlite_async: ^0.12.0
 
 dev_dependencies:
   flutter_test:

--- a/demos/supabase-todolist/ios/Podfile.lock
+++ b/demos/supabase-todolist/ios/Podfile.lock
@@ -7,10 +7,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.4.2)
+  - powersync-sqlite-core (0.4.4)
   - powersync_flutter_libs (0.0.1):
     - Flutter
-    - powersync-sqlite-core (~> 0.4.2)
+    - powersync-sqlite-core (~> 0.4.4)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -77,8 +77,8 @@ SPEC CHECKSUMS:
   camera_avfoundation: be3be85408cd4126f250386828e9b1dfa40ab436
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  powersync-sqlite-core: a58efd88833861f0a8bb636c171bdf0ed55c9801
-  powersync_flutter_libs: 881187a07f70ecabaf802fce45b186485464d618
+  powersync-sqlite-core: 954b7c4f068e21e6e759a7f487f0d7da4062e858
+  powersync_flutter_libs: ecbd37268a3705351178a05c81434592f0dcc6e5
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqlite3: 3c950dc86011117c307eb0b28c4a7bb449dce9f1
   sqlite3_flutter_libs: f6acaa2172e6bb3e2e70c771661905080e8ebcf2

--- a/demos/supabase-todolist/macos/Podfile.lock
+++ b/demos/supabase-todolist/macos/Podfile.lock
@@ -5,10 +5,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.4.2)
+  - powersync-sqlite-core (0.4.4)
   - powersync_flutter_libs (0.0.1):
     - FlutterMacOS
-    - powersync-sqlite-core (~> 0.4.2)
+    - powersync-sqlite-core (~> 0.4.4)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -71,8 +71,8 @@ SPEC CHECKSUMS:
   app_links: afe860c55c7ef176cea7fb630a2b7d7736de591d
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  powersync-sqlite-core: a58efd88833861f0a8bb636c171bdf0ed55c9801
-  powersync_flutter_libs: fa885a30ceb636655741eee2ff5282d0500fa96b
+  powersync-sqlite-core: 954b7c4f068e21e6e759a7f487f0d7da4062e858
+  powersync_flutter_libs: e8debf4b25a998c233cf7992d17cd49b407c56d1
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqlite3: 3c950dc86011117c307eb0b28c4a7bb449dce9f1
   sqlite3_flutter_libs: f6acaa2172e6bb3e2e70c771661905080e8ebcf2

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   camera: ^0.10.5+7
   image: ^4.1.3
   universal_io: ^2.2.2
-  sqlite_async: ^0.11.0
+  sqlite_async: ^0.12.0
 
 dev_dependencies:
   flutter_test:

--- a/demos/supabase-trello/ios/Podfile.lock
+++ b/demos/supabase-trello/ios/Podfile.lock
@@ -41,10 +41,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.4.2)
+  - powersync-sqlite-core (0.4.4)
   - powersync_flutter_libs (0.0.1):
     - Flutter
-    - powersync-sqlite-core (~> 0.4.2)
+    - powersync-sqlite-core (~> 0.4.4)
   - SDWebImage (5.21.1):
     - SDWebImage/Core (= 5.21.1)
   - SDWebImage/Core (5.21.1)
@@ -125,8 +125,8 @@ SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  powersync-sqlite-core: a58efd88833861f0a8bb636c171bdf0ed55c9801
-  powersync_flutter_libs: 881187a07f70ecabaf802fce45b186485464d618
+  powersync-sqlite-core: 954b7c4f068e21e6e759a7f487f0d7da4062e858
+  powersync_flutter_libs: ecbd37268a3705351178a05c81434592f0dcc6e5
   SDWebImage: f29024626962457f3470184232766516dee8dfea
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqlite3: 3c950dc86011117c307eb0b28c4a7bb449dce9f1

--- a/demos/supabase-trello/macos/Podfile.lock
+++ b/demos/supabase-trello/macos/Podfile.lock
@@ -9,10 +9,10 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - powersync-sqlite-core (0.4.2)
+  - powersync-sqlite-core (0.4.4)
   - powersync_flutter_libs (0.0.1):
     - FlutterMacOS
-    - powersync-sqlite-core (~> 0.4.2)
+    - powersync-sqlite-core (~> 0.4.4)
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -83,8 +83,8 @@ SPEC CHECKSUMS:
   file_selector_macos: 6280b52b459ae6c590af5d78fc35c7267a3c4b31
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  powersync-sqlite-core: a58efd88833861f0a8bb636c171bdf0ed55c9801
-  powersync_flutter_libs: fa885a30ceb636655741eee2ff5282d0500fa96b
+  powersync-sqlite-core: 954b7c4f068e21e6e759a7f487f0d7da4062e858
+  powersync_flutter_libs: e8debf4b25a998c233cf7992d17cd49b407c56d1
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqlite3: 3c950dc86011117c307eb0b28c4a7bb449dce9f1
   sqlite3_flutter_libs: f6acaa2172e6bb3e2e70c771661905080e8ebcf2

--- a/demos/supabase-trello/pubspec.yaml
+++ b/demos/supabase-trello/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   flutter_dotenv: ^5.2.1
   logging: ^1.3.0
   powersync: ^1.15.0
-  sqlite_async: ^0.11.0
+  sqlite_async: ^0.12.0
   path_provider: ^2.1.5
   supabase_flutter: ^2.8.3
   path: ^1.9.0

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
 
   powersync_core: ^1.5.0
   logging: ^1.2.0
-  sqlite_async: ^0.11.0
+  sqlite_async: ^0.12.0
   path_provider: ^2.0.13
 
 dev_dependencies:

--- a/packages/powersync_core/lib/src/database/core_version.dart
+++ b/packages/powersync_core/lib/src/database/core_version.dart
@@ -60,7 +60,7 @@ extension type const PowerSyncCoreVersion((int, int, int) _tuple) {
   // Note: When updating this, also update the download URL in
   // scripts/init_powersync_core_binary.dart and the version ref in
   // packages/sqlite3_wasm_build/build.sh
-  static const minimum = PowerSyncCoreVersion((0, 4, 2));
+  static const minimum = PowerSyncCoreVersion((0, 4, 4));
 
   /// The first version of the core extensions that this version of the Dart
   /// SDK doesn't support.

--- a/packages/powersync_core/pubspec.yaml
+++ b/packages/powersync_core/pubspec.yaml
@@ -8,12 +8,12 @@ environment:
   sdk: ^3.4.3
 
 dependencies:
-  sqlite_async: ^0.11.4
+  sqlite_async: ^0.12.0
   # We only use sqlite3 as a transitive dependency,
   # but right now we need a minimum of v2.4.6.
   sqlite3: ^2.4.6
   # We implement a database controller, which is an interface of sqlite3_web.
-  sqlite3_web: ^0.3.1
+  sqlite3_web: ^0.3.2
   universal_io: ^2.0.0
   meta: ^1.0.0
   http: ^1.4.0

--- a/packages/powersync_flutter_libs/android/build.gradle
+++ b/packages/powersync_flutter_libs/android/build.gradle
@@ -50,5 +50,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.powersync:powersync-sqlite-core:0.4.2'
+    implementation 'com.powersync:powersync-sqlite-core:0.4.4'
 }

--- a/packages/powersync_flutter_libs/ios/powersync_flutter_libs.podspec
+++ b/packages/powersync_flutter_libs/ios/powersync_flutter_libs.podspec
@@ -22,7 +22,7 @@ A new Flutter FFI plugin project.
   s.dependency 'Flutter'
   s.platform = :ios, '11.0'
 
-  s.dependency "powersync-sqlite-core", "~> 0.4.2"
+  s.dependency "powersync-sqlite-core", "~> 0.4.4"
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/packages/powersync_flutter_libs/macos/powersync_flutter_libs.podspec
+++ b/packages/powersync_flutter_libs/macos/powersync_flutter_libs.podspec
@@ -21,7 +21,7 @@ A new Flutter FFI plugin project.
   s.source_files     = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
 
-  s.dependency "powersync-sqlite-core", "~> 0.4.2"
+  s.dependency "powersync-sqlite-core", "~> 0.4.4"
 
   s.platform = :osx, '10.11'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }

--- a/packages/sqlite3_wasm_build/build.sh
+++ b/packages/sqlite3_wasm_build/build.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-SQLITE_VERSION="2.8.0"
-POWERSYNC_CORE_VERSION="0.4.2"
+SQLITE_VERSION="2.9.0"
+POWERSYNC_CORE_VERSION="0.4.4"
 SQLITE_PATH="sqlite3.dart"
 
 if [ -d "$SQLITE_PATH" ]; then

--- a/scripts/download_core_binary_demos.dart
+++ b/scripts/download_core_binary_demos.dart
@@ -3,7 +3,7 @@
 import 'dart:io';
 
 final coreUrl =
-    'https://github.com/powersync-ja/powersync-sqlite-core/releases/download/v0.4.2';
+    'https://github.com/powersync-ja/powersync-sqlite-core/releases/download/v0.4.4';
 
 void main() async {
   final powersyncLibsLinuxPath = "packages/powersync_flutter_libs/linux";

--- a/scripts/init_powersync_core_binary.dart
+++ b/scripts/init_powersync_core_binary.dart
@@ -6,7 +6,7 @@ import 'dart:io';
 import 'package:melos/melos.dart';
 
 final sqliteUrl =
-    'https://github.com/powersync-ja/powersync-sqlite-core/releases/download/v0.4.2';
+    'https://github.com/powersync-ja/powersync-sqlite-core/releases/download/v0.4.4';
 
 void main() async {
   final sqliteCoreFilename = getLibraryForPlatform();


### PR DESCRIPTION
This updates the core extesion to `0.4.4`. It also updates dependencies on `sqlite_async` to restore compatibility with the latest versions of `package:sqlite3` and to avoid the growing async queue issue for large transactions.