### PR TITLE
Update PowerSync core to 0.4.8

### DIFF
--- a/packages/powersync_core/CHANGELOG.md
+++ b/packages/powersync_core/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.7.0-dev
+
+- Update PowerSync core extension to 0.4.8.
+- `disconnectAndClear()`: Add `soft` parameter to only delete public data, allowing it to be reconstructed quickly.
+- Raw tables: Add `clear` parameter to clear raw tables in `disconnectAndClear()`.
+
 ## 1.6.1
 
  - Web: Fix decoding sync streams on status.

--- a/packages/powersync_core/lib/src/database/core_version.dart
+++ b/packages/powersync_core/lib/src/database/core_version.dart
@@ -63,7 +63,7 @@ extension type const PowerSyncCoreVersion((int, int, int) _tuple) {
   //  - scripts/download_core_binary_demos.dart
   //  - packages/sqlite3_wasm_build/build.sh
   //  - Android and Darwin (CocoaPods and SwiftPM) in powersync_flutter_libs
-  static const minimum = PowerSyncCoreVersion((0, 4, 6));
+  static const minimum = PowerSyncCoreVersion((0, 4, 8));
 
   /// The first version of the core extensions that this version of the Dart
   /// SDK doesn't support.

--- a/packages/powersync_core/lib/src/schema.dart
+++ b/packages/powersync_core/lib/src/schema.dart
@@ -1,3 +1,6 @@
+/// @docImport 'database/powersync_db_mixin.dart';
+library;
+
 import 'crud.dart';
 import 'schema_logic.dart';
 
@@ -368,16 +371,25 @@ final class RawTable {
   /// used here must all be [PendingStatementValue.id].
   final PendingStatement delete;
 
+  /// An optional SQL statement to run when a PowerSync database is cleared.
+  ///
+  /// When this value is unset, clearing the database (via
+  /// [PowerSyncDatabaseMixin.disconnectAndClear]) would not affect the raw
+  /// table.
+  final String? clear;
+
   const RawTable({
     required this.name,
     required this.put,
     required this.delete,
+    this.clear,
   });
 
   Map<String, dynamic> toJson() => {
         'name': name,
         'put': put,
         'delete': delete,
+        'clear': clear,
       };
 }
 

--- a/packages/powersync_flutter_libs/android/build.gradle
+++ b/packages/powersync_flutter_libs/android/build.gradle
@@ -50,5 +50,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.powersync:powersync-sqlite-core:0.4.6'
+    implementation 'com.powersync:powersync-sqlite-core:0.4.8'
 }

--- a/packages/powersync_flutter_libs/darwin/powersync_flutter_libs.podspec
+++ b/packages/powersync_flutter_libs/darwin/powersync_flutter_libs.podspec
@@ -25,7 +25,7 @@ A new Flutter FFI plugin project.
   s.osx.deployment_target = '10.15'
 
   # NOTE: Always update Package.swift as well when updating this!
-  s.dependency "powersync-sqlite-core", "~> 0.4.6"
+  s.dependency "powersync-sqlite-core", "~> 0.4.8"
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/packages/powersync_flutter_libs/linux/CMakeLists.txt
+++ b/packages/powersync_flutter_libs/linux/CMakeLists.txt
@@ -29,9 +29,9 @@ set(CORE_FILE_NAME "libpowersync.so")
 
 set(POWERSYNC_ARCH ${CMAKE_SYSTEM_PROCESSOR})
 if (${POWERSYNC_ARCH} MATCHES "x86_64" OR ${POWERSYNC_ARCH} MATCHES "AMD64")
-  set(CORE_FILE_NAME "libpowersync_x64.so")
+  set(CORE_FILE_NAME "libpowersync_x64.linux.so")
 elseif (${POWERSYNC_ARCH} MATCHES "^arm64" OR ${POWERSYNC_ARCH} MATCHES "^armv8")
-  set(CORE_FILE_NAME "libpowersync_aarch64.so")
+  set(CORE_FILE_NAME "libpowersync_aarch64.linux.so")
 endif ()
 
 set(POWERSYNC_FILE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${CORE_FILE_NAME}")

--- a/packages/sqlite3_wasm_build/build.sh
+++ b/packages/sqlite3_wasm_build/build.sh
@@ -2,7 +2,7 @@
 set -e
 
 SQLITE_VERSION="2.9.0"
-POWERSYNC_CORE_VERSION="0.4.6"
+POWERSYNC_CORE_VERSION="0.4.8"
 SQLITE_PATH="sqlite3.dart"
 
 if [ -d "$SQLITE_PATH" ]; then

--- a/scripts/download_core_binary_demos.dart
+++ b/scripts/download_core_binary_demos.dart
@@ -3,14 +3,14 @@
 import 'dart:io';
 
 final coreUrl =
-    'https://github.com/powersync-ja/powersync-sqlite-core/releases/download/v0.4.6';
+    'https://github.com/powersync-ja/powersync-sqlite-core/releases/download/v0.4.8';
 
 void main() async {
   final powersyncLibsLinuxPath = "packages/powersync_flutter_libs/linux";
   final powersyncLibsWindowsPath = "packages/powersync_flutter_libs/windows";
 
-  final linuxArm64FileName = "libpowersync_aarch64.so";
-  final linuxX64FileName = "libpowersync_x64.so";
+  final linuxArm64FileName = "libpowersync_aarch64.linux.so";
+  final linuxX64FileName = "libpowersync_x64.linux.so";
   final windowsX64FileName = "powersync_x64.dll";
 
   // Download dynamic library

--- a/scripts/init_powersync_core_binary.dart
+++ b/scripts/init_powersync_core_binary.dart
@@ -6,7 +6,7 @@ import 'dart:io';
 import 'package:melos/melos.dart';
 
 final sqliteUrl =
-    'https://github.com/powersync-ja/powersync-sqlite-core/releases/download/v0.4.6';
+    'https://github.com/powersync-ja/powersync-sqlite-core/releases/download/v0.4.8';
 
 void main() async {
   final sqliteCoreFilename = getLibraryForPlatform();
@@ -72,13 +72,13 @@ Future<void> downloadFile(String url, String savePath) async {
 String getLibraryForPlatform() {
   switch (Abi.current()) {
     case Abi.macosArm64:
-      return 'libpowersync_aarch64.dylib';
+      return 'libpowersync_aarch64.macos.dylib';
     case Abi.macosX64:
-      return 'libpowersync_x64.dylib';
+      return 'libpowersync_x64.macos.dylib';
     case Abi.linuxX64:
-      return 'libpowersync_x64.so';
+      return 'libpowersync_x64.linux.so';
     case Abi.linuxArm64:
-      return 'libpowersync_aarch64.so';
+      return 'libpowersync_aarch64.linux.so';
     case Abi.windowsX64:
       return 'powersync_x64.dll';
     case Abi.windowsArm64:


### PR DESCRIPTION
This updates the core extension to version 0.4.8 and adds APIs for `disconnectAndClear(soft: true)` as well as `RawTable.clear`.