### PR TITLE
Request cancellation

### DIFF
--- a/packages/powersync_core/lib/src/sync/streaming_sync.dart
+++ b/packages/powersync_core/lib/src/sync/streaming_sync.dart
@@ -517,7 +517,8 @@ class StreamingSyncImplementation implements StreamingSync {
     }
     final uri = credentials.endpointUri('sync/stream');
 
-    final request = http.Request('POST', uri);
+    final request =
+        http.AbortableRequest('POST', uri, abortTrigger: _abort!.onAbort);
     request.headers['Content-Type'] = 'application/json';
     request.headers['Authorization'] = "Token ${credentials.token}";
     request.headers['Accept'] =

--- a/packages/powersync_core/pubspec.yaml
+++ b/packages/powersync_core/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   sqlite3_web: ^0.3.2
   universal_io: ^2.0.0
   meta: ^1.0.0
-  http: ^1.4.0
+  http: ^1.5.0
   uuid: ^4.2.0
   async: ^2.10.0
   logging: ^1.1.1

--- a/packages/powersync_core/test/server/sync_server/in_memory_sync_server.dart
+++ b/packages/powersync_core/test/server/sync_server/in_memory_sync_server.dart
@@ -14,7 +14,7 @@ final class MockSyncService {
       StreamController();
   Completer<Request> _listener = Completer();
 
-  final router = Router();
+  var router = Router();
   Object? Function() writeCheckpoint = () {
     return {
       'data': {'write_checkpoint': '10'}

--- a/packages/powersync_core/test/utils/in_memory_http.dart
+++ b/packages/powersync_core/test/utils/in_memory_http.dart
@@ -35,6 +35,11 @@ final class _MockServer implements shelf.Server {
 
   Future<StreamedResponse> handleRequest(
       BaseRequest request, ByteStream body) async {
+    final cancellationFuture = switch (request) {
+      Abortable(:final abortTrigger) => abortTrigger,
+      _ => null,
+    };
+
     if (_handler case final endpoint?) {
       final shelfRequest = shelf.Request(
         request.method,
@@ -42,15 +47,55 @@ final class _MockServer implements shelf.Server {
         headers: request.headers,
         body: body,
       );
-      final shelfResponse = await endpoint(shelfRequest);
+
+      final shelfResponse = await Future.any<shelf.Response>([
+        Future.sync(() => endpoint(shelfRequest)),
+        if (cancellationFuture != null)
+          cancellationFuture.then((_) {
+            throw RequestAbortedException();
+          }),
+      ]);
 
       return StreamedResponse(
-        shelfResponse.read(),
+        shelfResponse.read().injectCancellation(cancellationFuture),
         shelfResponse.statusCode,
         headers: shelfResponse.headers,
       );
     } else {
       throw StateError('Request before handler was set on mock server');
     }
+  }
+}
+
+extension<T> on Stream<T> {
+  Stream<T> injectCancellation(Future<void>? token) {
+    if (token == null) {
+      return this;
+    }
+
+    return Stream.multi(
+      (listener) {
+        final subscription = listen(
+          listener.addSync,
+          onError: listener.addErrorSync,
+          onDone: listener.closeSync,
+        );
+
+        listener
+          ..onPause = subscription.pause
+          ..onResume = subscription.resume
+          ..onCancel = subscription.cancel;
+
+        token.whenComplete(() {
+          if (!listener.isClosed) {
+            listener
+              ..addErrorSync(RequestAbortedException())
+              ..closeSync();
+            subscription.cancel();
+          }
+        });
+      },
+      isBroadcast: isBroadcast,
+    );
   }
 }


### PR DESCRIPTION
Starting from version `1.5.0` of `package:http`, some client implementations (including the default ones from that package) support cancelling requests (with a mechanism similar to `AbortController` in JS, represented as a future that, when completed, aborts the request).

While we are already handling cancellations quite well in our sync client implementation (we currently cancel the stream subscription on the HTTP stream, closing the underlying connection), one thing that's not currently cancellable is establishing the connection. Especially when the user has poor connectivity, waiting for headers to be received just to abort the request at that point can be inefficient. Adopting abortable requests can improve this.

By passing an abort trigger to the request, the client will [behave as follows](https://pub.dev/documentation/http/latest/http/Abortable/abortTrigger.html):

1. If we abort the request before headers are completed (i.e., in `.send()`), `send()` itself will throw a `RequestAbortedException`, which extends `ClientException`.
2. If we abort the request while we're listening to the stream, an `RequestAbortedException` is injected into the Dart stream by the client.

In both cases, we forward this exception on the stream that `_dartSyncIteration` and `_ActiveRustStreamingIteration.receiveLines` listen to, which will cause them to abort and rethrow. The exception is not visible to users because `streamingSync` catches it and does nothing if it hapens while aborting the sync.