### PR TITLE
Don't copy worker file to itself

### DIFF
--- a/tool/compile_webworker.dart
+++ b/tool/compile_webworker.dart
@@ -32,13 +32,6 @@ Future<void> main() async {
         'Could not compile db worker.\nstdout: ${dbWorkerProcess.stdout.toString()}\nstderr: ${dbWorkerProcess.stderr.toString()}');
   }
 
-  final workerFile = File(dbWorkerOutputPath);
-
-  // Copy workers to powersync
-  final powersyncCoreAssetsPath =
-      path.join(repoRoot, 'packages/powersync/assets');
-  workerFile.copySync('$powersyncCoreAssetsPath/$workerFilename');
-
   // Copy this to all demo apps web folders
   final demosRoot = path.join(repoRoot, 'demos');
   final demoDirectories =


### PR DESCRIPTION
To compile the web worker, we run `dart compile js -o packages/powersync/assets/powersync_db.worker.js`. Afterwards, we used to copy the emitted JavaScript file to its own path. This is harmless on macOS, but causes the resulting `powersync_db.worker.js` file to be empty on Linux. That in turn caused [release automation failures](https://github.com/powersync-ja/powersync.dart/actions/runs/24385866742/job/71219494021), I had to manually upload the worker file for the last releases.

This PR should fix the release process and ensure we run tests with workers available.