### PR TITLE
Improve actions setup, add static analysis

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Install Flutter
-      uses: subosito/flutter-action@v2
+      uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
       with:
         flutter-version: "3.x"
         channel: "stable"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   zizmor:
     permissions:
-      security-events: write
+      security-events: write # Needed to upload findings as code scanning results.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -22,6 +22,8 @@ jobs:
           persist-credentials: false
       - name: Run zizmor 🌈
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          persona: pedantic
 
   setup:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,20 @@ on:
       - "**"
   pull_request:
 
+permissions: {}
+
 jobs:
+  zizmor:
+    permissions:
+      security-events: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+
   setup:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     uses: ./.github/workflows/prepare_wasm.yml
@@ -20,6 +33,8 @@ jobs:
     needs: [setup]
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/prepare
       - name: Check formatting
         run:  dart format --set-exit-if-changed -o none .
@@ -42,6 +57,8 @@ jobs:
     needs: [setup]
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/prepare
 
       - name: Install pana
@@ -57,6 +74,8 @@ jobs:
     needs: [setup]
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/prepare
       - name: Test powersync package
         working-directory: packages/powersync

--- a/.github/workflows/prepare_wasm.yml
+++ b/.github/workflows/prepare_wasm.yml
@@ -3,6 +3,8 @@ name: Build SQLite3 WASM
 on:
   workflow_call:
 
+permissions: {}
+
 jobs:
   compile_sqlite3_wasm:
     name: Compile sqlite3 wasm
@@ -10,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/cache@v5
         id: cache_build
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,9 +7,10 @@ on:
       - "powersync_flutter_libs-v[0-9]+.[0-9]+.[0-9]+*"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   setup:
-    permissions: {}
     uses: ./.github/workflows/prepare_wasm.yml
 
   github_release:
@@ -17,7 +18,7 @@ jobs:
     if: "${{ startsWith(github.ref_name, 'powersync-') }}"
     needs: [setup]
     permissions:
-      contents: write
+      contents: write # Needed to create a release
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
@@ -41,7 +42,7 @@ jobs:
   publish_powersync:
     needs: [setup]
     permissions:
-      id-token: write
+      id-token: write # Needed to create an OIDC token for pub.dev
     if: "${{ startsWith(github.ref_name, 'powersync-') }}"
     runs-on: ubuntu-latest
     steps:
@@ -67,7 +68,7 @@ jobs:
 
   publish_powersync_flutter_libs:
     permissions:
-      id-token: write
+      id-token: write # Needed to create an OIDC token for pub.dev
     if: "${{ startsWith(github.ref_name, 'powersync_flutter_libs-') }}"
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
     with:
@@ -75,7 +76,7 @@ jobs:
 
   publish_powersync_attachments_helper:
     permissions:
-      id-token: write
+      id-token: write # Needed to create an OIDC token for pub.dev
     if: "${{ startsWith(github.ref_name, 'powersync_attachments_helper-') }}"
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
     with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   setup:
+    permissions: {}
     uses: ./.github/workflows/prepare_wasm.yml
 
   github_release:
@@ -20,20 +21,22 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/prepare
       - name: Create Draft Release
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
-          tag="${{ github.ref_name }}"
+          tag="${GITHUB_REF_NAME}"
           version="${tag#powersync-v}"
           changes=$(awk "/## $version/{flag=1;next}/##/{flag=0}flag" packages/powersync/CHANGELOG.md)
           body="Release $tag
           $changes"
           gh release create "$tag" --title "$tag" --notes "$body"
-          gh release upload "${{ github.ref_name }}" packages/powersync/assets/*.wasm
-          gh release upload "${{ github.ref_name }}" packages/powersync/assets/powersync_db.worker.js
+          gh release upload "${GITHUB_REF_NAME}" packages/powersync/assets/*.wasm
+          gh release upload "${GITHUB_REF_NAME}" packages/powersync/assets/powersync_db.worker.js
 
   publish_powersync:
     needs: [setup]
@@ -44,10 +47,12 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       # Install Dart to install an OIDC token for publishing
       - uses: dart-lang/setup-dart@v1
       - name: Install Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: "3.x"
           channel: "stable"

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -6,3 +6,10 @@ rules:
         "actions/*": ref-pin
         "dart-lang/*": ref-pin
         "Homebrew/actions/*": ref-pin
+  anonymous-definition:
+    disable: true
+  concurrency-limits:
+    ignore:
+      # We don't need to limit concurrency for publishing, as only maintainers can
+      # push tags.
+      - publish.yml:2:1

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -1,0 +1,8 @@
+# Configuration for https://zizmor.sh/, a static analysis tool for GitHub actions.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "actions/*": ref-pin
+        "dart-lang/*": ref-pin
+        "Homebrew/actions/*": ref-pin


### PR DESCRIPTION
This adopts [zizmor](https://zizmor.sh/) as a static analysis tool for GitHub actions workflows in this repository, and fixes most lints. I'm mainly opening this to start a discussion - is this a tool we want to use or are the reports too noisy to be useful for us?

In this repository, the default configuration flagged:

1. Using actions without pinned refs: Zizmor warns about using actions like `actions/checkout@v6` since `v6` is a mutable tag that could change between runs. GitHub allows us to forbid mutable references altogether, too. IMHO, this is a bit too strict by default:
    - Is someone managed to attack `actions/checkout`, we'd have bigger problems. So I think explicitly using the latest version makes sense.
    - It's a similar story for Homebrew and Dart. We use whatever they ship anyway, so pinning an action doesn't help us at all.
    - `subosito/flutter-action` is community-maintained and adding an explicit ref can make sense for those.
2. To keep up with changes to ref-pinned actions dependencies, this configures dependabot. Zizmor also checks these configurations, and enforces a cooldown period for instance.
3. Workflows without an explicit `permissions` block since the default value is too broad. This makes sense to fix, and we also get warnings from GitHub about this.
4. `actions/checkout` uses without `persist-credentials: false`. That's a good point IMO, we don't need these credentials.
5. `${{ ... }}` expansions in scripts since it could "lead to running attacker-controlled code". This is a false-positive in `publish.yml` which was flagged here, but it can still be cleaned up with relatively little effort.

Zizmor can also be configured with a more strict ruleset (`zizmor --persona pedantic .`). In this repository, that additionally flags:

- Jobs without a `concurrency` setting (only affects the publishing workflow in this repository which is harmless).
- Jobs without an explicit name (this doesn't feel that useful to me).
- Permissions without a YAML comment next to them explaining why they're necessary (this one seems helpful).
