### PR TITLE
Update release instructions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish packages
 on:
   push:
     tags:
-      - "powersync-v[0-9]+.[0-9]+.[0-9]+"
+      - "powersync-v[0-9]+.[0-9]+.[0-9]+*"
       - "powersync_attachments_helper-v[0-9]+.[0-9]+.[0-9]+*"
       - "powersync_flutter_libs-v[0-9]+.[0-9]+.[0-9]+*"
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: Compile Assets and Create Draft Release
 on:
   push:
     tags:
-      - 'powersync-v[0-9]+.[0-9]+.[0-9]+'
+      - 'powersync-v[0-9]+.[0-9]+.[0-9]+*'
 
 # For trusted npm publishing, see https://docs.npmjs.com/trusted-publishers#github-actions-configuration
 permissions:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,30 +1,18 @@
 # Preparing Release
 
-Bump the version of the packages to be released using `melos`:
+As the repository only contains a single package we expect to update frequently, the release process is currently involves some manual steps.
 
-```
-melos version
-```
+1. Update the version in `powersync/pubspec.yaml`.
+2. Run `dart tool/update_version.dart` to ensure the SDK reports its updated version in user agents.
+3. Create a changelog entry for the same version.
+4. Open a PR with these changes and wait for it to get merged.
 
-if melos does not pick up changes or does not bump the version correctly, you can manually version the packages using
+## Perform Release
 
-```
-melos version -V ${PACKAGE_NAME}:M.M.P
-for e.g melos version -V powersync:1.6.3
-```
+We create a tag for each package update named `${packageName}-v${version}`, e.g.
 
-This will create a tag for all packages updated in the format of ${PACKAGE_NAME}-vM.M.P
+- `powersync-v2.0.1`
+- `powersync_flutter_libs-v0.5.0+eol`
 
-```
-e.g powersync-v1.6.4, powersync_attachments_helper-v0.6.3+1, etc.
-```
-
-# Perform Release
-
-```
-git push --follow-tags
-```
-
-**Note: This will launch the `release.yaml` and `publish.yaml` github actions in `.github/workflows`. So only run it when you are absolutely sure you want to release.**
-
-A version bump and tag push for `powersync` will also create a Github release for the PowerSync web workers. Verify the release exists and is published in the [releases](https://github.com/powersync-ja/powersync.dart/releases).
+Creating an pushing those tags will trigger an automated release to pub.dev and a GitHub release containing `sqlite3.wasm` files and the web worker.
+Verify the release exists and is published in the [releases](https://github.com/powersync-ja/powersync.dart/releases).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Preparing Release
 
-As the repository only contains a single package we expect to update frequently, the release process is currently involves some manual steps.
+As the repository only contains a single package we expect to update frequently, the release process currently involves some manual steps.
 
 1. Update the version in `powersync/pubspec.yaml`.
 2. Run `dart tool/update_version.dart` to ensure the SDK reports its updated version in user agents.
@@ -14,5 +14,5 @@ We create a tag for each package update named `${packageName}-v${version}`, e.g.
 - `powersync-v2.0.1`
 - `powersync_flutter_libs-v0.5.0+eol`
 
-Creating an pushing those tags will trigger an automated release to pub.dev and a GitHub release containing `sqlite3.wasm` files and the web worker.
-Verify the release exists and is published in the [releases](https://github.com/powersync-ja/powersync.dart/releases).
+Creating and pushing those tags will trigger an automated release to pub.dev and a GitHub release containing `sqlite3.wasm` files and the web worker.
+Verify the release exists and is published in [releases](https://github.com/powersync-ja/powersync.dart/releases).

--- a/packages/powersync/lib/src/version.dart
+++ b/packages/powersync/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String libraryVersion = '1.8.0';
+const String libraryVersion = '2.0.0-wip.0';


### PR DESCRIPTION
One (hopefully final) update for the `dev` branch before the WIP release:

1. Also trigger our release automation for tags containing a version suffix/prefix (like `-wip.0` for the current state on `dev`).
2. Update `RELEASING.md` with the updated steps (we no longer use melos to manage updates since there's really just a single SDK package to manage). We can revisit tooling to automate more of this again in the future.
