### PR TITLE
Use OIDC publishing to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,11 @@ on:
     tags:
       - 'powersync-v[0-9]+.[0-9]+.[0-9]+'
 
+# For trusted npm publishing, see https://docs.npmjs.com/trusted-publishers#github-actions-configuration
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   setup:
     uses: ./.github/workflows/prepare_wasm.yml
@@ -17,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - uses: ./.github/actions/prepare
 
       - name: Create Draft Release
@@ -34,15 +39,18 @@ jobs:
           gh release upload "${{ github.ref_name }}" packages/powersync/assets/powersync_db.worker.js packages/powersync/assets/powersync_sync.worker.js packages/sqlite3_wasm_build/dist/*.wasm
       
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
+        with:
+          node-version: latest
+      - name: Update npm
+        run: |
+          npm install -g npm@latest
+          npm --version
       - uses: pnpm/action-setup@v2
         name: Install pnpm
         with:
           run_install: false
           version: 10
-      - name: Add NPM auth
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${{secrets.NPM_TOKEN}}" >> ~/.npmrc
       - name: Publish npm package with WASM files
         working-directory: packages/sqlite3_wasm_build
         run: |
@@ -51,4 +59,3 @@ jobs:
           pnpm publish --no-git-checks --access public
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Whenever we release a new version of `package:powersync`, we also upload the current `sqlite3.wasm` to npm so that we can pull it from jsdelivr in some FlutterFlow setups.

This PR updates that workflow to use trusted publishing .