### PR TITLE
Add nextCrudTransactions() stream

### DIFF
--- a/packages/powersync_core/lib/src/database/powersync_db_mixin.dart
+++ b/packages/powersync_core/lib/src/database/powersync_db_mixin.dart
@@ -540,8 +540,8 @@ mixin PowerSyncDatabaseMixin implements SqliteConnection {
   /// Unlike [getNextCrudTransaction], which awalys returns the oldest
   /// transaction that hasn't been [CrudTransaction.complete]d yet, this stream
   /// can be used to receive multiple transactions. Calling
-  /// [CrudTransaction.complete] will mark _all_ transactions emitted by the
-  /// stream until that point as completed.
+  /// [CrudTransaction.complete] will mark that transaction and all prior
+  /// transactions emitted by the stream as completed.
   ///
   /// This can be used to upload multiple transactions in a single batch, e.g.
   /// with:

--- a/packages/powersync_core/lib/src/database/powersync_db_mixin.dart
+++ b/packages/powersync_core/lib/src/database/powersync_db_mixin.dart
@@ -527,7 +527,7 @@ mixin PowerSyncDatabaseMixin implements SqliteConnection {
   /// Unlike [getCrudBatch], this only returns data from a single transaction at a time.
   /// All data for the transaction is loaded into memory.
   Future<CrudTransaction?> getNextCrudTransaction() {
-    return nextCrudTransactions().firstOrNull;
+    return getCrudTransactions().firstOrNull;
   }
 
   /// Returns a stream of completed transactions with local writes against the
@@ -567,7 +567,7 @@ mixin PowerSyncDatabaseMixin implements SqliteConnection {
   ///
   /// If there is no local data to upload, the stream emits a single `onDone`
   /// event.
-  Stream<CrudTransaction> nextCrudTransactions() async* {
+  Stream<CrudTransaction> getCrudTransactions() async* {
     var lastCrudItemId = -1;
     const sql = '''
 WITH RECURSIVE crud_entries AS (

--- a/packages/powersync_core/lib/src/database/powersync_db_mixin.dart
+++ b/packages/powersync_core/lib/src/database/powersync_db_mixin.dart
@@ -544,7 +544,26 @@ mixin PowerSyncDatabaseMixin implements SqliteConnection {
   /// stream until that point as completed.
   ///
   /// This can be used to upload multiple transactions in a single batch, e.g.
-  /// with:AbortController
+  /// with:
+  ///
+  /// ```dart
+  /// CrudTransaction? lastTransaction;
+  /// final batch = <CrudEntry>[];
+  ///
+  /// await for (final transaction in powersync.nextCrudTransactions()) {
+  ///   batch.addAll(transaction.crud);
+  ///   lastTransaction = transaction;
+  ///
+  ///   if (batch.length > 100) {
+  ///     break;
+  ///   }
+  /// }
+  ///
+  /// if (batch.isNotEmpty) {
+  ///   await uploadBatch(batch);
+  ///   lastTransaction!.complete();
+  /// }
+  /// ```
   ///
   /// If there is no local data to upload, the stream emits a single `onDone`
   /// event.

--- a/packages/powersync_core/lib/src/database/powersync_db_mixin.dart
+++ b/packages/powersync_core/lib/src/database/powersync_db_mixin.dart
@@ -537,7 +537,7 @@ mixin PowerSyncDatabaseMixin implements SqliteConnection {
   /// method. Each entry emitted by the stream is a full transaction containing
   /// all local writes made while that transaction was active.
   ///
-  /// Unlike [getNextCrudTransaction], which awalys returns the oldest
+  /// Unlike [getNextCrudTransaction], which always returns the oldest
   /// transaction that hasn't been [CrudTransaction.complete]d yet, this stream
   /// can be used to receive multiple transactions. Calling
   /// [CrudTransaction.complete] will mark that transaction and all prior

--- a/packages/powersync_core/test/crud_test.dart
+++ b/packages/powersync_core/test/crud_test.dart
@@ -280,7 +280,7 @@ void main() {
         });
       }
 
-      await expectLater(powersync.nextCrudTransactions(), emitsDone);
+      await expectLater(powersync.getCrudTransactions(), emitsDone);
 
       await createTransaction(5);
       await createTransaction(10);
@@ -288,7 +288,7 @@ void main() {
 
       CrudTransaction? lastTransaction;
       final batch = <CrudEntry>[];
-      await for (final transaction in powersync.nextCrudTransactions()) {
+      await for (final transaction in powersync.getCrudTransactions()) {
         batch.addAll(transaction.crud);
         lastTransaction = transaction;
 


### PR DESCRIPTION
This adds `nextCrudTransactions()`, returning a stream of transactions starting with the oldest one.

By returning a stream, developers can batch multiple transactions in a flexible way, cancelling their stream subscription (usually by breaking out of an `await for` loop) once the batch has an appropriate size. By still returning transactions, we ensure no partial transactions are uploaded (a typical problem with `getNextCrudBatch()`).