### PR TITLE
Prepare update

### DIFF
--- a/demos/benchmarks/pubspec.yaml
+++ b/demos/benchmarks/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.18.0
+  powersync: ^2.0.0-beta.0
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/benchmarks/pubspec.yaml
+++ b/demos/benchmarks/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^2.0.0-beta.0
+  powersync: ^2.0.0-wip.0
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.18.0
+  powersync: ^2.0.0-beta.0
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^2.0.0-beta.0
+  powersync: ^2.0.0-wip.0
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/firebase-nodejs-todolist/pubspec.yaml
+++ b/demos/firebase-nodejs-todolist/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^2.0.0-beta.0
+  powersync: ^2.0.0-wip.0
   sqlite3: ^3.2.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1

--- a/demos/firebase-nodejs-todolist/pubspec.yaml
+++ b/demos/firebase-nodejs-todolist/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.18.0
+  powersync: ^2.0.0-beta.0
   sqlite3: ^3.2.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.18.0
+  powersync: ^2.0.0-beta.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^2.0.0-beta.0
+  powersync: ^2.0.0-wip.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.18.0
+  powersync: ^2.0.0-beta.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^2.0.0-beta.0
+  powersync: ^2.0.0-wip.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
 
   supabase_flutter: ^2.0.2
   timeago: ^3.6.0
-  powersync: ^2.0.0-beta.0
+  powersync: ^2.0.0-wip.0
   sqlite3: ^3.2.0
   path_provider: ^2.1.1
   path: ^1.8.3

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
 
   supabase_flutter: ^2.0.2
   timeago: ^3.6.0
-  powersync: ^1.18.0
+  powersync: ^2.0.0-beta.0
   sqlite3: ^3.2.0
   path_provider: ^2.1.1
   path: ^1.8.3

--- a/demos/supabase-todolist-drift/pubspec.yaml
+++ b/demos/supabase-todolist-drift/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.6.20+1
+  powersync_attachments_helper: ^0.7.0-wip.0
   powersync: ^2.0.0-wip.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1

--- a/demos/supabase-todolist-drift/pubspec.yaml
+++ b/demos/supabase-todolist-drift/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   powersync_attachments_helper: ^0.6.20+1
-  powersync: ^1.18.0
+  powersync: ^2.0.0-beta.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist-drift/pubspec.yaml
+++ b/demos/supabase-todolist-drift/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   powersync_attachments_helper: ^0.6.20+1
-  powersync: ^2.0.0-beta.0
+  powersync: ^2.0.0-wip.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist-optional-sync/pubspec.yaml
+++ b/demos/supabase-todolist-optional-sync/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.18.0
+  powersync: ^2.0.0-beta.0
   sqlite3: ^3.2.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1

--- a/demos/supabase-todolist-optional-sync/pubspec.yaml
+++ b/demos/supabase-todolist-optional-sync/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^2.0.0-beta.0
+  powersync: ^2.0.0-wip.0
   sqlite3: ^3.2.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^1.18.0
+  powersync: ^2.0.0-beta.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^2.0.0-beta.0
+  powersync: ^2.0.0-wip.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-trello/pubspec.yaml
+++ b/demos/supabase-trello/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   random_name_generator: ^1.5.0
   flutter_dotenv: ^6.0.0
   logging: ^1.3.0
-  powersync: ^2.0.0-beta.0
+  powersync: ^2.0.0-wip.0
   sqlite_async: ^0.14.0-wip
   sqlite3: ^3.2.0
   path_provider: ^2.1.5

--- a/demos/supabase-trello/pubspec.yaml
+++ b/demos/supabase-trello/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   random_name_generator: ^1.5.0
   flutter_dotenv: ^6.0.0
   logging: ^1.3.0
-  powersync: ^1.18.0
+  powersync: ^2.0.0-beta.0
   sqlite_async: ^0.14.0-wip
   sqlite3: ^3.2.0
   path_provider: ^2.1.5

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.0-beta.0
+## 2.0.0-wip.0
 
 - Upgrade sqlite packages: Version 3.x of `sqlite3`, 0.6.x of `sqlite3_web`, 0.14.0 of `sqlite_async`.
   - Remember to download updated db workers and `sqlite3.wasm` files after upgrading!

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.0-wip.0
 
-- Upgrade sqlite packages: Version 3.x of `sqlite3`, 0.6.x of `sqlite3_web`, 0.14.0 of `sqlite_async`.
+- Upgrade sqlite packages: Version 3.x of `sqlite3`, 0.6.x of `sqlite3_web`, 0.14.x of `sqlite_async`.
   - Remember to download updated db workers and `sqlite3.wasm` files after upgrading!
   - __Breaking__: Remove `package:powersync/sqlite3_open.dart`, since SQLite is now loaded through [build hooks](https://pub.dev/documentation/sqlite3/latest/topics/hook-topic.html) exclusively.
   - __Breaking__: Remove `AbstractPowerSyncOpenFactory` and `PowerSyncOpenFactory`. If you want to customize how databases

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,29 @@
+## 2.0.0-beta.0
+
+- Upgrade sqlite packages: Version 3.x of `sqlite3`, 0.6.x of `sqlite3_web`, 0.14.0 of `sqlite_async`.
+  - __Breaking__: Remove `package:powersync/sqlite3_open.dart`, since SQLite is now loaded through [build hooks](https://pub.dev/documentation/sqlite3/latest/topics/hook-topic.html) exclusively.
+  - __Breaking__: Remove `AbstractPowerSyncOpenFactory` and `PowerSyncOpenFactory`. If you want to customize how databases
+    are opened, use conditional imports for `package:powersync/native.dart` and `package:powersync/web.dart` to extend
+    `NativePowerSyncOpenFactory` or `WebPowerSyncOpenFactory`, respectively.
+  - Improve performance of native databases.
+  - Native databases can now be opened on multiple isolates or Flutter engines (e.g. for background tasks).
+    They will automatically share write locks and table updates. Note that only one instance may connect to the PowerSync service though.
+  - On the web, Chrome browsers now use an OPFS-based database instead of IndexedDB. This improves performance. Existing databases are still loaded from IndexedDB.
+  - The `maxReaders` parameter on `PowerSyncDatabase` constructors is no longer functional, set that parameter on
+  `SqliteOptions` instead.
+  - Add `watchUnthrottled` and `onChangeUnthrottled` as variants of `watch` and `onChange` that only take backpressure
+    from paused subscriptions into account withut using a fixed delay.
+  - Add `abortableReadLock` and `abortableWriteLock`, which can be used to acquire a read/write context with a flexible
+    abort signal instead of a fixed timeout.
+- __Breaking__: The `powersync_core`, `powersync_encryption` and `powersync_flutter_libs` packages have been removed.
+  The `powersync` package now provides the entire SDK for all platforms (both for Flutter and standalone Dart apps).
+- __Breaking__: The `powersync_sleep` and `powersync_connection_name` SQL functions have been removed. Also, it is
+  no longer possible to define additional user-defined functions in Dart.
+- Add encryption support to the `powersync` package (see the `EncryptionOptions` class for details).
+- Remove the legacy Dart sync client. The new Rust client has been the default since version 1.17.0.
+- Deprecate re-exports of other packages (`package:powersync/sqlite_async.dart`, `package:powersync/sqlite3_common.dart`,
+  `package:powersync/sqlite3.dart`). Instead, add a dependency on the respective package and import it directly.
+
 ## 1.18.0
 
 - Add `RawTable.inferred` constructor, which can be used to specify raw tables without manual `put` and `delete` statements.

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -9,14 +9,14 @@
   - Improve performance of native databases.
   - Native databases can now be opened on multiple isolates or Flutter engines (e.g. for background tasks).
     They will automatically share write locks and table updates. Note that only one instance may connect to the PowerSync service though.
-  - On the web, Chrome browsers now use an OPFS-based database instead of IndexedDB. This improves performance. Existing databases are still loaded from IndexedDB.
+  - For Chrome browsers, we now use OPFS by default instead of IndexedDB. This improves performance. Existing databases are still loaded from IndexedDB.
   - The `maxReaders` parameter on `PowerSyncDatabase` constructors is no longer functional, set that parameter on
   `SqliteOptions` instead.
   - Add `watchUnthrottled` and `onChangeUnthrottled` as variants of `watch` and `onChange` that only take backpressure
     from paused subscriptions into account withut using a fixed delay.
   - Add `abortableReadLock` and `abortableWriteLock`, which can be used to acquire a read/write context with a flexible
     abort signal instead of a fixed timeout.
-- __Breaking__: The `powersync_core`, `powersync_encryption` and `powersync_flutter_libs` packages have been removed.
+- __Breaking__: The `powersync_core`, `powersync_sqlcipher` and `powersync_flutter_libs` packages have been removed.
   The `powersync` package now provides the entire SDK for all platforms (both for Flutter and standalone Dart apps).
 - __Breaking__: The `powersync_sleep` and `powersync_connection_name` SQL functions have been removed. Also, it is
   no longer possible to define additional user-defined functions in Dart.

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.0.0-beta.0
 
 - Upgrade sqlite packages: Version 3.x of `sqlite3`, 0.6.x of `sqlite3_web`, 0.14.0 of `sqlite_async`.
+  - Remember to download updated db workers and `sqlite3.wasm` files after upgrading!
   - __Breaking__: Remove `package:powersync/sqlite3_open.dart`, since SQLite is now loaded through [build hooks](https://pub.dev/documentation/sqlite3/latest/topics/hook-topic.html) exclusively.
   - __Breaking__: Remove `AbstractPowerSyncOpenFactory` and `PowerSyncOpenFactory`. If you want to customize how databases
     are opened, use conditional imports for `package:powersync/native.dart` and `package:powersync/web.dart` to extend
@@ -23,6 +24,7 @@
 - Remove the legacy Dart sync client. The new Rust client has been the default since version 1.17.0.
 - Deprecate re-exports of other packages (`package:powersync/sqlite_async.dart`, `package:powersync/sqlite3_common.dart`,
   `package:powersync/sqlite3.dart`). Instead, add a dependency on the respective package and import it directly.
+- Remove `powersync_sync.worker.js`. `powersync_db.worker.js` now covers both database access and sync.
 
 ## 1.18.0
 

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 1.18.0
+version: 2.0.0-beta.0
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Dart and Flutter SDK. Sync Postgres, MongoDB, MySQL or SQL Server with SQLite in your app

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 2.0.0-beta.0
+version: 2.0.0-wip.0
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Dart and Flutter SDK. Sync Postgres, MongoDB, MySQL or SQL Server with SQLite in your app

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.21-beta.0
+
+- Support versions 2.x of the `powersync` package.
+
 ## 0.6.20+1
 
  - Update a dependency to the latest release.

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.6.21-beta.0
+## 0.6.21-wip.0
 
 - Support versions 2.x of the `powersync` package.
 

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.6.21-wip.0
+## 0.7.0-wip.0
 
 - Support versions 2.x of the `powersync` package.
 

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.6.20+1
+version: 0.6.21-beta.0
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 resolution: workspace
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^1.18.0
+  powersync: ^2.0.0-beta.0
   logging: ^1.2.0
   path_provider: ^2.0.13
   sqlite3: ^3.2.0

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.6.21-wip.0
+version: 0.7.0-wip.0
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 resolution: workspace

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.6.21-beta.0
+version: 0.6.21-wip.0
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 resolution: workspace
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^2.0.0-beta.0
+  powersync: ^2.0.0-wip.0
   logging: ^1.2.0
   path_provider: ^2.0.13
   sqlite3: ^3.2.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -676,10 +676,10 @@ packages:
     dependency: transitive
     description:
       name: hotreloader
-      sha256: bc167a1163807b03bada490bfe2df25b0d744df359227880220a5cbd04e5734b
+      sha256: "66871df468fc24eee81f1a0a7cb98acc104716f9b7376d355437b48d633c4ebf"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.0"
+    version: "4.4.0"
   http:
     dependency: transitive
     description:
@@ -732,10 +732,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: "9eae0cbd672549dacc18df855c2a23782afe4854ada5190b7d63b30ee0b0d3fd"
+      sha256: "66810af8e99b2657ee98e5c6f02064f69bb63f7a70e343937f70946c5f8c6622"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.13+15"
+    version: "0.8.13+16"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -800,6 +800,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  jni:
+    dependency: transitive
+    description:
+      name: jni
+      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  jni_flutter:
+    dependency: transitive
+    description:
+      name: jni_flutter
+      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   json_annotation:
     dependency: transitive
     description:
@@ -892,10 +908,10 @@ packages:
     dependency: "direct main"
     description:
       name: melos
-      sha256: "72942b70e2fad1f01b2d66b42696546f9f48f57c342bee61726c540e8bfdcb02"
+      sha256: "2f7381d209ab7554203c51481a6a57c7896593b7f06190a06a467aa5bfd693c5"
       url: "https://pub.dev"
     source: hosted
-    version: "7.5.0"
+    version: "7.5.1"
   meta:
     dependency: transitive
     description:
@@ -996,10 +1012,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "149441ca6e4f38193b2e004c0ca6376a3d11f51fa5a77552d8bd4d2b0c0912ba"
+      sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.23"
+    version: "2.3.1"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -1369,10 +1385,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: caa693ad15a587a2b4fde093b728131a1827903872171089dedb16f7665d3a91
+      sha256: b3fe250b4ebd681a8ba20b12794c42b00c1375e5b51005568f0b8731265beb03
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.3.0"
   sqlite3_connection_pool:
     dependency: transitive
     description:


### PR DESCRIPTION
This prepares version 2.0.0 (currently as a `-wip` release) of the `powersync` package and `0.7.0` of `powersync_attachments_helper`. I've considered making this a minor release since it shouldn't be breaking for almost all users, but making this a major update is the correct thing to do to follow semver rules. Apart from breaking changes affecting open factories and merged packages, users would also have to update their `sqlite3.wasm` and `powersync_db.worker.js`. 

I've added a changelog entry by copying relevant sections from the `sqlite_async` package and the other PRs on the `dev` branch.