### PR TITLE
Drop dependency on `package:universal_io`

### DIFF
--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  sqlite3_flutter_libs: ^0.5.23
+  sqlite3_flutter_libs: ^0.5.39
   powersync_core: ^1.5.2
   powersync_flutter_libs: ^0.4.11
   collection: ^1.17.0

--- a/packages/powersync_core/lib/src/open_factory/abstract_powersync_open_factory.dart
+++ b/packages/powersync_core/lib/src/open_factory/abstract_powersync_open_factory.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
-import 'package:universal_io/io.dart';
 import 'dart:math';
 
+import 'package:meta/meta.dart';
 import 'package:powersync_core/sqlite_async.dart';
 import 'package:powersync_core/src/open_factory/common_db_functions.dart';
 import 'package:sqlite_async/sqlite3_common.dart';
@@ -70,6 +70,11 @@ abstract class AbstractPowerSyncOpenFactory extends DefaultSqliteOpenFactory {
   /// Returns the library name for the current platform.
   /// [path] is optional and is used when the library is not in the default location.
   String getLibraryForPlatform({String? path});
+
+  /// On native platforms, synchronously pauses the current isolate for the
+  /// given [Duration].
+  @visibleForOverriding
+  void sleep(Duration duration) {}
 }
 
 /// Advanced: Define custom setup for each SQLite connection.

--- a/packages/powersync_core/lib/src/open_factory/native/native_open_factory.dart
+++ b/packages/powersync_core/lib/src/open_factory/native/native_open_factory.dart
@@ -1,8 +1,9 @@
+import 'dart:io';
+import 'dart:io' as io;
 import 'dart:ffi';
 
 import 'package:powersync_core/src/exceptions.dart';
 import 'package:powersync_core/src/log.dart';
-import 'package:universal_io/io.dart';
 import 'dart:isolate';
 import 'package:powersync_core/src/open_factory/abstract_powersync_open_factory.dart';
 import 'package:sqlite_async/sqlite3.dart' as sqlite;
@@ -108,5 +109,10 @@ class PowerSyncOpenFactory extends AbstractPowerSyncOpenFactory {
           'Please open an issue on GitHub to request it.',
         );
     }
+  }
+
+  @override
+  void sleep(Duration duration) {
+    io.sleep(duration);
   }
 }

--- a/packages/powersync_core/pubspec.yaml
+++ b/packages/powersync_core/pubspec.yaml
@@ -14,7 +14,6 @@ dependencies:
   sqlite3: ^2.4.6
   # We implement a database controller, which is an interface of sqlite3_web.
   sqlite3_web: ^0.3.2
-  universal_io: ^2.0.0
   meta: ^1.0.0
   http: ^1.5.0
   uuid: ^4.2.0


### PR DESCRIPTION
`package:powersync_core` has a dependency on `package:universal_io` to conditionally use the `sleep` method to delay opening a database when it's locked.

An issue with that package is that it exports `dart:io`, which is supposed to be unavailable on the web. Most compilers (such as the configuration used by Flutter or `dart compile js`) overlook that and still compile code importing `dart:io` (using a throwing implementation at runtime). However, there are stricter toolchains (such as e.g. the [`build_web_compilers` package](https://pub.dev/packages/build_web_compilers) commonly used for non-Flutter Dart web projects) which refuse to compile sources transitively importing `dart:io`.

To allow PowerSync to be used with such projects, this refactors the open factory to avoid that dependency.

I've also raised the minimum version of `package:sqlite3_flutter_libs`, which closes https://github.com/powersync-ja/powersync.dart/issues/328.