### PR TITLE
Restore encryption support

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,3 +54,10 @@ jobs:
       - name: Test powersync package
         working-directory: packages/powersync
         run: dart test -p chrome,vm
+
+      - name: Enable encryption
+        run: dart tool/enable_encryption.dart
+
+      - name: Encryption tests
+        working-directory: packages/powersync
+        run: dart test -p vm -P encryption

--- a/packages/powersync/dart_test.yaml
+++ b/packages/powersync/dart_test.yaml
@@ -1,0 +1,21 @@
+tags:
+  require_encryption:
+    skip: Requires encryption
+  require_no_encryption:
+    skip: false
+
+on_platform:
+  browser:
+    tags:
+      require_encryption:
+        skip: false
+      require_no_encryption:
+        skip: "Encryption is always available on web platform"
+
+presets:
+  # We enable this preset in CI after configuring encryption support.
+  encryption:
+    include_tags: require_encryption
+    tags:
+      require_encryption:
+        skip: false

--- a/packages/powersync/lib/powersync.dart
+++ b/packages/powersync/lib/powersync.dart
@@ -7,6 +7,7 @@ export 'src/connector.dart';
 export 'src/crud.dart';
 export 'src/database/powersync_database.dart'
     hide BasePowerSyncDatabase, powerSyncUpdateNotifications;
+export 'src/database/encryption_options.dart';
 export 'src/exceptions.dart';
 export 'src/log.dart';
 export 'src/schema.dart';

--- a/packages/powersync/lib/src/database/encryption_options.dart
+++ b/packages/powersync/lib/src/database/encryption_options.dart
@@ -1,0 +1,78 @@
+import 'package:sqlite3/common.dart';
+import 'package:sqlite_async/utils.dart';
+
+const _isCompilingToJavaScript = identical(0, 0.0);
+const _isDart2Wasm = bool.fromEnvironment('dart.tool.dart2wasm');
+const _isWeb = _isCompilingToJavaScript || _isDart2Wasm;
+
+/// Options controlling if and how a database should be encrypted.
+///
+/// ## Setup
+///
+/// Enabling encryption requires additional setup depending on the target
+/// platform.
+///
+/// ### Native
+///
+/// On native platforms, the `sqlite3` package provides a copy of SQLite with
+/// your app. To use encryption, we need to replace SQLite with
+/// [SQLite3MultipleCiphers](https://utelle.github.io/SQLite3MultipleCiphers/).
+/// To enable that, add this to your `pubspec.yaml`:
+///
+/// ```yaml
+/// hooks:
+///   user_defines:
+///     sqlite3:
+///       source: sqlite3mc
+/// ```
+///
+/// If you're using pub workspaces, this needs to be added to the `pubspec.yaml`
+/// defining the workspace.
+///
+/// ### Web
+///
+/// Using SQLite3MultipleCiphers is also required for the web. Each
+/// [release](https://github.com/powersync-ja/powersync.dart/releases) or the
+/// PowerSync SDK provides both a `sqlite3.wasm` and a `sqlite3mc.wasm` file.
+///
+/// To use encryption, download `sqlite3mc.wasm` as `web/sqlite3.wasm`. If you
+/// use the `powersync:setup_web` tool to download that file, pass the
+/// `--encryption` option.
+final class EncryptionOptions {
+  /// The key used to encrypt the database file.
+  final String key;
+
+  /// Whether to use an encryption scheme that is compatible with SQLCipher-
+  /// based databases.
+  ///
+  /// For backwards-compatibility with the `powersync_sqlcipher` package, this
+  /// is enabled by default on native platforms. If you've never used that
+  /// package, this can be disabled.
+  final bool sqlcipherCompatibility;
+
+  const EncryptionOptions({
+    required this.key,
+    this.sqlcipherCompatibility = !_isWeb,
+  });
+
+  Iterable<String>? pragmaStatements() sync* {
+    if (sqlcipherCompatibility) {
+      yield "PRAGMA cipher = 'sqlcipher'";
+      yield 'PRAGMA legacy = 4';
+    }
+
+    // https://utelle.github.io/SQLite3MultipleCiphers/docs/configuration/config_sql_pragmas/#pragma-key--hexkey
+    yield 'PRAGMA key = ${quoteString(key)}';
+  }
+
+  /// Throws if the `cipher` pragma doesn't exist, as that indicates that
+  /// SQLite3MultipleCiphers is not available.
+  static void checkHasCipherPragma(CommonDatabase database) {
+    if (database.select('pragma cipher').isEmpty) {
+      throw UnsupportedError(
+        'Tried to use encryption, but SQLite3MultipleCiphers is not available. '
+        'Consult the documentation on EncryptionOptions on how to resolve this.',
+      );
+    }
+  }
+}

--- a/packages/powersync/lib/src/database/encryption_options.dart
+++ b/packages/powersync/lib/src/database/encryption_options.dart
@@ -40,6 +40,10 @@ const _isWeb = _isCompilingToJavaScript || _isDart2Wasm;
 /// `--encryption` option.
 final class EncryptionOptions {
   /// The key used to encrypt the database file.
+  ///
+  /// To change the key of an existing encrypted database, first open it with
+  /// the old key, then run a [`PRAGMA rekey`](https://utelle.github.io/SQLite3MultipleCiphers/docs/configuration/config_sql_pragmas/#pragma-rekey--hexrekey)
+  /// statement and finally re-open the database with the new key.
   final String key;
 
   /// Whether to use an encryption scheme that is compatible with SQLCipher-

--- a/packages/powersync/lib/src/database/powersync_database.dart
+++ b/packages/powersync/lib/src/database/powersync_database.dart
@@ -25,6 +25,7 @@ import '../sync/streaming_sync.dart';
 import '../sync/sync_status.dart';
 import 'active_instances.dart';
 import 'core_version.dart';
+import 'encryption_options.dart';
 
 const powerSyncDefaultSqliteOptions = SqliteOptions(
   webSqliteOptions: WebSqliteOptions(
@@ -115,6 +116,9 @@ abstract base class PowerSyncDatabase extends SqliteConnection {
   /// from the last committed write transaction.
   ///
   /// [logger] defaults to [autoLogger], which logs to the console in debug builds.
+  ///
+  /// If [encryption] is passed, PowerSync will use an encrypted database. This
+  /// requires additional setup, see the [EncryptionOptions] class for details.
   factory PowerSyncDatabase({
     required Schema schema,
     required String path,
@@ -122,9 +126,10 @@ abstract base class PowerSyncDatabase extends SqliteConnection {
     int maxReaders = SqliteOptions.defaultMaxReaders,
     Logger? logger,
     SqliteOptions sqliteOptions = powerSyncDefaultSqliteOptions,
+    EncryptionOptions? encryption,
   }) {
     return PowerSyncDatabase.withFactory(
-      openFactory(path: path, options: sqliteOptions),
+      openFactory(path: path, options: sqliteOptions, encryption: encryption),
       schema: schema,
       logger: logger,
     );
@@ -177,9 +182,15 @@ abstract base class PowerSyncDatabase extends SqliteConnection {
   /// web, this returns a [WebPowerSyncOpenFactory]. Both of these classes can
   /// be extended if additional customization is necessary, and these instances
   /// can be passed to the [PowerSyncDatabase.withFactory] constructor.
-  static SqliteOpenFactory openFactory(
-      {required String path, SqliteOptions options = const SqliteOptions()}) {
-    return powerSyncOpenFactory(path, options);
+  ///
+  /// If [encryption] is passed, PowerSync will use an encrypted database. This
+  /// requires additional setup, see the [EncryptionOptions] class for details.
+  static SqliteOpenFactory openFactory({
+    required String path,
+    SqliteOptions options = const SqliteOptions(),
+    EncryptionOptions? encryption,
+  }) {
+    return powerSyncOpenFactory(path, options, encryption);
   }
 
   /// Check that a supported version of the powersync extension is loaded.

--- a/packages/powersync/lib/src/open_factory/native/native_open_factory.dart
+++ b/packages/powersync/lib/src/open_factory/native/native_open_factory.dart
@@ -6,6 +6,7 @@ import 'package:sqlite3/sqlite3.dart';
 import 'package:sqlite_async/sqlite_async.dart';
 import 'package:sqlite_async/native.dart';
 
+import '../../database/encryption_options.dart';
 import 'sqlite3_powersync_init.dart';
 
 var _didInstallExtension = false;
@@ -13,11 +14,15 @@ var _didInstallExtension = false;
 /// A [NativeSqliteOpenFactory] that also loads the PowerSync SQLite core
 /// extension on opened databases.
 base class NativePowerSyncOpenFactory extends NativeSqliteOpenFactory {
-  NativePowerSyncOpenFactory({required super.path, super.sqliteOptions});
+  final EncryptionOptions? encryptionOptions;
+
+  NativePowerSyncOpenFactory(
+      {required super.path, super.sqliteOptions, this.encryptionOptions});
 
   @override
   List<String> pragmaStatements(SqliteOpenOptions options) {
     return [
+      ...?encryptionOptions?.pragmaStatements(),
       ...super.pragmaStatements(options),
       'PRAGMA recursive_triggers = TRUE',
     ];
@@ -68,5 +73,14 @@ base class NativePowerSyncOpenFactory extends NativeSqliteOpenFactory {
 
   Database openConnectionAttempt(SqliteOpenOptions options) {
     return super.openNativeConnection(options);
+  }
+
+  @override
+  void configureConnection(Database database, SqliteOpenOptions options) {
+    if (encryptionOptions != null) {
+      EncryptionOptions.checkHasCipherPragma(database);
+    }
+
+    super.configureConnection(database, options);
   }
 }

--- a/packages/powersync/lib/src/open_factory/web/web_open_factory.dart
+++ b/packages/powersync/lib/src/open_factory/web/web_open_factory.dart
@@ -4,6 +4,7 @@ import 'package:sqlite3_web/sqlite3_web.dart';
 import 'package:sqlite_async/sqlite_async.dart';
 import 'package:sqlite_async/web.dart';
 
+import '../../database/encryption_options.dart';
 import '../../web/worker_utils.dart';
 
 /// PowerSync-specific [WebSqliteOpenFactory].
@@ -11,7 +12,10 @@ import '../../web/worker_utils.dart';
 /// This mostly installs a [PowerSyncAsyncSqliteController] to ensure we use
 /// an encrypted VFS where necessary.
 base class WebPowerSyncOpenFactory extends WebSqliteOpenFactory {
-  WebPowerSyncOpenFactory({required super.path, super.sqliteOptions});
+  final EncryptionOptions? encryptionOptions;
+
+  WebPowerSyncOpenFactory(
+      {required super.path, super.sqliteOptions, this.encryptionOptions});
 
   @override
   Future<WebSqlite> openWebSqlite(WebSqliteOptions options) async {
@@ -22,5 +26,23 @@ base class WebPowerSyncOpenFactory extends WebSqliteOpenFactory {
       controller: PowerSyncAsyncSqliteController(),
       handleCustomRequest: handleCustomRequest,
     );
+  }
+
+  @override
+  Future<ConnectToRecommendedResult> connectToWorker(
+      WebSqlite sqlite, String name) {
+    return sqlite.connectToRecommended(
+      name,
+      additionalOptions: PowerSyncAdditionalOpenOptions(
+          useMultipleCiphersVfs: encryptionOptions != null),
+    );
+  }
+
+  @override
+  List<String> pragmaStatements(SqliteOpenOptions options) {
+    return [
+      ...?encryptionOptions?.pragmaStatements(),
+      ...super.pragmaStatements(options),
+    ];
   }
 }

--- a/packages/powersync/lib/src/platform_specific/native.dart
+++ b/packages/powersync/lib/src/platform_specific/native.dart
@@ -1,6 +1,7 @@
 import 'package:logging/logging.dart';
 import 'package:sqlite_async/sqlite_async.dart';
 
+import '../database/encryption_options.dart';
 import '../database/native/native_powersync_database.dart';
 import '../database/powersync_database.dart';
 import '../open_factory/native/native_open_factory.dart';
@@ -10,8 +11,10 @@ Mutex potentiallySharedMutex(String identifier) {
   return Mutex.simple();
 }
 
-SqliteOpenFactory powerSyncOpenFactory(String path, SqliteOptions options) {
-  return NativePowerSyncOpenFactory(path: path, sqliteOptions: options);
+SqliteOpenFactory powerSyncOpenFactory(
+    String path, SqliteOptions options, EncryptionOptions? encryption) {
+  return NativePowerSyncOpenFactory(
+      path: path, sqliteOptions: options, encryptionOptions: encryption);
 }
 
 BasePowerSyncDatabase openPowerSyncDatabase(

--- a/packages/powersync/lib/src/platform_specific/unsupported.dart
+++ b/packages/powersync/lib/src/platform_specific/unsupported.dart
@@ -1,6 +1,7 @@
 import 'package:logging/logging.dart';
 import 'package:sqlite_async/sqlite_async.dart';
 
+import '../database/encryption_options.dart';
 import '../database/powersync_database.dart';
 import '../schema.dart';
 
@@ -16,7 +17,8 @@ Mutex potentiallySharedMutex(String identifier) {
   _unsupportedPlatform();
 }
 
-SqliteOpenFactory powerSyncOpenFactory(String path, SqliteOptions options) {
+SqliteOpenFactory powerSyncOpenFactory(
+    String path, SqliteOptions options, EncryptionOptions? encryption) {
   _unsupportedPlatform();
 }
 

--- a/packages/powersync/lib/src/platform_specific/web.dart
+++ b/packages/powersync/lib/src/platform_specific/web.dart
@@ -3,6 +3,7 @@ import 'package:sqlite_async/sqlite_async.dart';
 // ignore: implementation_imports
 import 'package:sqlite_async/src/web/web_mutex.dart';
 
+import '../database/encryption_options.dart';
 import '../database/powersync_database.dart';
 import '../database/web/web_powersync_database.dart';
 import '../open_factory/web/web_open_factory.dart';
@@ -16,8 +17,10 @@ Mutex potentiallySharedMutex(String identifier) {
   return WebMutexImpl(identifier: identifier);
 }
 
-SqliteOpenFactory powerSyncOpenFactory(String path, SqliteOptions options) {
-  return WebPowerSyncOpenFactory(path: path, sqliteOptions: options);
+SqliteOpenFactory powerSyncOpenFactory(
+    String path, SqliteOptions options, EncryptionOptions? encryption) {
+  return WebPowerSyncOpenFactory(
+      path: path, sqliteOptions: options, encryptionOptions: encryption);
 }
 
 BasePowerSyncDatabase openPowerSyncDatabase(

--- a/packages/powersync/lib/src/setup/web.dart
+++ b/packages/powersync/lib/src/setup/web.dart
@@ -53,7 +53,9 @@ Future<void> downloadWebAssets(List<String> arguments) async {
 
   if (Platform.environment.containsKey('IS_IN_POWERSYNC_CI')) {
     print('IS_IN_POWERSYNC_CI env variable is set, copying from local build');
-    return _copyPrecompiled(Directory.current, wasmFileName, outputDir);
+    await _copyPrecompiled(Directory.current, 'sqlite3.wasm', outputDir);
+    await _copyPrecompiled(Directory.current, 'sqlite3mc.wasm', outputDir);
+    return;
   }
 
   try {

--- a/packages/powersync/lib/src/setup/web.dart
+++ b/packages/powersync/lib/src/setup/web.dart
@@ -7,19 +7,24 @@ import 'package:pubspec_parse/pubspec_parse.dart';
 import 'package:args/args.dart';
 import 'package:path/path.dart' as p;
 
-Future<void> downloadWebAssets(List<String> arguments,
-    {bool encryption = false}) async {
+Future<void> downloadWebAssets(List<String> arguments) async {
   var parser = ArgParser();
   // Add a flag to enable/disable the download of worker (defaults to true)
   // Pass the --no-worker argument to disable the download of the worker
   // dart run powersync:setup_web --no-worker
   parser.addFlag('worker', defaultsTo: true);
+  parser.addFlag(
+    'encryption',
+    defaultsTo: false,
+    help: 'Download a sqlite3.wasm with encryption support.',
+  );
   // Add a option to specify the output directory (defaults to web)
   // Pass the --output-dir argument to specify the output directory
   // dart run powersync:setup_web --output-dir assets
   parser.addOption('output-dir', abbr: 'o', defaultsTo: 'web');
   var results = parser.parse(arguments);
   bool downloadWorker = results.flag('worker');
+  bool encryption = results.flag('encryption');
   String outputDir = results.option('output-dir')!;
 
   final root = Directory.current.uri;

--- a/packages/powersync/test/database/encryption_test.dart
+++ b/packages/powersync/test/database/encryption_test.dart
@@ -1,0 +1,87 @@
+import 'package:powersync/powersync.dart';
+import 'package:powersync/sqlite3_common.dart';
+import 'package:test/test.dart';
+
+import '../utils/test_utils_impl.dart';
+
+void main() {
+  late String path;
+  late TestUtils testUtils;
+
+  setUpAll(() => testUtils = TestUtils());
+
+  setUp(() async {
+    path = testUtils.dbPath();
+    await testUtils.cleanDb(path: path);
+  });
+
+  test('generates pragma statements', () {
+    expect(
+      EncryptionOptions(key: 'foo', sqlcipherCompatibility: false)
+          .pragmaStatements(),
+      ["PRAGMA key = 'foo'"],
+    );
+    expect(
+      EncryptionOptions(key: 'foo', sqlcipherCompatibility: true)
+          .pragmaStatements(),
+      [
+        "PRAGMA cipher = 'sqlcipher'",
+        'PRAGMA legacy = 4',
+        "PRAGMA key = 'foo'"
+      ],
+    );
+
+    expect(
+      EncryptionOptions(key: "f'o'o", sqlcipherCompatibility: false)
+          .pragmaStatements(),
+      ["PRAGMA key = 'f''o''o'"],
+    );
+  });
+
+  group(
+    'without encryption',
+    () {
+      test('throws when encryption options are used', () async {
+        await expectLater(() async {
+          await testUtils.setupPowerSync(
+              encryption: EncryptionOptions(key: 'foo'));
+        }, throwsA(anything));
+      });
+    },
+    tags: 'require_no_encryption',
+  );
+
+  // To run the following tests, uncomment hook options in the monorepo's
+  // pubspec.yaml and run dart test -P encryption.
+
+  group('with encryption', () {
+    test('smoke test', () async {
+      final path = testUtils.dbPath();
+
+      // First database: Open with encryption key.
+      {
+        final db = await testUtils.setupPowerSync(
+          path: path,
+          encryption: EncryptionOptions(key: 'foo'),
+        );
+
+        await db.execute('INSERT INTO customers (id, name) VALUES (uuid(), ?)',
+            ['secret customer']);
+        await db.close();
+      }
+
+      // Opening without the key should fail.
+      await expectLater(() async {
+        await testUtils.setupPowerSync(path: path);
+      }, throwsA(isA<SqliteException>()));
+
+      // A different key should fail too.
+      await expectLater(() async {
+        await testUtils.setupPowerSync(
+          path: path,
+          encryption: EncryptionOptions(key: 'bar'),
+        );
+      }, throwsA(isA<SqliteException>()));
+    });
+  }, tags: 'require_encryption');
+}

--- a/packages/powersync/test/utils/abstract_test_utils.dart
+++ b/packages/powersync/test/utils/abstract_test_utils.dart
@@ -74,17 +74,22 @@ abstract class AbstractTestUtils {
   }
 
   /// Generates a test open factory
-  Future<SqliteOpenFactory> testFactory(
-      {String? path, SqliteOptions options = const SqliteOptions()});
+  Future<SqliteOpenFactory> testFactory({
+    String? path,
+    SqliteOptions options = const SqliteOptions(),
+    EncryptionOptions? encryption,
+  });
 
   /// Creates a SqliteDatabaseConnection
   Future<PowerSyncDatabase> setupPowerSync({
     String? path,
     Schema? schema,
     Logger? logger,
+    EncryptionOptions? encryption,
     bool initialize = true,
   }) async {
-    final db = PowerSyncDatabase.withFactory(await testFactory(path: path),
+    final db = PowerSyncDatabase.withFactory(
+        await testFactory(path: path, encryption: encryption),
         schema: schema ?? defaultSchema,
         logger: logger ?? _makeTestLogger(name: _testName));
     if (initialize) {

--- a/packages/powersync/test/utils/native_test_utils.dart
+++ b/packages/powersync/test/utils/native_test_utils.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 import 'package:powersync/native.dart';
+import 'package:powersync/powersync.dart';
 import 'package:sqlite3/sqlite3.dart';
 import 'package:sqlite3/src/database.dart';
 import 'package:sqlite_async/sqlite_async.dart';
@@ -36,11 +37,15 @@ class TestUtils extends AbstractTestUtils {
   }
 
   @override
-  Future<SqliteOpenFactory> testFactory(
-      {String? path, SqliteOptions options = const SqliteOptions()}) async {
+  Future<SqliteOpenFactory> testFactory({
+    String? path,
+    SqliteOptions options = const SqliteOptions(),
+    EncryptionOptions? encryption,
+  }) async {
     return NativePowerSyncOpenFactory(
       path: path ?? dbPath(),
       sqliteOptions: options,
+      encryptionOptions: encryption,
     );
   }
 

--- a/packages/powersync/test/utils/stub_test_utils.dart
+++ b/packages/powersync/test/utils/stub_test_utils.dart
@@ -1,3 +1,4 @@
+import 'package:powersync/powersync.dart';
 import 'package:sqlite3/src/database.dart';
 import 'package:sqlite_async/sqlite_async.dart';
 
@@ -8,7 +9,8 @@ class TestUtils extends AbstractTestUtils {
   Future<SqliteOpenFactory> testFactory(
       {String? path,
       String sqlitePath = '',
-      SqliteOptions options = const SqliteOptions()}) {
+      SqliteOptions options = const SqliteOptions(),
+      EncryptionOptions? encryption}) {
     throw UnimplementedError();
   }
 

--- a/packages/powersync/test/utils/web_test_utils.dart
+++ b/packages/powersync/test/utils/web_test_utils.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:js_interop';
 
+import 'package:powersync/powersync.dart';
 import 'package:powersync/web.dart';
 import 'package:sqlite3/wasm.dart';
 import 'package:sqlite_async/sqlite_async.dart';
@@ -14,6 +15,7 @@ external String _createObjectURL(Blob blob);
 class TestUtils extends AbstractTestUtils {
   late Future<void> _isInitialized;
   late final String sqlite3WASMUri;
+  late final String sqlite3McUri;
   late final String workerUri;
 
   TestUtils() {
@@ -25,6 +27,7 @@ class TestUtils extends AbstractTestUtils {
         spawnHybridUri('/test/server/worker_server.dart', stayAlive: true);
     final port = await channel.stream.first as int;
     sqlite3WASMUri = 'http://localhost:$port/sqlite3.wasm';
+    sqlite3McUri = 'http://localhost:$port/sqlite3mc.wasm';
     // Cross origin workers are not supported, but we can supply a Blob
     final workerUriSource = 'http://localhost:$port/powersync_db.worker.js';
 
@@ -38,18 +41,23 @@ class TestUtils extends AbstractTestUtils {
   Future<void> cleanDb({required String path}) async {}
 
   @override
-  Future<SqliteOpenFactory> testFactory(
-      {String? path,
-      String sqlitePath = '',
-      SqliteOptions options = const SqliteOptions()}) async {
+  Future<SqliteOpenFactory> testFactory({
+    String? path,
+    String sqlitePath = '',
+    SqliteOptions options = const SqliteOptions(),
+    EncryptionOptions? encryption,
+  }) async {
     await _isInitialized;
 
     return WebPowerSyncOpenFactory(
       path: path ?? '',
       sqliteOptions: options.copyWith(
-        webSqliteOptions:
-            WebSqliteOptions(wasmUri: sqlite3WASMUri, workerUri: workerUri),
+        webSqliteOptions: WebSqliteOptions(
+          wasmUri: encryption == null ? sqlite3WASMUri : sqlite3McUri,
+          workerUri: workerUri,
+        ),
       ),
+      encryptionOptions: encryption,
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,11 +28,12 @@ dependencies:
   path: ^1.0.0
   yaml: ^3.1.2
 
-# Uncomment this to run PowerSync encryption tests.
-#hooks:
-#  user_defines:
-#    sqlite3:
-#      source: sqlite3mc
+hooks:
+  user_defines:
+    sqlite3:
+      # To run PowerSync encryption tests, replace this with sqlite3mc and run
+      # dart test -P encryption
+      source: sqlite3
 
 dependency_overrides:
   # The only drift version with support for version 3.x of the sqlite3 package

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,12 @@ dependencies:
   path: ^1.0.0
   yaml: ^3.1.2
 
+# Uncomment this to run PowerSync encryption tests.
+#hooks:
+#  user_defines:
+#    sqlite3:
+#      source: sqlite3mc
+
 dependency_overrides:
   # The only drift version with support for version 3.x of the sqlite3 package
   # needs this analyzer, but riverpod doesn't support it yet:

--- a/tool/enable_encryption.dart
+++ b/tool/enable_encryption.dart
@@ -1,0 +1,11 @@
+import 'dart:io';
+
+/// Replaces the sqlite3 override with sqlite3mc in pubspec.yaml to enable
+/// encryption tests.
+void main() {
+  final file = File('pubspec.yaml');
+  final updated = file
+      .readAsStringSync()
+      .replaceAll('source: sqlite3', 'source: sqlite3mc');
+  file.writeAsStringSync(updated);
+}

--- a/tool/enable_encryption.dart
+++ b/tool/enable_encryption.dart
@@ -2,10 +2,12 @@ import 'dart:io';
 
 /// Replaces the sqlite3 override with sqlite3mc in pubspec.yaml to enable
 /// encryption tests.
+///
+/// Must be run from the root of the repository.
 void main() {
   final file = File('pubspec.yaml');
   final updated = file
       .readAsStringSync()
-      .replaceAll('source: sqlite3', 'source: sqlite3mc');
+      .replaceFirst('source: sqlite3', 'source: sqlite3mc');
   file.writeAsStringSync(updated);
 }


### PR DESCRIPTION
This restores support for encrypting databases (removed with the `package:sqlite_async` update in https://github.com/powersync-ja/powersync.dart/pull/390). Encrypting databases does not require additional dependencies anymore. Instead, users enable enable encryption by passing the `encryption` parameter to a `PowerSyncDatabase` constructor. This makes the open factory run a `pragma cipher = ` statement to encrypt databases.

For this to work, SQLite3MultipleCiphers must be used. The `sqlite3` package supports that, but it requires a configuration option in `pubspec.yaml`. The `EncryptionOptions` class documents required steps.

This also adds tests using encrypted databases, both on the web and on native platforms (`powersync_sqlcipher` was essentially untested).