### PR TITLE
Release mutex per attachment, persist incrementally, allow stopSync to interrupt mid-batch

### DIFF
--- a/packages/powersync/lib/src/attachments/attachment_queue_service.dart
+++ b/packages/powersync/lib/src/attachments/attachment_queue_service.dart
@@ -185,9 +185,6 @@ base class AttachmentQueue {
 
         previouslyConnected = status.connected;
       });
-      _watchAttachments().listen((items) async {
-        await _processWatchedAttachments(items);
-      });
 
       _logger.info('AttachmentQueue started syncing.');
     });

--- a/packages/powersync/lib/src/attachments/sync/syncing_service.dart
+++ b/packages/powersync/lib/src/attachments/sync/syncing_service.dart
@@ -65,12 +65,21 @@ final class SyncingService {
         StreamGroup.merge<void>([attachmentChanges, manualTriggers])
             .takeWhile((_) => sub == _syncSubscription)
             .asyncMap((_) async {
-      await attachmentsService.withContext((context) async {
-        final attachments = await context.getActiveAttachments();
-        logger.info('Found ${attachments.length} active attachments');
-        await handleSync(attachments, context);
-        await deleteArchivedAttachments(context);
-      });
+      // Read the active set inside the mutex; release it before doing any
+      // per-attachment I/O so that concurrent `saveFile`/`deleteFile` and
+      // `_processWatchedAttachments` calls aren't blocked for the duration
+      // of the whole batch.
+      final attachments = await attachmentsService.withContext(
+        (context) => context.getActiveAttachments(),
+      );
+      logger.info('Found ${attachments.length} active attachments');
+
+      await handleSync(
+        attachments,
+        isActive: () => sub == _syncSubscription,
+      );
+
+      await attachmentsService.withContext(deleteArchivedAttachments);
     });
 
     _syncSubscription = sub = syncStream.listen(null);
@@ -110,51 +119,72 @@ final class SyncingService {
     await _syncTriggerController.close();
   }
 
-  /// Handles syncing operations for a list of attachments, including downloading,
-  /// uploading, and deleting files based on their states.
+  /// Handles syncing operations for a list of attachments, including
+  /// downloading, uploading, and deleting files based on their states.
+  ///
+  /// Each attachment's I/O runs outside the attachment-service mutex, and the
+  /// row's state transition is persisted immediately after it completes. This
+  /// keeps the mutex available to concurrent `saveFile` / `deleteFile` /
+  /// watched-attachment processing while a batch is in flight, and means
+  /// consumer queries against the attachments queue see incremental progress
+  /// instead of one atomic commit at the end of the batch.
   ///
   /// [attachments]: The list of attachments to process.
-  /// [context]: The attachment context used for managing attachment states.
+  /// [isActive]: Polled between attachments; when it returns `false` the loop
+  /// exits early. Used by `stopSync` to interrupt a running batch within one
+  /// attachment's processing time.
   Future<void> handleSync(
-    List<Attachment> attachments,
-    AttachmentContext context,
-  ) async {
+    List<Attachment> attachments, {
+    bool Function()? isActive,
+  }) async {
     logger.info('Starting handleSync with ${attachments.length} attachments');
-    final updatedAttachments = <Attachment>[];
 
     for (final attachment in attachments) {
+      if (isActive != null && !isActive()) {
+        logger.info('Sync cancelled; stopping iteration early');
+        return;
+      }
+
       logger.info(
         'Processing attachment ${attachment.id} with state: ${attachment.state}',
       );
+
+      Attachment? updated;
       try {
         switch (attachment.state) {
           case AttachmentState.queuedDownload:
             logger.info('Downloading [${attachment.filename}]');
-            updatedAttachments.add(await downloadAttachment(attachment));
+            updated = await downloadAttachment(attachment);
             break;
           case AttachmentState.queuedUpload:
             logger.info('Uploading [${attachment.filename}]');
-            updatedAttachments.add(await uploadAttachment(attachment));
+            updated = await uploadAttachment(attachment);
             break;
           case AttachmentState.queuedDelete:
             logger.info('Deleting [${attachment.filename}]');
-            updatedAttachments.add(await deleteAttachment(attachment, context));
+            // `deleteAttachment` needs a context (it removes the row in a
+            // transaction); briefly re-acquire the mutex for just this row.
+            updated = await attachmentsService.withContext(
+              (context) => deleteAttachment(attachment, context),
+            );
             break;
           case AttachmentState.synced:
             logger.info('Attachment ${attachment.id} is already synced');
-            break;
+            continue;
           case AttachmentState.archived:
             logger.info('Attachment ${attachment.id} is archived');
-            break;
+            continue;
         }
       } catch (e, st) {
         logger.warning('Error during sync for ${attachment.id}', e, st);
+        continue;
       }
-    }
 
-    if (updatedAttachments.isNotEmpty) {
-      logger.info('Saving ${updatedAttachments.length} updated attachments');
-      await context.saveAttachments(updatedAttachments);
+      if (updated != null) {
+        await attachmentsService.withContext(
+          (context) => context.saveAttachments([updated!]),
+        );
+      }
     }
   }
 

--- a/packages/powersync/lib/src/attachments/sync/syncing_service.dart
+++ b/packages/powersync/lib/src/attachments/sync/syncing_service.dart
@@ -149,17 +149,15 @@ final class SyncingService {
         'Processing attachment ${attachment.id} with state: ${attachment.state}',
       );
 
-      Attachment? updated;
       try {
+        final Attachment updated;
         switch (attachment.state) {
           case AttachmentState.queuedDownload:
             logger.info('Downloading [${attachment.filename}]');
             updated = await downloadAttachment(attachment);
-            break;
           case AttachmentState.queuedUpload:
             logger.info('Uploading [${attachment.filename}]');
             updated = await uploadAttachment(attachment);
-            break;
           case AttachmentState.queuedDelete:
             logger.info('Deleting [${attachment.filename}]');
             // `deleteAttachment` needs a context (it removes the row in a
@@ -167,7 +165,6 @@ final class SyncingService {
             updated = await attachmentsService.withContext(
               (context) => deleteAttachment(attachment, context),
             );
-            break;
           case AttachmentState.synced:
             logger.info('Attachment ${attachment.id} is already synced');
             continue;
@@ -175,15 +172,12 @@ final class SyncingService {
             logger.info('Attachment ${attachment.id} is archived');
             continue;
         }
+
+        await attachmentsService.withContext(
+          (context) => context.saveAttachments([updated]),
+        );
       } catch (e, st) {
         logger.warning('Error during sync for ${attachment.id}', e, st);
-        continue;
-      }
-
-      if (updated != null) {
-        await attachmentsService.withContext(
-          (context) => context.saveAttachments([updated!]),
-        );
       }
     }
   }

--- a/packages/powersync/test/attachments/attachment_test.dart
+++ b/packages/powersync/test/attachments/attachment_test.dart
@@ -334,10 +334,14 @@ void main() {
       watchAttachments: watchAttachments,
       localStorage: localStorage,
       archivedCacheLimit: 0,
-      // Short throttle so the watch fires promptly after seeding rows;
-      // default is 1 s which would make the timing thresholds below
-      // unreliable.
       syncThrottleDuration: const Duration(milliseconds: 10),
+    );
+
+    final queuedDownloadCounts = StreamQueue(
+      db.watchUnthrottled(
+        'SELECT COUNT(*) AS c FROM attachments_queue WHERE state = ?',
+        parameters: [AttachmentState.queuedDownload.index],
+      ).map((rs) => rs[0]['c'] as int),
     );
 
     await queue.startSync();
@@ -351,16 +355,15 @@ void main() {
       }
     });
 
-    // Wait for the batch to be in flight (at least one download started).
-    await Future<void>.delayed(const Duration(milliseconds: 250));
+    await expectLater(queuedDownloadCounts, emitsThrough(greaterThan(0)));
 
     final sw = Stopwatch()..start();
     await queue.stopSyncing();
     sw.stop();
 
-    // Before the fix this awaited the full batch (~5 s). Bound generously
-    // for CI noise; the fix returns within one attachment's processing time.
     expect(sw.elapsed, lessThan(const Duration(seconds: 1)));
+
+    await queuedDownloadCounts.cancel();
   });
 
   test('attachments_queue commits per-attachment, not at end of batch',
@@ -372,10 +375,14 @@ void main() {
       watchAttachments: watchAttachments,
       localStorage: localStorage,
       archivedCacheLimit: 0,
-      // Short throttle so the watch fires promptly after seeding rows;
-      // default is 1 s which would make the timing thresholds below
-      // unreliable.
       syncThrottleDuration: const Duration(milliseconds: 10),
+    );
+
+    final syncedCounts = StreamQueue(
+      db.watchUnthrottled(
+        'SELECT COUNT(*) AS c FROM attachments_queue WHERE state = ?',
+        parameters: [AttachmentState.synced.index],
+      ).map((rs) => rs[0]['c'] as int),
     );
 
     await queue.startSync();
@@ -389,17 +396,12 @@ void main() {
       }
     });
 
-    // Sample partway through the batch: expect a partial count, neither 0
-    // (legacy behaviour: atomic end-of-batch commit) nor 20 (batch already
-    // finished, threshold too loose).
-    await Future<void>.delayed(const Duration(milliseconds: 700));
-    final midBatchRow = await db.get(
-      'SELECT COUNT(*) AS c FROM attachments_queue WHERE state = ?',
-      [AttachmentState.synced.index],
+    await expectLater(
+      syncedCounts,
+      emitsThrough(allOf(greaterThan(0), lessThan(20))),
     );
-    final midBatchCount = midBatchRow['c'] as int;
-    expect(midBatchCount, greaterThan(0));
-    expect(midBatchCount, lessThan(20));
+
+    await syncedCounts.cancel();
   });
 
   test('saveFile is not blocked by an in-flight sync batch', () async {
@@ -410,10 +412,14 @@ void main() {
       watchAttachments: watchAttachments,
       localStorage: localStorage,
       archivedCacheLimit: 0,
-      // Short throttle so the watch fires promptly after seeding rows;
-      // default is 1 s which would make the timing thresholds below
-      // unreliable.
       syncThrottleDuration: const Duration(milliseconds: 10),
+    );
+
+    final queuedDownloadCounts = StreamQueue(
+      db.watchUnthrottled(
+        'SELECT COUNT(*) AS c FROM attachments_queue WHERE state = ?',
+        parameters: [AttachmentState.queuedDownload.index],
+      ).map((rs) => rs[0]['c'] as int),
     );
 
     await queue.startSync();
@@ -427,8 +433,7 @@ void main() {
       }
     });
 
-    // Wait for the batch to be in flight.
-    await Future<void>.delayed(const Duration(milliseconds: 250));
+    await expectLater(queuedDownloadCounts, emitsThrough(greaterThan(0)));
 
     final sw = Stopwatch()..start();
     await queue.saveFile(
@@ -444,9 +449,9 @@ void main() {
     );
     sw.stop();
 
-    // Before the fix this awaited the full batch (mutex held across all
-    // downloads). The fix releases the mutex between attachments.
     expect(sw.elapsed, lessThan(const Duration(seconds: 1)));
+
+    await queuedDownloadCounts.cancel();
   });
 }
 

--- a/packages/powersync/test/attachments/attachment_test.dart
+++ b/packages/powersync/test/attachments/attachment_test.dart
@@ -325,6 +325,129 @@ void main() {
           .having((e) => e.state, 'state', AttachmentState.archived)
     ]);
   });
+
+  test('stopSyncing interrupts an in-flight batch', () async {
+    _stubSlowRemoteStorage(remoteStorage, const Duration(milliseconds: 100));
+    queue = AttachmentQueue(
+      db: db,
+      remoteStorage: remoteStorage,
+      watchAttachments: watchAttachments,
+      localStorage: localStorage,
+      archivedCacheLimit: 0,
+      // Short throttle so the watch fires promptly after seeding rows;
+      // default is 1 s which would make the timing thresholds below
+      // unreliable.
+      syncThrottleDuration: const Duration(milliseconds: 10),
+    );
+
+    await queue.startSync();
+
+    await db.writeTransaction((tx) async {
+      for (var i = 0; i < 50; i++) {
+        await tx.execute(
+          'INSERT INTO users (id, name, email, photo_id) VALUES (uuid(), ?, ?, ?)',
+          ['user-$i', 'user$i@example.com', 'photo-$i'],
+        );
+      }
+    });
+
+    // Wait for the batch to be in flight (at least one download started).
+    await Future<void>.delayed(const Duration(milliseconds: 250));
+
+    final sw = Stopwatch()..start();
+    await queue.stopSyncing();
+    sw.stop();
+
+    // Before the fix this awaited the full batch (~5 s). Bound generously
+    // for CI noise; the fix returns within one attachment's processing time.
+    expect(sw.elapsed, lessThan(const Duration(seconds: 1)));
+  });
+
+  test('attachments_queue commits per-attachment, not at end of batch',
+      () async {
+    _stubSlowRemoteStorage(remoteStorage, const Duration(milliseconds: 100));
+    queue = AttachmentQueue(
+      db: db,
+      remoteStorage: remoteStorage,
+      watchAttachments: watchAttachments,
+      localStorage: localStorage,
+      archivedCacheLimit: 0,
+      // Short throttle so the watch fires promptly after seeding rows;
+      // default is 1 s which would make the timing thresholds below
+      // unreliable.
+      syncThrottleDuration: const Duration(milliseconds: 10),
+    );
+
+    await queue.startSync();
+
+    await db.writeTransaction((tx) async {
+      for (var i = 0; i < 20; i++) {
+        await tx.execute(
+          'INSERT INTO users (id, name, email, photo_id) VALUES (uuid(), ?, ?, ?)',
+          ['user-$i', 'user$i@example.com', 'photo-$i'],
+        );
+      }
+    });
+
+    // Sample partway through the batch: expect a partial count, neither 0
+    // (legacy behaviour: atomic end-of-batch commit) nor 20 (batch already
+    // finished, threshold too loose).
+    await Future<void>.delayed(const Duration(milliseconds: 700));
+    final midBatchRow = await db.get(
+      'SELECT COUNT(*) AS c FROM attachments_queue WHERE state = ?',
+      [AttachmentState.synced.index],
+    );
+    final midBatchCount = midBatchRow['c'] as int;
+    expect(midBatchCount, greaterThan(0));
+    expect(midBatchCount, lessThan(20));
+  });
+
+  test('saveFile is not blocked by an in-flight sync batch', () async {
+    _stubSlowRemoteStorage(remoteStorage, const Duration(milliseconds: 100));
+    queue = AttachmentQueue(
+      db: db,
+      remoteStorage: remoteStorage,
+      watchAttachments: watchAttachments,
+      localStorage: localStorage,
+      archivedCacheLimit: 0,
+      // Short throttle so the watch fires promptly after seeding rows;
+      // default is 1 s which would make the timing thresholds below
+      // unreliable.
+      syncThrottleDuration: const Duration(milliseconds: 10),
+    );
+
+    await queue.startSync();
+
+    await db.writeTransaction((tx) async {
+      for (var i = 0; i < 50; i++) {
+        await tx.execute(
+          'INSERT INTO users (id, name, email, photo_id) VALUES (uuid(), ?, ?, ?)',
+          ['user-$i', 'user$i@example.com', 'photo-$i'],
+        );
+      }
+    });
+
+    // Wait for the batch to be in flight.
+    await Future<void>.delayed(const Duration(milliseconds: 250));
+
+    final sw = Stopwatch()..start();
+    await queue.saveFile(
+      data: Stream.value(Uint8List(8)),
+      mediaType: 'image/jpg',
+      fileExtension: 'jpg',
+      updateHook: (tx, attachment) async {
+        await tx.execute(
+          'INSERT INTO users (id, name, email, photo_id) VALUES (uuid(), ?, ?, ?)',
+          ['savefile-user', 'savefile@example.com', attachment.id],
+        );
+      },
+    );
+    sw.stop();
+
+    // Before the fix this awaited the full batch (mutex held across all
+    // downloads). The fix releases the mutex between attachments.
+    expect(sw.elapsed, lessThan(const Duration(seconds: 1)));
+  });
 }
 
 extension on PowerSyncDatabase {
@@ -370,4 +493,20 @@ final _schema = Schema([
 
 TypeMatcher<Attachment> isAttachment(String id) {
   return isA<Attachment>().having((e) => e.id, 'id', id);
+}
+
+/// Configures [remoteStorage] so each download/upload/delete waits [delay]
+/// before completing, making a sync batch observably in-flight while a test
+/// races concurrent operations against it.
+void _stubSlowRemoteStorage(MockRemoteStorage remoteStorage, Duration delay) {
+  when(remoteStorage.downloadFile(any)).thenAnswer((_) async {
+    await Future<void>.delayed(delay);
+    return Stream.value(<int>[0]);
+  });
+  when(remoteStorage.uploadFile(any, any)).thenAnswer((_) async {
+    await Future<void>.delayed(delay);
+  });
+  when(remoteStorage.deleteFile(any)).thenAnswer((_) async {
+    await Future<void>.delayed(delay);
+  });
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -429,10 +429,10 @@ packages:
     dependency: transitive
     description:
       name: devtools_shared
-      sha256: d626d5d6d0c98c803d5b58f72ded629f24ca3a4101facf1ac715481eb6fbf314
+      sha256: "5ab724cfd36ef4b0e47ef4719527be61ba262c5cfdb8522535f9bad7aa862556"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "13.0.1"
   drift:
     dependency: transitive
     description:


### PR DESCRIPTION
## Problem

Reported on Discord ([thread](https://discord.com/channels/1138230179878154300/1501962462910611597)).

1. `startSync`'s `asyncMap` wraps the entire per-attachment loop in `attachmentsService.withContext(...)`, so the attachment-service mutex is held for the whole batch.

2. `handleSync` iterates every active attachment serially with `await`, doing network I/O for each one inside that held mutex.

3. State changes are accumulated in a local list and committed once via a single `context.saveAttachments(updatedAttachments)` call at the end of the iteration.

4. Cancellation (`stopSync`) only re-evaluates the `takeWhile` predicate between batches so it cannot interrupt a running `asyncMap` step.

With ~20k queued downloads at ~200 ms each (the case in the report), it produces three observable failures:

- `stopSync()` can't complete until the in-flight `asyncMap` step finishes, i.e. until the full batch (~hours) drains.
- `saveFile()`, `deleteFile()`, `clearQueue()`, `expireCache()`, and `_processWatchedAttachments()` all call `withContext(...)` and are blocked behind the same mutex for the duration of the batch.
- Any consumer query against `attachments_queue` (e.g. a diagnostics page running `SELECT state, COUNT(*) ... GROUP BY state`) sees zero progress until the batch finishes and then a single atomic jump.

## Expected behavior

- `stopSync()` returns within one attachment's processing time, not one batch's.
- `saveFile()`, `deleteFile()`, and other queue mutations are not blocked behind an in-flight sync batch.
- `attachments_queue` reflects real-time progress, so consumer queries and `db.watch(...)` streams see incremental state changes instead of an end-of-batch commit.

## AI disclosure

This PR was created with the help of Opus 4.7 and Claude Code after reproducing the issue locally, and I’ve reviewed the resulting code changes. 