### PR TITLE
Prepare stable 2.0.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 # Created by `dart pub`
 .dart_tool/
 .DS_Store
-pubspec_overrides.yaml
 .idea
 .vscode
 *.iml

--- a/demos/benchmarks/linux/flutter/generated_plugin_registrant.cc
+++ b/demos/benchmarks/linux/flutter/generated_plugin_registrant.cc
@@ -6,14 +6,6 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <powersync_flutter_libs/powersync_flutter_libs_plugin.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
-  g_autoptr(FlPluginRegistrar) powersync_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "PowersyncFlutterLibsPlugin");
-  powersync_flutter_libs_plugin_register_with_registrar(powersync_flutter_libs_registrar);
-  g_autoptr(FlPluginRegistrar) sqlite3_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
-  sqlite3_flutter_libs_plugin_register_with_registrar(sqlite3_flutter_libs_registrar);
 }

--- a/demos/benchmarks/linux/flutter/generated_plugins.cmake
+++ b/demos/benchmarks/linux/flutter/generated_plugins.cmake
@@ -3,11 +3,10 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  powersync_flutter_libs
-  sqlite3_flutter_libs
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/demos/benchmarks/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/demos/benchmarks/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,10 +5,6 @@
 import FlutterMacOS
 import Foundation
 
-import powersync_flutter_libs
-import sqlite3_flutter_libs
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  PowersyncFlutterLibsPlugin.register(with: registry.registrar(forPlugin: "PowersyncFlutterLibsPlugin"))
-  Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
 }

--- a/demos/benchmarks/pubspec.yaml
+++ b/demos/benchmarks/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   path: ^1.8.3
   logging: ^1.2.0
   universal_io: ^2.2.2
-  sqlite_async: ^0.14.0-wip
+  sqlite_async: ^0.14.0
   sqlite3: ^3.2.0
   http: ^1.2.2
 

--- a/demos/benchmarks/pubspec.yaml
+++ b/demos/benchmarks/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^2.0.0-wip.0
+  powersync: ^2.0.0
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/benchmarks/windows/flutter/generated_plugin_registrant.cc
+++ b/demos/benchmarks/windows/flutter/generated_plugin_registrant.cc
@@ -6,12 +6,6 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <powersync_flutter_libs/powersync_flutter_libs_plugin.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
-  PowersyncFlutterLibsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("PowersyncFlutterLibsPlugin"));
-  Sqlite3FlutterLibsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
 }

--- a/demos/benchmarks/windows/flutter/generated_plugins.cmake
+++ b/demos/benchmarks/windows/flutter/generated_plugins.cmake
@@ -3,11 +3,10 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  powersync_flutter_libs
-  sqlite3_flutter_libs
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/demos/django-todolist/linux/flutter/generated_plugin_registrant.cc
+++ b/demos/django-todolist/linux/flutter/generated_plugin_registrant.cc
@@ -6,14 +6,6 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <powersync_flutter_libs/powersync_flutter_libs_plugin.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
-  g_autoptr(FlPluginRegistrar) powersync_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "PowersyncFlutterLibsPlugin");
-  powersync_flutter_libs_plugin_register_with_registrar(powersync_flutter_libs_registrar);
-  g_autoptr(FlPluginRegistrar) sqlite3_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
-  sqlite3_flutter_libs_plugin_register_with_registrar(sqlite3_flutter_libs_registrar);
 }

--- a/demos/django-todolist/linux/flutter/generated_plugins.cmake
+++ b/demos/django-todolist/linux/flutter/generated_plugins.cmake
@@ -3,11 +3,10 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  powersync_flutter_libs
-  sqlite3_flutter_libs
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/demos/django-todolist/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/demos/django-todolist/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,12 +5,8 @@
 import FlutterMacOS
 import Foundation
 
-import powersync_flutter_libs
 import shared_preferences_foundation
-import sqlite3_flutter_libs
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  PowersyncFlutterLibsPlugin.register(with: registry.registrar(forPlugin: "PowersyncFlutterLibsPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
-  Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
 }

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.14.0-wip
+  sqlite_async: ^0.14.0
   sqlite3:  ^3.2.0
   http: ^1.2.1
   shared_preferences: ^2.2.3

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^2.0.0-wip.0
+  powersync: ^2.0.0
   path_provider: ^2.1.1
   path: ^1.8.3
   logging: ^1.2.0

--- a/demos/django-todolist/windows/flutter/generated_plugin_registrant.cc
+++ b/demos/django-todolist/windows/flutter/generated_plugin_registrant.cc
@@ -6,12 +6,6 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <powersync_flutter_libs/powersync_flutter_libs_plugin.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
-  PowersyncFlutterLibsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("PowersyncFlutterLibsPlugin"));
-  Sqlite3FlutterLibsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
 }

--- a/demos/django-todolist/windows/flutter/generated_plugins.cmake
+++ b/demos/django-todolist/windows/flutter/generated_plugins.cmake
@@ -3,11 +3,10 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  powersync_flutter_libs
-  sqlite3_flutter_libs
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/demos/firebase-nodejs-todolist/linux/flutter/generated_plugin_registrant.cc
+++ b/demos/firebase-nodejs-todolist/linux/flutter/generated_plugin_registrant.cc
@@ -7,20 +7,12 @@
 #include "generated_plugin_registrant.h"
 
 #include <gtk/gtk_plugin.h>
-#include <powersync_flutter_libs/powersync_flutter_libs_plugin.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) gtk_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
   gtk_plugin_register_with_registrar(gtk_registrar);
-  g_autoptr(FlPluginRegistrar) powersync_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "PowersyncFlutterLibsPlugin");
-  powersync_flutter_libs_plugin_register_with_registrar(powersync_flutter_libs_registrar);
-  g_autoptr(FlPluginRegistrar) sqlite3_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
-  sqlite3_flutter_libs_plugin_register_with_registrar(sqlite3_flutter_libs_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/demos/firebase-nodejs-todolist/linux/flutter/generated_plugins.cmake
+++ b/demos/firebase-nodejs-todolist/linux/flutter/generated_plugins.cmake
@@ -4,12 +4,11 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   gtk
-  powersync_flutter_libs
-  sqlite3_flutter_libs
   url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/demos/firebase-nodejs-todolist/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/demos/firebase-nodejs-todolist/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,17 +8,13 @@ import Foundation
 import app_links
 import firebase_auth
 import firebase_core
-import powersync_flutter_libs
 import shared_preferences_foundation
-import sqlite3_flutter_libs
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
-  PowersyncFlutterLibsPlugin.register(with: registry.registrar(forPlugin: "PowersyncFlutterLibsPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
-  Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/demos/firebase-nodejs-todolist/pubspec.yaml
+++ b/demos/firebase-nodejs-todolist/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^2.0.0-wip.0
+  powersync: ^2.0.0
   sqlite3: ^3.2.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1

--- a/demos/firebase-nodejs-todolist/windows/flutter/generated_plugin_registrant.cc
+++ b/demos/firebase-nodejs-todolist/windows/flutter/generated_plugin_registrant.cc
@@ -9,8 +9,6 @@
 #include <app_links/app_links_plugin_c_api.h>
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
-#include <powersync_flutter_libs/powersync_flutter_libs_plugin.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
@@ -20,10 +18,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FirebaseAuthPluginCApi"));
   FirebaseCorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
-  PowersyncFlutterLibsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("PowersyncFlutterLibsPlugin"));
-  Sqlite3FlutterLibsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/demos/firebase-nodejs-todolist/windows/flutter/generated_plugins.cmake
+++ b/demos/firebase-nodejs-todolist/windows/flutter/generated_plugins.cmake
@@ -6,12 +6,11 @@ list(APPEND FLUTTER_PLUGIN_LIST
   app_links
   firebase_auth
   firebase_core
-  powersync_flutter_libs
-  sqlite3_flutter_libs
   url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/demos/supabase-anonymous-auth/linux/flutter/generated_plugin_registrant.cc
+++ b/demos/supabase-anonymous-auth/linux/flutter/generated_plugin_registrant.cc
@@ -7,20 +7,12 @@
 #include "generated_plugin_registrant.h"
 
 #include <gtk/gtk_plugin.h>
-#include <powersync_flutter_libs/powersync_flutter_libs_plugin.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) gtk_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
   gtk_plugin_register_with_registrar(gtk_registrar);
-  g_autoptr(FlPluginRegistrar) powersync_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "PowersyncFlutterLibsPlugin");
-  powersync_flutter_libs_plugin_register_with_registrar(powersync_flutter_libs_registrar);
-  g_autoptr(FlPluginRegistrar) sqlite3_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
-  sqlite3_flutter_libs_plugin_register_with_registrar(sqlite3_flutter_libs_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/demos/supabase-anonymous-auth/linux/flutter/generated_plugins.cmake
+++ b/demos/supabase-anonymous-auth/linux/flutter/generated_plugins.cmake
@@ -4,12 +4,11 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   gtk
-  powersync_flutter_libs
-  sqlite3_flutter_libs
   url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/demos/supabase-anonymous-auth/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/demos/supabase-anonymous-auth/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,15 +6,11 @@ import FlutterMacOS
 import Foundation
 
 import app_links
-import powersync_flutter_libs
 import shared_preferences_foundation
-import sqlite3_flutter_libs
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
-  PowersyncFlutterLibsPlugin.register(with: registry.registrar(forPlugin: "PowersyncFlutterLibsPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
-  Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^2.0.0-wip.0
+  powersync: ^2.0.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   supabase_flutter: ^2.0.2
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.14.0-wip
+  sqlite_async: ^0.14.0
   universal_io: ^2.2.2
 
 dev_dependencies:

--- a/demos/supabase-anonymous-auth/windows/flutter/generated_plugin_registrant.cc
+++ b/demos/supabase-anonymous-auth/windows/flutter/generated_plugin_registrant.cc
@@ -7,17 +7,11 @@
 #include "generated_plugin_registrant.h"
 
 #include <app_links/app_links_plugin_c_api.h>
-#include <powersync_flutter_libs/powersync_flutter_libs_plugin.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AppLinksPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
-  PowersyncFlutterLibsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("PowersyncFlutterLibsPlugin"));
-  Sqlite3FlutterLibsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/demos/supabase-anonymous-auth/windows/flutter/generated_plugins.cmake
+++ b/demos/supabase-anonymous-auth/windows/flutter/generated_plugins.cmake
@@ -4,12 +4,11 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   app_links
-  powersync_flutter_libs
-  sqlite3_flutter_libs
   url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/demos/supabase-edge-function-auth/linux/flutter/generated_plugin_registrant.cc
+++ b/demos/supabase-edge-function-auth/linux/flutter/generated_plugin_registrant.cc
@@ -7,20 +7,12 @@
 #include "generated_plugin_registrant.h"
 
 #include <gtk/gtk_plugin.h>
-#include <powersync_flutter_libs/powersync_flutter_libs_plugin.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) gtk_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
   gtk_plugin_register_with_registrar(gtk_registrar);
-  g_autoptr(FlPluginRegistrar) powersync_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "PowersyncFlutterLibsPlugin");
-  powersync_flutter_libs_plugin_register_with_registrar(powersync_flutter_libs_registrar);
-  g_autoptr(FlPluginRegistrar) sqlite3_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
-  sqlite3_flutter_libs_plugin_register_with_registrar(sqlite3_flutter_libs_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/demos/supabase-edge-function-auth/linux/flutter/generated_plugins.cmake
+++ b/demos/supabase-edge-function-auth/linux/flutter/generated_plugins.cmake
@@ -4,12 +4,11 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   gtk
-  powersync_flutter_libs
-  sqlite3_flutter_libs
   url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/demos/supabase-edge-function-auth/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/demos/supabase-edge-function-auth/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,15 +6,11 @@ import FlutterMacOS
 import Foundation
 
 import app_links
-import powersync_flutter_libs
 import shared_preferences_foundation
-import sqlite3_flutter_libs
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
-  PowersyncFlutterLibsPlugin.register(with: registry.registrar(forPlugin: "PowersyncFlutterLibsPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
-  Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^2.0.0-wip.0
+  powersync: ^2.0.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.2
   path: ^1.8.3

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   supabase_flutter: ^2.0.2
   path: ^1.8.3
   logging: ^1.2.0
-  sqlite_async: ^0.14.0-wip
+  sqlite_async: ^0.14.0
   universal_io: ^2.2.2
 
 dev_dependencies:

--- a/demos/supabase-edge-function-auth/windows/flutter/generated_plugin_registrant.cc
+++ b/demos/supabase-edge-function-auth/windows/flutter/generated_plugin_registrant.cc
@@ -7,17 +7,11 @@
 #include "generated_plugin_registrant.h"
 
 #include <app_links/app_links_plugin_c_api.h>
-#include <powersync_flutter_libs/powersync_flutter_libs_plugin.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AppLinksPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
-  PowersyncFlutterLibsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("PowersyncFlutterLibsPlugin"));
-  Sqlite3FlutterLibsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/demos/supabase-edge-function-auth/windows/flutter/generated_plugins.cmake
+++ b/demos/supabase-edge-function-auth/windows/flutter/generated_plugins.cmake
@@ -4,12 +4,11 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   app_links
-  powersync_flutter_libs
-  sqlite3_flutter_libs
   url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/demos/supabase-simple-chat/linux/flutter/generated_plugin_registrant.cc
+++ b/demos/supabase-simple-chat/linux/flutter/generated_plugin_registrant.cc
@@ -7,20 +7,12 @@
 #include "generated_plugin_registrant.h"
 
 #include <gtk/gtk_plugin.h>
-#include <powersync_flutter_libs/powersync_flutter_libs_plugin.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) gtk_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
   gtk_plugin_register_with_registrar(gtk_registrar);
-  g_autoptr(FlPluginRegistrar) powersync_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "PowersyncFlutterLibsPlugin");
-  powersync_flutter_libs_plugin_register_with_registrar(powersync_flutter_libs_registrar);
-  g_autoptr(FlPluginRegistrar) sqlite3_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
-  sqlite3_flutter_libs_plugin_register_with_registrar(sqlite3_flutter_libs_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/demos/supabase-simple-chat/linux/flutter/generated_plugins.cmake
+++ b/demos/supabase-simple-chat/linux/flutter/generated_plugins.cmake
@@ -4,12 +4,11 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   gtk
-  powersync_flutter_libs
-  sqlite3_flutter_libs
   url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/demos/supabase-simple-chat/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/demos/supabase-simple-chat/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,15 +6,11 @@ import FlutterMacOS
 import Foundation
 
 import app_links
-import powersync_flutter_libs
 import shared_preferences_foundation
-import sqlite3_flutter_libs
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
-  PowersyncFlutterLibsPlugin.register(with: registry.registrar(forPlugin: "PowersyncFlutterLibsPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
-  Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
 
   supabase_flutter: ^2.0.2
   timeago: ^3.6.0
-  powersync: ^2.0.0-wip.0
+  powersync: ^2.0.0
   sqlite3: ^3.2.0
   path_provider: ^2.1.1
   path: ^1.8.3

--- a/demos/supabase-simple-chat/windows/flutter/generated_plugin_registrant.cc
+++ b/demos/supabase-simple-chat/windows/flutter/generated_plugin_registrant.cc
@@ -7,17 +7,11 @@
 #include "generated_plugin_registrant.h"
 
 #include <app_links/app_links_plugin_c_api.h>
-#include <powersync_flutter_libs/powersync_flutter_libs_plugin.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AppLinksPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
-  PowersyncFlutterLibsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("PowersyncFlutterLibsPlugin"));
-  Sqlite3FlutterLibsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/demos/supabase-simple-chat/windows/flutter/generated_plugins.cmake
+++ b/demos/supabase-simple-chat/windows/flutter/generated_plugins.cmake
@@ -4,12 +4,11 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   app_links
-  powersync_flutter_libs
-  sqlite3_flutter_libs
   url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/demos/supabase-todolist-drift/linux/flutter/generated_plugin_registrant.cc
+++ b/demos/supabase-todolist-drift/linux/flutter/generated_plugin_registrant.cc
@@ -7,16 +7,12 @@
 #include "generated_plugin_registrant.h"
 
 #include <gtk/gtk_plugin.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) gtk_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
   gtk_plugin_register_with_registrar(gtk_registrar);
-  g_autoptr(FlPluginRegistrar) sqlite3_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
-  sqlite3_flutter_libs_plugin_register_with_registrar(sqlite3_flutter_libs_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/demos/supabase-todolist-drift/linux/flutter/generated_plugins.cmake
+++ b/demos/supabase-todolist-drift/linux/flutter/generated_plugins.cmake
@@ -4,11 +4,11 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   gtk
-  sqlite3_flutter_libs
   url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/demos/supabase-todolist-drift/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/demos/supabase-todolist-drift/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,15 +6,11 @@ import FlutterMacOS
 import Foundation
 
 import app_links
-import path_provider_foundation
 import shared_preferences_foundation
-import sqlite3_flutter_libs
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
-  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
-  Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/demos/supabase-todolist-drift/pubspec.yaml
+++ b/demos/supabase-todolist-drift/pubspec.yaml
@@ -19,10 +19,10 @@ dependencies:
   camera: ^0.12.0
   image: ^4.1.3
   universal_io: ^2.2.2
-  sqlite_async: ^0.14.0-wip
+  sqlite_async: ^0.14.0
   sqlite3: ^3.2.0
   drift: ^2.20.2
-  drift_sqlite_async: ^0.3.0-wip
+  drift_sqlite_async: ^0.3.0
   riverpod_annotation: ^4.0.2
   riverpod: ^3.2.1
   flutter_hooks: ^0.21.2

--- a/demos/supabase-todolist-drift/pubspec.yaml
+++ b/demos/supabase-todolist-drift/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync_attachments_helper: ^0.7.0-wip.0
-  powersync: ^2.0.0-wip.0
+  powersync_attachments_helper: ^0.7.0
+  powersync: ^2.0.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist-drift/windows/flutter/generated_plugin_registrant.cc
+++ b/demos/supabase-todolist-drift/windows/flutter/generated_plugin_registrant.cc
@@ -7,14 +7,11 @@
 #include "generated_plugin_registrant.h"
 
 #include <app_links/app_links_plugin_c_api.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AppLinksPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
-  Sqlite3FlutterLibsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/demos/supabase-todolist-drift/windows/flutter/generated_plugins.cmake
+++ b/demos/supabase-todolist-drift/windows/flutter/generated_plugins.cmake
@@ -4,11 +4,11 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   app_links
-  sqlite3_flutter_libs
   url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/demos/supabase-todolist-optional-sync/linux/flutter/generated_plugin_registrant.cc
+++ b/demos/supabase-todolist-optional-sync/linux/flutter/generated_plugin_registrant.cc
@@ -7,20 +7,12 @@
 #include "generated_plugin_registrant.h"
 
 #include <gtk/gtk_plugin.h>
-#include <powersync_flutter_libs/powersync_flutter_libs_plugin.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) gtk_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
   gtk_plugin_register_with_registrar(gtk_registrar);
-  g_autoptr(FlPluginRegistrar) powersync_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "PowersyncFlutterLibsPlugin");
-  powersync_flutter_libs_plugin_register_with_registrar(powersync_flutter_libs_registrar);
-  g_autoptr(FlPluginRegistrar) sqlite3_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
-  sqlite3_flutter_libs_plugin_register_with_registrar(sqlite3_flutter_libs_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/demos/supabase-todolist-optional-sync/linux/flutter/generated_plugins.cmake
+++ b/demos/supabase-todolist-optional-sync/linux/flutter/generated_plugins.cmake
@@ -4,12 +4,11 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   gtk
-  powersync_flutter_libs
-  sqlite3_flutter_libs
   url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/demos/supabase-todolist-optional-sync/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/demos/supabase-todolist-optional-sync/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,15 +6,11 @@ import FlutterMacOS
 import Foundation
 
 import app_links
-import powersync_flutter_libs
 import shared_preferences_foundation
-import sqlite3_flutter_libs
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
-  PowersyncFlutterLibsPlugin.register(with: registry.registrar(forPlugin: "PowersyncFlutterLibsPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
-  Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/demos/supabase-todolist-optional-sync/pubspec.yaml
+++ b/demos/supabase-todolist-optional-sync/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   camera: ^0.12.0
   image: ^4.1.3
   universal_io: ^2.2.2
-  sqlite_async: ^0.14.0-wip
+  sqlite_async: ^0.14.0
 
 dev_dependencies:
   flutter_test:

--- a/demos/supabase-todolist-optional-sync/pubspec.yaml
+++ b/demos/supabase-todolist-optional-sync/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^2.0.0-wip.0
+  powersync: ^2.0.0
   sqlite3: ^3.2.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1

--- a/demos/supabase-todolist-optional-sync/windows/flutter/generated_plugin_registrant.cc
+++ b/demos/supabase-todolist-optional-sync/windows/flutter/generated_plugin_registrant.cc
@@ -7,17 +7,11 @@
 #include "generated_plugin_registrant.h"
 
 #include <app_links/app_links_plugin_c_api.h>
-#include <powersync_flutter_libs/powersync_flutter_libs_plugin.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AppLinksPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
-  PowersyncFlutterLibsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("PowersyncFlutterLibsPlugin"));
-  Sqlite3FlutterLibsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/demos/supabase-todolist-optional-sync/windows/flutter/generated_plugins.cmake
+++ b/demos/supabase-todolist-optional-sync/windows/flutter/generated_plugins.cmake
@@ -4,12 +4,11 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   app_links
-  powersync_flutter_libs
-  sqlite3_flutter_libs
   url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/demos/supabase-todolist/linux/flutter/generated_plugin_registrant.cc
+++ b/demos/supabase-todolist/linux/flutter/generated_plugin_registrant.cc
@@ -7,20 +7,12 @@
 #include "generated_plugin_registrant.h"
 
 #include <gtk/gtk_plugin.h>
-#include <powersync_flutter_libs/powersync_flutter_libs_plugin.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) gtk_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
   gtk_plugin_register_with_registrar(gtk_registrar);
-  g_autoptr(FlPluginRegistrar) powersync_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "PowersyncFlutterLibsPlugin");
-  powersync_flutter_libs_plugin_register_with_registrar(powersync_flutter_libs_registrar);
-  g_autoptr(FlPluginRegistrar) sqlite3_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
-  sqlite3_flutter_libs_plugin_register_with_registrar(sqlite3_flutter_libs_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/demos/supabase-todolist/linux/flutter/generated_plugins.cmake
+++ b/demos/supabase-todolist/linux/flutter/generated_plugins.cmake
@@ -4,12 +4,11 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   gtk
-  powersync_flutter_libs
-  sqlite3_flutter_libs
   url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/demos/supabase-todolist/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/demos/supabase-todolist/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,15 +6,11 @@ import FlutterMacOS
 import Foundation
 
 import app_links
-import powersync_flutter_libs
 import shared_preferences_foundation
-import sqlite3_flutter_libs
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
-  PowersyncFlutterLibsPlugin.register(with: registry.registrar(forPlugin: "PowersyncFlutterLibsPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
-  Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  powersync: ^2.0.0-wip.0
+  powersync: ^2.0.0
   path_provider: ^2.1.1
   supabase_flutter: ^2.0.1
   path: ^1.8.3

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   camera: ^0.12.0
   image: ^4.1.3
   universal_io: ^2.2.2
-  sqlite_async: ^0.14.0-wip
+  sqlite_async: ^0.14.0
   sqlite3: ^3.2.0
 
 dev_dependencies:

--- a/demos/supabase-todolist/windows/flutter/generated_plugin_registrant.cc
+++ b/demos/supabase-todolist/windows/flutter/generated_plugin_registrant.cc
@@ -7,17 +7,11 @@
 #include "generated_plugin_registrant.h"
 
 #include <app_links/app_links_plugin_c_api.h>
-#include <powersync_flutter_libs/powersync_flutter_libs_plugin.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AppLinksPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
-  PowersyncFlutterLibsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("PowersyncFlutterLibsPlugin"));
-  Sqlite3FlutterLibsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/demos/supabase-todolist/windows/flutter/generated_plugins.cmake
+++ b/demos/supabase-todolist/windows/flutter/generated_plugins.cmake
@@ -4,12 +4,11 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   app_links
-  powersync_flutter_libs
-  sqlite3_flutter_libs
   url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/demos/supabase-trello/linux/flutter/generated_plugin_registrant.cc
+++ b/demos/supabase-trello/linux/flutter/generated_plugin_registrant.cc
@@ -8,8 +8,6 @@
 
 #include <file_selector_linux/file_selector_plugin.h>
 #include <gtk/gtk_plugin.h>
-#include <powersync_flutter_libs/powersync_flutter_libs_plugin.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
@@ -19,12 +17,6 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) gtk_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
   gtk_plugin_register_with_registrar(gtk_registrar);
-  g_autoptr(FlPluginRegistrar) powersync_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "PowersyncFlutterLibsPlugin");
-  powersync_flutter_libs_plugin_register_with_registrar(powersync_flutter_libs_registrar);
-  g_autoptr(FlPluginRegistrar) sqlite3_flutter_libs_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "Sqlite3FlutterLibsPlugin");
-  sqlite3_flutter_libs_plugin_register_with_registrar(sqlite3_flutter_libs_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/demos/supabase-trello/linux/flutter/generated_plugins.cmake
+++ b/demos/supabase-trello/linux/flutter/generated_plugins.cmake
@@ -5,12 +5,11 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
   gtk
-  powersync_flutter_libs
-  sqlite3_flutter_libs
   url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/demos/supabase-trello/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/demos/supabase-trello/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,17 +8,13 @@ import Foundation
 import app_links
 import file_picker
 import file_selector_macos
-import powersync_flutter_libs
 import shared_preferences_foundation
-import sqlite3_flutter_libs
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
-  PowersyncFlutterLibsPlugin.register(with: registry.registrar(forPlugin: "PowersyncFlutterLibsPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
-  Sqlite3FlutterLibsPlugin.register(with: registry.registrar(forPlugin: "Sqlite3FlutterLibsPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/demos/supabase-trello/pubspec.yaml
+++ b/demos/supabase-trello/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   random_name_generator: ^1.5.0
   flutter_dotenv: ^6.0.0
   logging: ^1.3.0
-  powersync: ^2.0.0-wip.0
+  powersync: ^2.0.0
   sqlite_async: ^0.14.0-wip
   sqlite3: ^3.2.0
   path_provider: ^2.1.5

--- a/demos/supabase-trello/pubspec.yaml
+++ b/demos/supabase-trello/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   flutter_dotenv: ^6.0.0
   logging: ^1.3.0
   powersync: ^2.0.0
-  sqlite_async: ^0.14.0-wip
+  sqlite_async: ^0.14.0
   sqlite3: ^3.2.0
   path_provider: ^2.1.5
   supabase_flutter: ^2.8.3

--- a/demos/supabase-trello/windows/flutter/generated_plugin_registrant.cc
+++ b/demos/supabase-trello/windows/flutter/generated_plugin_registrant.cc
@@ -8,8 +8,6 @@
 
 #include <app_links/app_links_plugin_c_api.h>
 #include <file_selector_windows/file_selector_windows.h>
-#include <powersync_flutter_libs/powersync_flutter_libs_plugin.h>
-#include <sqlite3_flutter_libs/sqlite3_flutter_libs_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
@@ -17,10 +15,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
-  PowersyncFlutterLibsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("PowersyncFlutterLibsPlugin"));
-  Sqlite3FlutterLibsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("Sqlite3FlutterLibsPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/demos/supabase-trello/windows/flutter/generated_plugins.cmake
+++ b/demos/supabase-trello/windows/flutter/generated_plugins.cmake
@@ -5,12 +5,11 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   app_links
   file_selector_windows
-  powersync_flutter_libs
-  sqlite3_flutter_libs
   url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.0-wip.0
+## 2.0.0
 
 - Upgrade sqlite packages: Version 3.x of `sqlite3`, 0.6.x of `sqlite3_web`, 0.14.x of `sqlite_async`.
   - Remember to download updated db workers and `sqlite3.wasm` files after upgrading!

--- a/packages/powersync/lib/src/version.dart
+++ b/packages/powersync/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String libraryVersion = '2.0.0-wip.0';
+const String libraryVersion = '2.0.0';

--- a/packages/powersync/lib/src/web/worker_utils.dart
+++ b/packages/powersync/lib/src/web/worker_utils.dart
@@ -18,12 +18,6 @@ final class PowerSyncAsyncSqliteController extends AsyncSqliteController {
 
     return sqlite3.open(path, vfs: vfs);
   }
-
-  @override
-  Future<JSAny?> handleCustomRequest(
-      ClientConnection connection, JSAny? request) {
-    throw UnimplementedError();
-  }
 }
 
 @JS()

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 2.0.0-wip.0
+version: 2.0.0
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Dart and Flutter SDK. Sync Postgres, MongoDB, MySQL or SQL Server with SQLite in your app
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   sqlite_async: ^0.14.0-wip
-  sqlite3_web: ^0.6.0
+  sqlite3_web: ^0.7.0
   sqlite3: ^3.2.0
   meta: ^1.0.0
   http: ^1.5.0
@@ -47,6 +47,7 @@ dev_dependencies:
   bson: ^5.0.7
   test_descriptor: ^2.0.2
   mockito: ^5.5.0
+  yaml: ^3.1.3
 
 platforms:
   android:

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.6.0
 
 dependencies:
-  sqlite_async: ^0.14.0-wip
+  sqlite_async: ^0.14.0
   sqlite3_web: ^0.7.0
   sqlite3: ^3.2.0
   meta: ^1.0.0

--- a/packages/powersync/test/version_test.dart
+++ b/packages/powersync/test/version_test.dart
@@ -1,0 +1,19 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:powersync/src/version.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  test('libraryVersion matches pubspec version', () {
+    final pubspec = loadYamlDocument(File('pubspec.yaml').readAsStringSync());
+    final versionInPubspec = (pubspec.contents as YamlMap)['version'] as String;
+
+    expect(libraryVersion, versionInPubspec,
+        reason:
+            'Version in lib/src/version.dart ($libraryVersion) must match version in pubspec ($versionInPubspec)');
+  });
+}

--- a/packages/powersync_attachments_helper/CHANGELOG.md
+++ b/packages/powersync_attachments_helper/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.0-wip.0
+## 0.7.0
 
 - Support versions 2.x of the `powersync` package.
 

--- a/packages/powersync_attachments_helper/pubspec.yaml
+++ b/packages/powersync_attachments_helper/pubspec.yaml
@@ -1,6 +1,6 @@
 name: powersync_attachments_helper
 description: A helper library for handling attachments when using PowerSync.
-version: 0.7.0-wip.0
+version: 0.7.0
 repository: https://github.com/powersync-ja/powersync.dart
 homepage: https://www.powersync.com/
 resolution: workspace
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  powersync: ^2.0.0-wip.0
+  powersync: ^2.0.0
   logging: ^1.2.0
   path_provider: ^2.0.13
   sqlite3: ^3.2.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -405,10 +405,10 @@ packages:
     dependency: transitive
     description:
       name: drift_sqlite_async
-      sha256: c020e3bc75f964fe5c26b3360057b71cffd022caa7bdfa2c4601ef3fc215441e
+      sha256: "1b6e99562fc5d35fe5e3696741720a8aca47f4c3eee35d4b9b94be819f53a6f6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0-wip.0"
+    version: "0.3.0"
   fake_async:
     dependency: transitive
     description:
@@ -1385,10 +1385,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: b3fe250b4ebd681a8ba20b12794c42b00c1375e5b51005568f0b8731265beb03
+      sha256: "56da3e13ed7d28a66f930aa2b2b29db6736a233f08283326e96321dd812030f5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.3.1"
   sqlite3_connection_pool:
     dependency: transitive
     description:
@@ -1409,18 +1409,18 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_web
-      sha256: f6733fb0d40c7981e67f268bf71b525316501381aec26522a54a0a61eb7b82d7
+      sha256: "857e913bd27ec7d1d9eb517c87ea43d1d851f5ad4c7334b7a4f6114b9929584b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.7.0"
   sqlite_async:
     dependency: transitive
     description:
       name: sqlite_async
-      sha256: e4e8b6fbcef160ead6f4390af678d1718aaacd256420a8dcc9aad9116dcfcab1
+      sha256: "380323b249146b6af2d4247df8b71bc3278abcba1f909fd8637f7ba429db7194"
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.0-wip.0"
+    version: "0.14.0"
   sqlparser:
     dependency: transitive
     description:


### PR DESCRIPTION
This:

- Upgrades to the stable versions of `sqlite_async` and `drift_sqlite_async`.
- Re-generates CMake definitions in demos.
- Adds a test verifying that our `libraryVersion` constant always matches the version in `pubspec.yaml` (making it harder to forget that step when preparing a release).
- Prepares a stable release of `package:powersync` version 2.0.0 and `package:powersync_attachments_helper` version 0.7.0.