### PR TITLE
Fix decoding subscriptions from status

### DIFF
--- a/packages/powersync_core/lib/src/web/sync_worker_protocol.dart
+++ b/packages/powersync_core/lib/src/web/sync_worker_protocol.dart
@@ -328,8 +328,8 @@ extension type SerializedSyncStatus._(JSObject _) implements JSObject {
       },
       streamSubscriptions: switch (streamSubscriptions) {
         null => null,
-        final serialized => (json.decode(serialized) as List)
-            .map((e) => CoreActiveStreamSubscription.fromJson(
+        final serialized => (json.decode(serialized) as List?)
+            ?.map((e) => CoreActiveStreamSubscription.fromJson(
                 e as Map<String, Object?>))
             .toList(),
       },


### PR DESCRIPTION
The `streamSubscriptions` field on `SerializedSyncStatus` is nullable for compatibility with older workers. When the worker initializes, it has no subscriptions on its status and serializes them as the string `null` (because subscriptions are JSON-serialized). This then crashes the client, which either expects the field itself to be null or to contain a JSON array.

This fixes the issue by handling the JSON null as well.

Closes https://github.com/powersync-ja/powersync.dart/issues/335.