### PR TITLE
chore(release): publish packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2025-08-14
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`powersync_core` - `v1.5.2`](#powersync_core---v152)
+ - [`powersync` - `v1.15.2`](#powersync---v1152)
+ - [`powersync_sqlcipher` - `v0.1.11+1`](#powersync_sqlcipher---v01111)
+
+---
+
+#### `powersync_core` - `v1.5.2`
+
+ - Fix excessive memory consumption during large sync.
+
+#### `powersync` - `v1.15.2`
+
+ - Fix excessive memory consumption during large sync.
+
+#### `powersync_sqlcipher` - `v0.1.11+1`
+
+ - Fix excessive memory consumption during large sync.
+
+
 ## 2025-08-11
 
 ### Changes

--- a/demos/benchmarks/pubspec.yaml
+++ b/demos/benchmarks/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.15.1
+  powersync: ^1.15.2
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.15.1
+  powersync: ^1.15.2
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/firebase-nodejs-todolist/pubspec.yaml
+++ b/demos/firebase-nodejs-todolist/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.15.1
+  powersync: ^1.15.2
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.15.1
+  powersync: ^1.15.2
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.15.1
+  powersync: ^1.15.2
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   supabase_flutter: ^2.0.2
   timeago: ^3.6.0
-  powersync: ^1.15.1
+  powersync: ^1.15.2
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/supabase-todolist-drift/pubspec.yaml
+++ b/demos/supabase-todolist-drift/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   powersync_attachments_helper: ^0.6.18+11
-  powersync: ^1.15.1
+  powersync: ^1.15.2
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist-optional-sync/pubspec.yaml
+++ b/demos/supabase-todolist-optional-sync/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.15.1
+  powersync: ^1.15.2
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   powersync_attachments_helper: ^0.6.18+11
-  powersync: ^1.15.1
+  powersync: ^1.15.2
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-trello/pubspec.yaml
+++ b/demos/supabase-trello/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   random_name_generator: ^1.5.0
   flutter_dotenv: ^5.2.1
   logging: ^1.3.0
-  powersync: ^1.15.1
+  powersync: ^1.15.2
   sqlite_async: ^0.12.0
   path_provider: ^2.1.5
   supabase_flutter: ^2.8.3

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.15.2
+
+ - Fix excessive memory consumption during large sync.
+
 ## 1.15.1
 
  - Support latest versions of `package:sqlite3` and `package:sqlite_async`.

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.15.1
+version: 1.15.2
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK. Sync Postgres, MongoDB or MySQL with SQLite in your Flutter app
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
 
   sqlite3_flutter_libs: ^0.5.23
-  powersync_core: ^1.5.1
+  powersync_core: ^1.5.2
   powersync_flutter_libs: ^0.4.11
   collection: ^1.17.0
 

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync_core: ^1.5.1
+  powersync_core: ^1.5.2
   logging: ^1.2.0
   path_provider: ^2.0.13
 

--- a/packages/powersync_core/CHANGELOG.md
+++ b/packages/powersync_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.2
+
+ - Fix excessive memory consumption during large sync.
+
 ## 1.5.1
 
  - Support latest versions of `package:sqlite3` and `package:sqlite_async`.

--- a/packages/powersync_core/lib/src/version.dart
+++ b/packages/powersync_core/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String libraryVersion = '1.5.1';
+const String libraryVersion = '1.5.2';

--- a/packages/powersync_core/pubspec.yaml
+++ b/packages/powersync_core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync_core
-version: 1.5.1
+version: 1.5.2
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Dart SDK - sync engine for building local-first apps.

--- a/packages/powersync_sqlcipher/CHANGELOG.md
+++ b/packages/powersync_sqlcipher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.11+1
+
+ - Fix excessive memory consumption during large sync.
+
 ## 0.1.11
 
  - Support latest versions of `package:sqlite3` and `package:sqlite_async`.

--- a/packages/powersync_sqlcipher/example/pubspec.yaml
+++ b/packages/powersync_sqlcipher/example/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 
   path: ^1.9.1
   path_provider: ^2.1.5
-  powersync_sqlcipher: ^0.1.11
+  powersync_sqlcipher: ^0.1.11+1
 
 dev_dependencies:
   flutter_test:

--- a/packages/powersync_sqlcipher/pubspec.yaml
+++ b/packages/powersync_sqlcipher/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync_sqlcipher
-version: 0.1.11
+version: 0.1.11+1
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Flutter SDK - sync engine for building local-first apps.
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync_core: ^1.5.1
+  powersync_core: ^1.5.2
   powersync_flutter_libs: ^0.4.11
   sqlcipher_flutter_libs: ^0.6.4
   sqlite3_web: ^0.3.0


### PR DESCRIPTION
This prepares a release of the following packages:

 - powersync_core@1.5.2
 - powersync@1.15.2
 - powersync_sqlcipher@0.1.11+1

The only change is that the native sync isolate will now use a synchronous update stream, making the short-lived `SqliteUpdate` instances garbage-collectable during the `sync_local` step (https://github.com/powersync-ja/powersync.dart/pull/318).