### PR TITLE
Sync isolate: Use updatesSync

### DIFF
--- a/packages/powersync_core/lib/src/database/native/native_powersync_database.dart
+++ b/packages/powersync_core/lib/src/database/native/native_powersync_database.dart
@@ -438,7 +438,7 @@ Future<void> _syncIsolate(_PowerSyncDatabaseIsolateArgs args) async {
       }
     }
 
-    localUpdatesSubscription = db!.updates.listen((event) {
+    localUpdatesSubscription = db!.updatesSync.listen((event) {
       updatedTables.add(event.tableName);
 
       updateDebouncer ??=


### PR DESCRIPTION
In https://github.com/powersync-ja/sqlite_async.dart/pull/105, we've fixed the updated stream to be based on synchronous udpate hooks behind the scenes, avoiding a growing async buffer for long-running writes that don't yield back to Dart.

Unfortunately, I've missed that the sync isolate uses a raw `CommonDatabase` and the `updates` stream, so the original issue is not actually fixed. This changes that to `updatesSync`. I've verified this with a one million item sync in the todolist sample (so there are also fts5 rows being created here). This reduces the amount of live update notifications from growing and reaching 2M+ items (old) to hovering from 0-60k before being GCed (new).

I think a better fix would be to obtain a `sqlite_async` database instead of the underlying one, since that would eventually allow us to move to the update hook implementation in the core extension. But this seems like an obvious fix with little chance for regressions.