### PR TITLE
Prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2025-08-11
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`powersync_core` - `v1.5.1`](#powersync_core---v151)
+ - [`powersync` - `v1.15.1`](#powersync---v1151)
+ - [`powersync_sqlcipher` - `v0.1.11`](#powersync_sqlcipher---v0111)
+ - [`powersync_flutter_libs` - `v0.4.11`](#powersync_flutter_libs---v0411)
+
+---
+
+#### `powersync_core` - `v1.5.1`
+#### `powersync` - `v1.15.1`
+#### `powersync_sqlcipher` - `v0.1.11`
+#### `powersync_flutter_libs` - `v0.4.11`
+
+ - Support latest versions of `package:sqlite3` and `package:sqlite_async`.
+ - Stream client: Improve `disconnect()` while a connection is being opened.
+ - Stream client: Support binary sync lines with Rust client and compatible PowerSync service versions.
+ - Sync client: Improve parsing error responses.
+
 ## 2025-07-17
 
 ### Changes

--- a/demos/benchmarks/pubspec.yaml
+++ b/demos/benchmarks/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.15.0
+  powersync: ^1.15.1
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.15.0
+  powersync: ^1.15.1
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/firebase-nodejs-todolist/pubspec.yaml
+++ b/demos/firebase-nodejs-todolist/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.15.0
+  powersync: ^1.15.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.15.0
+  powersync: ^1.15.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.15.0
+  powersync: ^1.15.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^2.0.2
   timeago: ^3.6.0
-  powersync: ^1.15.0
+  powersync: ^1.15.1
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist-drift/pubspec.yaml
+++ b/demos/supabase-todolist-drift/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   powersync_attachments_helper: ^0.6.18+11
-  powersync: ^1.15.0
+  powersync: ^1.15.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist-optional-sync/pubspec.yaml
+++ b/demos/supabase-todolist-optional-sync/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.15.0
+  powersync: ^1.15.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   powersync_attachments_helper: ^0.6.18+11
-  powersync: ^1.15.0
+  powersync: ^1.15.1
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-trello/pubspec.yaml
+++ b/demos/supabase-trello/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   random_name_generator: ^1.5.0
   flutter_dotenv: ^5.2.1
   logging: ^1.3.0
-  powersync: ^1.15.0
+  powersync: ^1.15.1
   sqlite_async: ^0.12.0
   path_provider: ^2.1.5
   supabase_flutter: ^2.8.3

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.15.1
+
+ - Support latest versions of `package:sqlite3` and `package:sqlite_async`.
+ - Stream client: Improve `disconnect()` while a connection is being opened.
+ - Stream client: Support binary sync lines with Rust client and compatible PowerSync service versions.
+ - Sync client: Improve parsing error responses.
+
 ## 1.15.0
 
  - Update the PowerSync core extension to `0.4.2`.

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.15.0
+version: 1.15.1
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK. Sync Postgres, MongoDB or MySQL with SQLite in your Flutter app
@@ -12,8 +12,8 @@ dependencies:
     sdk: flutter
 
   sqlite3_flutter_libs: ^0.5.23
-  powersync_core: ^1.5.0
-  powersync_flutter_libs: ^0.4.10
+  powersync_core: ^1.5.1
+  powersync_flutter_libs: ^0.4.11
   collection: ^1.17.0
 
 dev_dependencies:

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync_core: ^1.5.0
+  powersync_core: ^1.5.1
   logging: ^1.2.0
   path_provider: ^2.0.13
 

--- a/packages/powersync_core/CHANGELOG.md
+++ b/packages/powersync_core/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.5.1
+
+ - Support latest versions of `package:sqlite3` and `package:sqlite_async`.
+ - Stream client: Improve `disconnect()` while a connection is being opened.
+ - Stream client: Support binary sync lines with Rust client and compatible PowerSync service versions.
+ - Sync client: Improve parsing error responses.
+
 ## 1.5.0
 
  - Update the PowerSync core extension to `0.4.2`.

--- a/packages/powersync_core/lib/src/version.dart
+++ b/packages/powersync_core/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String libraryVersion = '1.5.0';
+const String libraryVersion = '1.5.1';

--- a/packages/powersync_core/pubspec.yaml
+++ b/packages/powersync_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync_core
-version: 1.5.0
+version: 1.5.1
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Dart SDK - sync engine for building local-first apps.

--- a/packages/powersync_flutter_libs/CHANGELOG.md
+++ b/packages/powersync_flutter_libs/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.11
+
+ - Update PowerSync core extension to version 0.4.4.
+
 ## 0.4.10
 
  - Update PowerSync core extension to version 0.4.2.

--- a/packages/powersync_flutter_libs/pubspec.yaml
+++ b/packages/powersync_flutter_libs/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_flutter_libs
 description: PowerSync core binaries for the PowerSync Flutter SDK. Needs to be included for Flutter apps.
-version: 0.4.10
+version: 0.4.11
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 

--- a/packages/powersync_sqlcipher/CHANGELOG.md
+++ b/packages/powersync_sqlcipher/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.11
+
+ - Support latest versions of `package:sqlite3` and `package:sqlite_async`.
+ - Stream client: Improve `disconnect()` while a connection is being opened.
+ - Stream client: Support binary sync lines with Rust client and compatible PowerSync service versions.
+ - Sync client: Improve parsing error responses.
+
 ## 0.1.10
 
  - raw tables

--- a/packages/powersync_sqlcipher/example/pubspec.yaml
+++ b/packages/powersync_sqlcipher/example/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 
   path: ^1.9.1
   path_provider: ^2.1.5
-  powersync_sqlcipher: ^0.1.10
+  powersync_sqlcipher: ^0.1.11
 
 dev_dependencies:
   flutter_test:

--- a/packages/powersync_sqlcipher/pubspec.yaml
+++ b/packages/powersync_sqlcipher/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync_sqlcipher
-version: 0.1.10
+version: 0.1.11
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - sync engine for building local-first apps.
@@ -12,8 +12,8 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync_core: ^1.5.0
-  powersync_flutter_libs: ^0.4.10
+  powersync_core: ^1.5.1
+  powersync_flutter_libs: ^0.4.11
   sqlcipher_flutter_libs: ^0.6.4
   sqlite3_web: ^0.3.0
 


### PR DESCRIPTION
This prepares a patch release of the Dart SDK. Relevant changes are:

- Update `package:sqlite3` and `package:sqlite_async` (https://github.com/powersync-ja/powersync.dart/pull/314 and https://github.com/powersync-ja/powersync.dart/pull/313).
- Support the unified format for HTTP errors from the sync service (https://github.com/powersync-ja/powersync.dart/pull/309).
- Support BSON sync lines with the Rust client (https://github.com/powersync-ja/powersync.dart/pull/312).
- Improving `disconnect()` while we're currently establishing a connection (https://github.com/powersync-ja/powersync.dart/pull/315)
