### PR TITLE
Simplify control flow in sync client

### DIFF
--- a/.github/workflows/prepare_wasm.yml
+++ b/.github/workflows/prepare_wasm.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Homebrew
         if: steps.cache_build.outputs.cache-hit != 'true'
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
       - name: Install Dart SDK
         if: steps.cache_build.outputs.cache-hit != 'true'
         uses: dart-lang/setup-dart@v1

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.2
+
+- Update PowerSync SQLite core extension to version 0.4.13.
+- Fix changes in active Sync Stream subscriptions causing a reconnect delay.
+
 ## 2.0.1
 
 - Fix documentation not generating.

--- a/packages/powersync/lib/src/database/core_version.dart
+++ b/packages/powersync/lib/src/database/core_version.dart
@@ -63,7 +63,7 @@ extension type const PowerSyncCoreVersion((int, int, int) _tuple) {
   //
   //  - ../setup/native.dart
   //  - packages/sqlite3_wasm_build/build.sh
-  static const minimum = PowerSyncCoreVersion((0, 4, 11));
+  static const minimum = PowerSyncCoreVersion((0, 4, 13));
 
   /// The first version of the core extensions that this version of the Dart
   /// SDK doesn't support.

--- a/packages/powersync/lib/src/setup/native.dart
+++ b/packages/powersync/lib/src/setup/native.dart
@@ -1,42 +1,48 @@
 /// After updating this, run `dart tool/update_core_extension_hashes.dart` to
 /// update [assetNameToSha256Hash].
-const releaseVersion = 'v0.4.12';
+const releaseVersion = 'v0.4.13';
 
 const Map<String, String> assetNameToSha256Hash = {
   // start of generated hashes
   'libpowersync_aarch64.android.so':
-      '17c84a8cb79640e71ace5a82fcb84a168b364b4f2cf6ef57f09e132f3ae58011',
+      '8151b637facb6fd0db19ac3aa2eb4bceb215beba3217b39b9fe3d205b9e94f82',
   'libpowersync_aarch64.ios-sim.dylib':
-      'ce204bfccd3161b50c9bbd80db18a2bf0053e931e717f45e37ddbe7d80f9537b',
+      '79cd65d02b38fd60248eaa6b2f11c2e4b0b0ae49ac93dafb957aff26e48655a7',
   'libpowersync_aarch64.ios.dylib':
-      '0984d1db648154eab81422865a07ee25a01096f0c10cfc87c5d8765256879d91',
+      '0735f1eadeaa6b44a0979863248c8c31ff2ac7ebf3e37a91922ea4552aeda841',
   'libpowersync_aarch64.linux.so':
-      'acbf2a1b27f413d8a83e5efc91f0531c6989519203eaf2814c52942f1a445649',
+      '53a4250821a317705a864e3b4dc2e4cdaacc24ebc1cfe37bdf99148b024c9144',
   'libpowersync_aarch64.macos.dylib':
-      'cfbfa86a0b8203619059be4bf4cf3078f122866dcc4896b07f7b412a41628abe',
+      '861829b7a209d20620ab9e9742c65324ff720e345da5a8e24c2550ab92459943',
+  'libpowersync_aarch64.tvos-sim.dylib':
+      '21b3805d487896ebdde899ea358f80b4da7762462cd0acb15e8587a19047214b',
+  'libpowersync_aarch64.tvos.dylib':
+      '2c705e7d01b5c4e0fb89b3659b831adefacf6e83f5598ed66dfe059378499c0a',
   'libpowersync_armv7.android.so':
-      'b8a7ee7f440be9809d096577e06eb1567eb0baed9a19583f90285cf86927e2c4',
+      'caf23e1e15b5859fc2eb061e9cdf08b0b01684f496956bf188562476597fe938',
   'libpowersync_armv7.linux.so':
-      'e262fcf4c1509d96a692f159af572a09fad781d4cc3ba885d3de276926526432',
+      '0012a0926d4edae848d9175604f1c2fd7e038165a4a0adc4da4ba789b2cdb3a1',
   'libpowersync_riscv64gc.linux.so':
-      '46101c885b4ff23e4a7059a5eb9f3fc697762455e6d296815a8ccece8eeacd41',
+      'e43118524dc0954e40bf12cc0a5d97f89415ffe0ba2cfe55f28481e7dafe3cc6',
   'libpowersync_x64.android.so':
-      '156f7b6673901a3644fbf5c96facf5ee92141dca2fd2b6f05c6a2ed26b258e39',
+      'a54858b939f871013ca39ef1993b14f58648dcc11b9b16388812ccab450cea70',
   'libpowersync_x64.ios-sim.dylib':
-      '5573ec2894471760bb3389b02fa0a682b691babce5c8a23440bd3e4831ae3568',
+      '716b9916a0e014b19b5d6ce3f61914b2e666ebc46f7fa5c35f945bb14c0963c6',
   'libpowersync_x64.linux.so':
-      'c15d5a069200c823c95435bbad38a9dc12743deca42b30b0c40557b2bc32ac5d',
+      'b9885eb188ee827453bd94100b657cda76e23722610abf2e33170ca15d2c0de3',
   'libpowersync_x64.macos.dylib':
-      'e0b2402702bd744d65a2c8aba4d7242f5cefd67c33926d92567ee4e02b13e20d',
+      '074ab6886d919d8339bc30545bca9473a83ea6fb36f2b6bf1a948f2dfd9bc555',
+  'libpowersync_x64.tvos-sim.dylib':
+      '072422965be81440b4517fe5f6fc2d5d64c22aa19f8ee91ec6e522356a7e4777',
   'libpowersync_x86.android.so':
-      '0cf3f73c8a0027077bbb287f030cef10aeb16c053e582ab8df5906e557715a30',
+      'b7a264412aaecab86cfc42c29debea160bca334a409239e05b978540b20fd0d2',
   'libpowersync_x86.linux.so':
-      '89b8b7451a01e533a5736a7025d13f0bd0640c1df40025cf8a90d6d2e7e8b1ee',
+      'fa60a92cefb9961ba590aee01f0e42cd416e6486e3845083100b7d3308e30af0',
   'powersync_aarch64.dll':
-      '90fbce6a22bc7fcde0ee62ed52eec821afa86b1bacff4597ddc9cea2f7203cb1',
+      '2935366f4cd9ffd6624a56498c266029bd846390413e14935be14d02759c3e33',
   'powersync_x64.dll':
-      'efc095c2dff5194c1dbf4943012ae8bb5349e8aaac481d18cb0d3a49fa6a1255',
+      'ef568b6c43dff7fec9d400408c8a56bcb83b4ed20e131b6b992c9a057e64e5b5',
   'powersync_x86.dll':
-      '147ef50acdab8dc27075f29ae6f86dd26fb574f373e3a186492ca7d55d0b867c',
+      'e85fd1219a3bcbfde24dd22769da13403c43f736dee9640137332e34436d60b0',
   // end of generated hashes
 };

--- a/packages/powersync/lib/src/sync/instruction.dart
+++ b/packages/powersync/lib/src/sync/instruction.dart
@@ -23,7 +23,10 @@ sealed class Instruction {
   }
 }
 
-final class LogLine implements Instruction {
+/// An [Instruction] that doesn't start or stop a sync iteration.
+sealed class NonInterruptingInstruction implements Instruction {}
+
+final class LogLine implements NonInterruptingInstruction {
   final String severity;
   final String line;
 
@@ -47,7 +50,7 @@ final class EstablishSyncStream implements Instruction {
   }
 }
 
-final class UpdateSyncStatus implements Instruction {
+final class UpdateSyncStatus implements NonInterruptingInstruction {
   final CoreSyncStatus status;
 
   UpdateSyncStatus({required this.status});
@@ -132,7 +135,7 @@ final class DownloadProgress {
   }
 }
 
-final class FetchCredentials implements Instruction {
+final class FetchCredentials implements NonInterruptingInstruction {
   final bool didExpire;
 
   FetchCredentials(this.didExpire);
@@ -148,15 +151,15 @@ final class CloseSyncStream implements Instruction {
   const CloseSyncStream(this.hideDisconnect);
 }
 
-final class FlushFileSystem implements Instruction {
+final class FlushFileSystem implements NonInterruptingInstruction {
   const FlushFileSystem();
 }
 
-final class DidCompleteSync implements Instruction {
+final class DidCompleteSync implements NonInterruptingInstruction {
   const DidCompleteSync();
 }
 
-final class UnknownSyncInstruction implements Instruction {
+final class UnknownSyncInstruction implements NonInterruptingInstruction {
   final Map<String, Object?> source;
 
   UnknownSyncInstruction(this.source);

--- a/packages/powersync/lib/src/sync/mutable_sync_status.dart
+++ b/packages/powersync/lib/src/sync/mutable_sync_status.dart
@@ -21,17 +21,6 @@ final class MutableSyncStatus {
   Object? uploadError;
   Object? downloadError;
 
-  void setConnectingIfNotConnected() {
-    if (!connected) {
-      connecting = true;
-    }
-  }
-
-  void setConnected() {
-    connected = true;
-    connecting = false;
-  }
-
   void applyDownloadError(Object error) {
     connected = false;
     connecting = false;

--- a/packages/powersync/lib/src/sync/streaming_sync.dart
+++ b/packages/powersync/lib/src/sync/streaming_sync.dart
@@ -141,27 +141,21 @@ class StreamingSyncImplementation implements StreamingSync {
 
   @override
   Future<void> streamingSync() async {
+    assert(_abort == null);
+    final abort = _abort = AbortController();
+
     try {
-      assert(_abort == null);
-      _abort = AbortController();
       clientId = await adapter.getClientId();
       _crudLoop();
-      var invalidCredentials = false;
       while (!aborted) {
-        _state.updateStatus((s) => s.setConnectingIfNotConnected());
         var delayNextIteration = false;
 
         try {
-          if (invalidCredentials) {
-            // This may error. In that case it will be retried again on the next
-            // iteration.
-            await connector.prefetchCredentials();
-            invalidCredentials = false;
-          }
           // Protect sync iterations with exclusivity (if a valid Mutex is provided)
           final (:immediateRestart) = await syncMutex.lock(
-              () => _rustStreamingSyncIteration(),
-              abortTrigger: Future.delayed(_retryDelay));
+            () => _rustStreamingSyncIteration(abort),
+            abortTrigger: Future.delayed(_retryDelay),
+          );
           delayNextIteration = !immediateRestart;
         } catch (e, stacktrace) {
           if (aborted && e is http.ClientException) {
@@ -172,7 +166,6 @@ class StreamingSyncImplementation implements StreamingSync {
           delayNextIteration = true;
           final message = _syncErrorMessage(e);
           logger.warning('Sync error: $message', e, stacktrace);
-          invalidCredentials = true;
 
           _state.updateStatus((s) => s.applyDownloadError(e));
         }
@@ -184,7 +177,7 @@ class StreamingSyncImplementation implements StreamingSync {
         }
       }
     } finally {
-      _abort!.completeAbort();
+      abort.completeAbort();
     }
   }
 
@@ -286,7 +279,7 @@ class StreamingSyncImplementation implements StreamingSync {
 
     final response = await _client.get(uri, headers: headers);
     if (response.statusCode == 401) {
-      await connector.prefetchCredentials();
+      await connector.prefetchCredentials(invalidate: true);
     }
     if (response.statusCode != 200) {
       throw SyncResponseException.fromResponse(response);
@@ -296,16 +289,17 @@ class StreamingSyncImplementation implements StreamingSync {
     return body['data']['write_checkpoint'] as String;
   }
 
-  Future<RustSyncIterationResult> _rustStreamingSyncIteration() async {
+  Future<RustSyncIterationResult> _rustStreamingSyncIteration(
+      AbortController abortController) async {
     logger.info('Starting Rust sync iteration');
-    final response = await _ActiveRustStreamingIteration(this).syncIteration();
+    final response = await _ActiveRustStreamingIteration(this, abortController)
+        .syncIteration();
     logger.info(
         'Ending Rust sync iteration. Immediate restart: ${response.immediateRestart}');
     return response;
   }
 
-  Future<http.StreamedResponse?> _postStreamRequest(
-      Object? data, bool acceptBson,
+  Future<http.StreamedResponse?> _postStreamRequest(Object? data,
       {Future<void>? onAbort}) async {
     const ndJson = 'application/x-ndjson';
     const bson = 'application/vnd.powersync.bson-stream';
@@ -320,8 +314,7 @@ class StreamingSyncImplementation implements StreamingSync {
         abortTrigger: onAbort ?? _abort!.onAbort);
     request.headers['Content-Type'] = 'application/json';
     request.headers['Authorization'] = "Token ${credentials.token}";
-    request.headers['Accept'] =
-        acceptBson ? '$bson;q=0.9,$ndJson;q=0.8' : ndJson;
+    request.headers['Accept'] = '$bson;q=0.9,$ndJson;q=0.8';
     request.headers.addAll(_userAgentHeaders);
 
     request.body = convert.jsonEncode(data);
@@ -379,14 +372,12 @@ typedef BucketDescription = ({
 
 final class _ActiveRustStreamingIteration {
   final StreamingSyncImplementation sync;
+  final AbortController _abortController;
 
-  var _isActive = true;
   var _hadSyncLine = false;
-
   StreamSubscription<void>? _completedUploads;
-  final Completer<RustSyncIterationResult> _completedStream = Completer();
 
-  _ActiveRustStreamingIteration(this.sync);
+  _ActiveRustStreamingIteration(this.sync, this._abortController);
 
   List<Object?> _encodeSubscriptions(List<SubscribedStream> subscriptions) {
     return sync._activeSubscriptions
@@ -396,30 +387,48 @@ final class _ActiveRustStreamingIteration {
   }
 
   Future<RustSyncIterationResult> syncIteration() async {
+    const defaultResult = (immediateRestart: false);
+    Stream<SyncEvent>? events;
+
+    for (final startInstruction in await _startCommand()) {
+      switch (startInstruction) {
+        case EstablishSyncStream(:final request):
+          events = addBroadcast(
+            _receiveLines(request),
+            sync._nonLineSyncEvents.stream,
+          );
+        case CloseSyncStream():
+          return defaultResult;
+        case final NonInterruptingInstruction other:
+          await _handleInstruction(other);
+      }
+    }
+    if (events == null) return defaultResult;
+
     try {
-      await _control(
-        'start',
-        convert.json.encode({
-          'app_metadata': sync.options.appMetadata,
-          'parameters': sync.options.params,
-          'schema': convert.json.decode(sync.schemaJson),
-          'include_defaults': sync.options.includeDefaultStreams,
-          'active_streams': _encodeSubscriptions(sync._activeSubscriptions),
-        }),
-      );
-      assert(_completedStream.isCompleted, 'Should have started streaming');
-      return await _completedStream.future;
+      return await _handleLines(events);
     } finally {
-      _isActive = false;
-      _completedUploads?.cancel();
       await _stop();
+      await _completedUploads?.cancel();
     }
   }
 
-  Stream<SyncEvent> _receiveLines(Object? data,
-      {required Future<void> onAbort}) {
+  Future<Iterable<Instruction>> _startCommand() async {
+    return await _invokePowerSyncControl(
+      'start',
+      convert.json.encode({
+        'app_metadata': sync.options.appMetadata,
+        'parameters': sync.options.params,
+        'schema': convert.json.decode(sync.schemaJson),
+        'include_defaults': sync.options.includeDefaultStreams,
+        'active_streams': _encodeSubscriptions(sync._activeSubscriptions),
+      }),
+    );
+  }
+
+  Stream<SyncEvent> _receiveLines(Object? data) {
     return streamFromFutureAwaitInCancellation(
-            sync._postStreamRequest(data, true, onAbort: onAbort))
+            sync._postStreamRequest(data, onAbort: _abortController.onAbort))
         .asyncExpand<SyncEvent>((response) async* {
       if (response == null) {
         return;
@@ -436,67 +445,58 @@ final class _ActiveRustStreamingIteration {
     });
   }
 
-  Future<RustSyncIterationResult> _handleLines(
-      EstablishSyncStream request) async {
-    // This is a workaround for https://github.com/dart-lang/http/issues/1820:
-    // When cancelling the stream subscription of an HTTP response with the
-    // fetch-based client implementation, cancelling the subscription is delayed
-    // until the next chunk (typically a token_expires_in message in our case).
-    // So, before cancelling, we complete an abort controller for the request to
-    // speed things up. This is not an issue in most cases because the abort
-    // controller on this stream would be completed when disconnecting. But
-    // when switching sync streams, that's not the case and we need a second
-    // abort controller for the inner iteration.
-    final innerAbort = Completer<void>.sync();
-    final events = addBroadcast(
-      _receiveLines(
-        request.request,
-        onAbort: Future.any([
-          sync._abort!.onAbort,
-          innerAbort.future,
-        ]),
-      ),
-      sync._nonLineSyncEvents.stream,
-    );
-
+  Future<RustSyncIterationResult> _handleLines(Stream<SyncEvent> events) async {
     var needsImmediateRestart = false;
-    loop:
     try {
+      loop:
       await for (final event in events) {
-        if (!_isActive || sync.aborted) {
-          innerAbort.complete();
+        if (sync.aborted) {
           break;
         }
-
+        final Iterable<Instruction> instructions;
         switch (event) {
           case ConnectionEvent():
-            await _control('connection', event.name);
+            instructions = await _invokePowerSyncControl(
+              'connection',
+              event.name,
+            );
           case ReceivedLine(line: final Uint8List line):
             _triggerCrudUploadOnFirstLine();
-            await _control('line_binary', line);
+            instructions = await _invokePowerSyncControl('line_binary', line);
           case ReceivedLine(line: final line as String):
             _triggerCrudUploadOnFirstLine();
-            await _control('line_text', line);
+            instructions = await _invokePowerSyncControl('line_text', line);
           case UploadCompleted():
-            await _control('completed_upload');
-          case AbortCurrentIteration(:final hideDisconnectState):
-            innerAbort.complete();
-            needsImmediateRestart = hideDisconnectState;
-            break loop;
+            instructions = await _invokePowerSyncControl('completed_upload');
           case TokenRefreshComplete():
-            await _control('refreshed_token');
+            instructions = await _invokePowerSyncControl('refreshed_token');
           case HandleChangedSubscriptions(:final currentSubscriptions):
-            await _control(
-                'update_subscriptions',
-                convert.json
-                    .encode(_encodeSubscriptions(currentSubscriptions)));
+            instructions = await _invokePowerSyncControl(
+              'update_subscriptions',
+              convert.json.encode(_encodeSubscriptions(currentSubscriptions)),
+            );
+        }
+
+        for (final instruction in instructions) {
+          switch (instruction) {
+            case EstablishSyncStream():
+              sync.logger.warning(
+                'Received EstablishSyncStream connection while already '
+                'connected.',
+              );
+            case CloseSyncStream(:final hideDisconnect):
+              needsImmediateRestart = hideDisconnect;
+              break loop;
+            case final NonInterruptingInstruction other:
+              await _handleInstruction(other);
+          }
         }
       }
     } on http.RequestAbortedException {
       // Unlike a regular cancellation, cancelling via the abort controller
       // emits an error. We did mean to just cancel the stream, so we can
       // safely ignore that.
-      if (innerAbort.isCompleted) {
+      if (sync.aborted) {
         // ignore
       } else {
         rethrow;
@@ -517,21 +517,27 @@ final class _ActiveRustStreamingIteration {
     }
   }
 
-  Future<void> _stop() {
-    return _control('stop');
-  }
-
-  Future<void> _control(String operation, [Object? payload]) async {
-    final rawResponse = await sync.adapter.control(operation, payload);
-    final instructions = convert.json.decode(rawResponse) as List;
-
+  Future<void> _stop() async {
+    final instructions = await _invokePowerSyncControl('stop');
     for (final instruction in instructions) {
-      await _handleInstruction(
-          Instruction.fromJson(instruction as Map<String, Object?>));
+      // We don't need to handle interrupting instructions since we're
+      // unconditionally ending the sync iteration at this point.
+      if (instruction is NonInterruptingInstruction) {
+        await _handleInstruction(instruction);
+      }
     }
   }
 
-  Future<void> _handleInstruction(Instruction instruction) async {
+  Future<Iterable<Instruction>> _invokePowerSyncControl(String operation,
+      [Object? payload]) async {
+    final rawResponse = await sync.adapter.control(operation, payload);
+    final instructions = convert.json.decode(rawResponse) as List;
+
+    return instructions.cast<Map<String, Object?>>().map(Instruction.fromJson);
+  }
+
+  Future<void> _handleInstruction(
+      NonInterruptingInstruction instruction) async {
     switch (instruction) {
       case LogLine(:final severity, :final line):
         sync.logger.log(
@@ -541,8 +547,6 @@ final class _ActiveRustStreamingIteration {
               _ => Level.WARNING,
             },
             line);
-      case EstablishSyncStream():
-        _completedStream.complete(_handleLines(instruction));
       case UpdateSyncStatus(:final status):
         sync._state.updateStatus((m) => m.applyFromCore(status));
       case FetchCredentials(:final didExpire):
@@ -550,18 +554,12 @@ final class _ActiveRustStreamingIteration {
           await sync.connector.prefetchCredentials(invalidate: true);
         } else {
           sync.connector.prefetchCredentials().then((_) {
-            if (_isActive && !sync.aborted) {
+            if (!sync.aborted) {
               sync._nonLineSyncEvents.add(const TokenRefreshComplete());
             }
           }, onError: (Object e, StackTrace s) {
             sync.logger.warning('Could not prefetch credentials', e, s);
           });
-        }
-      case CloseSyncStream(:final hideDisconnect):
-        if (!sync.aborted) {
-          _isActive = false;
-          sync._nonLineSyncEvents
-              .add(AbortCurrentIteration(hideDisconnectState: hideDisconnect));
         }
       case FlushFileSystem():
         await sync.adapter.flushFileSystem();
@@ -594,17 +592,6 @@ final class UploadCompleted implements SyncEvent {
 
 final class TokenRefreshComplete implements SyncEvent {
   const TokenRefreshComplete();
-}
-
-final class AbortCurrentIteration implements SyncEvent {
-  /// Whether we should immediately disconnect and hide the `disconnected`
-  /// state.
-  ///
-  /// This is used when we're changing subscription, to hide the brief downtime
-  /// we have while reconnecting.
-  final bool hideDisconnectState;
-
-  const AbortCurrentIteration({this.hideDisconnectState = false});
 }
 
 final class HandleChangedSubscriptions implements SyncEvent {

--- a/packages/powersync/lib/src/sync/streaming_sync.dart
+++ b/packages/powersync/lib/src/sync/streaming_sync.dart
@@ -408,8 +408,8 @@ final class _ActiveRustStreamingIteration {
     try {
       return await _handleLines(events);
     } finally {
-      await _stop();
       await _completedUploads?.cancel();
+      await _stop();
     }
   }
 

--- a/packages/powersync/lib/src/version.dart
+++ b/packages/powersync/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String libraryVersion = '2.0.1';
+const String libraryVersion = '2.0.2';

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 2.0.1
+version: 2.0.2
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Dart and Flutter SDK. Sync Postgres, MongoDB, MySQL or SQL Server with SQLite in your app
@@ -12,7 +12,7 @@ dependencies:
   sqlite3_web: ^0.7.0
   sqlite3: ^3.2.0
   meta: ^1.0.0
-  http: ^1.5.0
+  http: ^1.6.0
   uuid: ^4.2.0
   async: ^2.10.0
   logging: ^1.1.1

--- a/packages/powersync/test/sync/stream_test.dart
+++ b/packages/powersync/test/sync/stream_test.dart
@@ -44,12 +44,17 @@ void main() {
   }
 
   setUp(() async {
-    options = SyncOptions(syncImplementation: SyncClientImplementation.rust);
+    options = SyncOptions(
+      syncImplementation: SyncClientImplementation.rust,
+      // None of the tests in here should await this, so setting this to a long
+      // delay helps catch issues.
+      retryDelay: const Duration(minutes: 1),
+    );
     logger = Logger.detached('powersync.active')..level = Level.ALL;
     credentialsCallbackCount = 0;
     syncService = MockSyncService();
 
-    (_, database) = await testUtils.openInMemoryDatabase();
+    (_, database) = await testUtils.openInMemoryDatabase(logger: logger);
     await database.initialize();
   });
 
@@ -154,6 +159,10 @@ void main() {
 
     syncService.addLine(checkpointComplete());
     await a.waitForFirstSync();
+
+    await database.disconnect();
+    a.unsubscribe();
+    b.unsubscribe();
   });
 
   test('reports default streams', () async {
@@ -181,12 +190,24 @@ void main() {
   });
 
   test('changes subscriptions dynamically', () async {
+    final logLines = <String>[];
+    logger.onRecord.listen((l) => logLines.add(l.message));
+
     await waitForConnection();
     syncService.addKeepAlive();
 
+    // Adding a subscription should stop the HTTP response.
+    final didStop = Completer<void>();
+    syncService.controller.onCancel = () {
+      didStop.complete();
+    };
     final subscription = await database.syncStream('a').subscribe();
+
+    await didStop.future;
     syncService.endCurrentListener();
     final request = await syncService.waitForListener;
+    expect(logLines,
+        contains('Ending Rust sync iteration. Immediate restart: true'));
     expect(
       json.decode(await request.readAsString()),
       containsPair(

--- a/packages/sqlite3_wasm_build/build.sh
+++ b/packages/sqlite3_wasm_build/build.sh
@@ -2,7 +2,7 @@
 set -e
 
 SQLITE_VERSION="3.2.0"
-POWERSYNC_CORE_VERSION="0.4.12"
+POWERSYNC_CORE_VERSION="0.4.13"
 SQLITE_PATH="sqlite3.dart"
 
 if [ -d "$SQLITE_PATH" ]; then


### PR DESCRIPTION
This closes https://github.com/powersync-ja/powersync.dart/issues/409. Previously, there was a potential race condition when adding new sync streams because we:

1. First added a `AbortCurrentIteration` local sync event.
2. Which is then handled asynchronously to break out of the client loop once handled, but it's possible for additional server-side events to come in before we get to that.

Instead of handling close events asynchronously, this refactors the control flow of the sync client, allowing us to just break out of a loop when the core extension tells us to instead of having to go through these hoops. We do this by making all instructions that won't interrupt a sync iteration extend a common class, so we can safely express which instructions we can handle in a separate methods and which ones need to be part of the loop.

This also updates the core extension and removes a workaround for a `package:http` bug related to cancelling streams on the web.