### PR TITLE
Fix client immediately restarting on checksum failures

### DIFF
--- a/packages/powersync_core/lib/src/database/powersync_db_mixin.dart
+++ b/packages/powersync_core/lib/src/database/powersync_db_mixin.dart
@@ -210,9 +210,9 @@ mixin PowerSyncDatabaseMixin implements SqliteConnection {
 
     final resolvedOptions = ResolvedSyncOptions.resolve(
       options,
-      crudThrottleTime: crudThrottleTime,
+      crudThrottleTime: options?.crudThrottleTime ?? crudThrottleTime,
       // ignore: deprecated_member_use_from_same_package
-      retryDelay: retryDelay,
+      retryDelay: options?.retryDelay ?? retryDelay,
       params: params,
     );
 

--- a/packages/powersync_core/lib/src/sync/streaming_sync.dart
+++ b/packages/powersync_core/lib/src/sync/streaming_sync.dart
@@ -149,6 +149,8 @@ class StreamingSyncImplementation implements StreamingSync {
       var invalidCredentials = false;
       while (!aborted) {
         _state.updateStatus((s) => s.setConnectingIfNotConnected());
+        var delayNextIteration = false;
+
         try {
           if (invalidCredentials) {
             // This may error. In that case it will be retried again on the next
@@ -157,13 +159,14 @@ class StreamingSyncImplementation implements StreamingSync {
             invalidCredentials = false;
           }
           // Protect sync iterations with exclusivity (if a valid Mutex is provided)
-          await syncMutex.lock(() {
+          await syncMutex.lock(() async {
             switch (options.source.syncImplementation) {
               // ignore: deprecated_member_use_from_same_package
               case SyncClientImplementation.dart:
-                return _dartStreamingSyncIteration();
+                await _dartStreamingSyncIteration();
               case SyncClientImplementation.rust:
-                return _rustStreamingSyncIteration();
+                final (:immediateRestart) = await _rustStreamingSyncIteration();
+                delayNextIteration = !immediateRestart;
             }
           }, timeout: _retryDelay);
         } catch (e, stacktrace) {
@@ -172,14 +175,17 @@ class StreamingSyncImplementation implements StreamingSync {
             // ClientException: Connection closed while receiving data, uri=http://localhost:8080/sync/stream
             return;
           }
+          delayNextIteration = true;
           final message = _syncErrorMessage(e);
           logger.warning('Sync error: $message', e, stacktrace);
           invalidCredentials = true;
 
           _state.updateStatus((s) => s.applyDownloadError(e));
+        }
 
-          // On error, wait a little before retrying
-          // When aborting, don't wait
+        // On error, wait a little before retrying
+        // When aborting, don't wait
+        if (!aborted && delayNextIteration) {
           await _delayRetry();
         }
       }
@@ -308,13 +314,12 @@ class StreamingSyncImplementation implements StreamingSync {
     });
   }
 
-  Future<void> _rustStreamingSyncIteration() async {
+  Future<({bool immediateRestart})> _rustStreamingSyncIteration() async {
     logger.info('Starting Rust sync iteration');
     final response = await _ActiveRustStreamingIteration(this).syncIteration();
     logger.info(
         'Ending Rust sync iteration. Immediate restart: ${response.immediateRestart}');
-    // Note: With the current loop in streamingSync(), any return value that
-    // isn't an exception triggers an immediate restart.
+    return response;
   }
 
   Future<(List<BucketRequest>, Map<String, BucketDescription?>)>

--- a/packages/powersync_core/lib/src/sync/streaming_sync.dart
+++ b/packages/powersync_core/lib/src/sync/streaming_sync.dart
@@ -159,16 +159,16 @@ class StreamingSyncImplementation implements StreamingSync {
             invalidCredentials = false;
           }
           // Protect sync iterations with exclusivity (if a valid Mutex is provided)
-          await syncMutex.lock(() async {
+          final (:immediateRestart) = await syncMutex.lock(() {
             switch (options.source.syncImplementation) {
               // ignore: deprecated_member_use_from_same_package
               case SyncClientImplementation.dart:
-                await _dartStreamingSyncIteration();
+                return _dartStreamingSyncIteration();
               case SyncClientImplementation.rust:
-                final (:immediateRestart) = await _rustStreamingSyncIteration();
-                delayNextIteration = !immediateRestart;
+                return _rustStreamingSyncIteration();
             }
           }, timeout: _retryDelay);
+          delayNextIteration = !immediateRestart;
         } catch (e, stacktrace) {
           if (aborted && e is http.ClientException) {
             // Explicit abort requested - ignore. Example error:
@@ -314,7 +314,7 @@ class StreamingSyncImplementation implements StreamingSync {
     });
   }
 
-  Future<({bool immediateRestart})> _rustStreamingSyncIteration() async {
+  Future<RustSyncIterationResult> _rustStreamingSyncIteration() async {
     logger.info('Starting Rust sync iteration');
     final response = await _ActiveRustStreamingIteration(this).syncIteration();
     logger.info(
@@ -336,10 +336,10 @@ class StreamingSyncImplementation implements StreamingSync {
     return (initialRequests, localDescriptions);
   }
 
-  Future<void> _dartStreamingSyncIteration() async {
+  Future<RustSyncIterationResult> _dartStreamingSyncIteration() async {
     var (bucketRequests, bucketMap) = await _collectLocalBucketState();
     if (aborted) {
-      return;
+      return (immediateRestart: false);
     }
 
     Checkpoint? targetCheckpoint;
@@ -352,6 +352,7 @@ class StreamingSyncImplementation implements StreamingSync {
 
     Future<void>? credentialsInvalidation;
     bool shouldStopIteration = false;
+    bool immediateRestart = false;
 
     // Trigger a CRUD upload on reconnect
     _internalCrudTriggerController.add(null);
@@ -452,6 +453,7 @@ class StreamingSyncImplementation implements StreamingSync {
               // trigger next loop iteration ASAP, don't wait for another
               // message from the server.
               if (!aborted) {
+                immediateRestart = true;
                 _nonLineSyncEvents.add(TokenRefreshComplete());
               }
             }, onError: (_) {
@@ -489,6 +491,8 @@ class StreamingSyncImplementation implements StreamingSync {
         break;
       }
     }
+
+    return (immediateRestart: immediateRestart);
   }
 
   Future<({bool abort, bool didApply})> _applyCheckpoint(


### PR DESCRIPTION
The Dart SDK only awaits the reconnect delay when an exception has been thrown in the sync client. There are other things that can cause the sync iteration to fail though, like checksum mismatches.

This fixes both the Dart and Rust client to properly wait on those mismatches instead of reconnecting immediately. During testing, I also realized that the `crudThrottleTime` and `retryDelay` fields on `SyncOptions` are ignored. This is fixed in this PR as well.