### PR TITLE
feat(powersync): add SyncOptions.headers for custom sync HTTP headers

### DIFF
--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+- Add `SyncOptions.headers` to attach custom HTTP headers to every request the
+  sync client makes to the PowerSync service. Useful for traversing corporate
+  proxies or zero-trust gateways (e.g. Cloudflare Access service tokens)
+  without bypassing them for sync traffic.
+
 ## 2.1.0
 
 - Add a DevTools extension to inspect running PowerSync databases in your app.

--- a/packages/powersync/lib/src/sync/options.dart
+++ b/packages/powersync/lib/src/sync/options.dart
@@ -38,6 +38,21 @@ final class SyncOptions {
   /// This is enabled by default.
   final bool? includeDefaultStreams;
 
+  /// Additional HTTP headers to attach to every request the sync client makes
+  /// to the PowerSync service.
+  ///
+  /// Use this to traverse corporate proxies or zero-trust gateways
+  /// (for example, Cloudflare Access requires `CF-Access-Client-Id` and
+  /// `CF-Access-Client-Secret`), or to attach custom telemetry tags.
+  ///
+  /// Protocol-critical headers (`Authorization`, `Content-Type`, `Accept`,
+  /// and the user-agent header) are always set by the sync client and
+  /// override any matching entries here.
+  ///
+  /// Changing this value while a sync connection is active will trigger a
+  /// reconnect so the new headers take effect.
+  final Map<String, String>? headers;
+
   const SyncOptions({
     this.crudThrottleTime,
     this.retryDelay,
@@ -45,6 +60,7 @@ final class SyncOptions {
     this.syncImplementation = SyncClientImplementation.defaultClient,
     this.includeDefaultStreams,
     this.appMetadata,
+    this.headers,
   });
 
   SyncOptions _copyWith({
@@ -52,6 +68,7 @@ final class SyncOptions {
     Duration? retryDelay,
     Map<String, dynamic>? params,
     Map<String, String>? appMetadata,
+    Map<String, String>? headers,
   }) {
     return SyncOptions(
       crudThrottleTime: crudThrottleTime ?? this.crudThrottleTime,
@@ -60,6 +77,7 @@ final class SyncOptions {
       syncImplementation: syncImplementation,
       includeDefaultStreams: includeDefaultStreams,
       appMetadata: appMetadata ?? this.appMetadata,
+      headers: headers ?? this.headers,
     );
   }
 }
@@ -89,16 +107,20 @@ extension type ResolvedSyncOptions(SyncOptions source) {
     Duration? retryDelay,
     Map<String, dynamic>? params,
     Map<String, String>? appMetadata,
+    Map<String, String>? headers,
   }) {
     return ResolvedSyncOptions((source ?? SyncOptions())._copyWith(
       crudThrottleTime: crudThrottleTime,
       retryDelay: retryDelay,
       params: params,
       appMetadata: appMetadata,
+      headers: headers,
     ));
   }
 
   Map<String, String> get appMetadata => source.appMetadata ?? const {};
+
+  Map<String, String> get headers => source.headers ?? const {};
 
   Duration get crudThrottleTime =>
       source.crudThrottleTime ?? const Duration(milliseconds: 10);
@@ -118,6 +140,7 @@ extension type ResolvedSyncOptions(SyncOptions source) {
       includeDefaultStreams:
           other.includeDefaultStreams ?? includeDefaultStreams,
       appMetadata: other.appMetadata ?? appMetadata,
+      headers: other.headers ?? headers,
     );
 
     final didChange = !_mapEquality.equals(newOptions.params, params) ||
@@ -125,7 +148,8 @@ extension type ResolvedSyncOptions(SyncOptions source) {
         newOptions.retryDelay != retryDelay ||
         newOptions.syncImplementation != source.syncImplementation ||
         newOptions.includeDefaultStreams != includeDefaultStreams ||
-        !_mapEquality.equals(newOptions.appMetadata, appMetadata);
+        !_mapEquality.equals(newOptions.appMetadata, appMetadata) ||
+        !_mapEquality.equals(newOptions.headers, headers);
     return (ResolvedSyncOptions(newOptions), didChange);
   }
 

--- a/packages/powersync/lib/src/sync/streaming_sync.dart
+++ b/packages/powersync/lib/src/sync/streaming_sync.dart
@@ -272,6 +272,9 @@ class StreamingSyncImplementation implements StreamingSync {
         credentials.endpointUri('write-checkpoint2.json?client_id=$clientId');
 
     Map<String, String> headers = {
+      // User-supplied headers come first so the protocol-critical headers below
+      // (Content-Type, Authorization, user-agent) always win on conflict.
+      ...options.headers,
       'Content-Type': 'application/json',
       'Authorization': "Token ${credentials.token}",
       ..._userAgentHeaders
@@ -312,6 +315,9 @@ class StreamingSyncImplementation implements StreamingSync {
 
     final request = http.AbortableRequest('POST', uri,
         abortTrigger: onAbort ?? _abort!.onAbort);
+    // User-supplied headers are added first so the protocol-critical headers
+    // assigned below always take precedence on conflict.
+    request.headers.addAll(options.headers);
     request.headers['Content-Type'] = 'application/json';
     request.headers['Authorization'] = "Token ${credentials.token}";
     request.headers['Accept'] = '$bson;q=0.9,$ndJson;q=0.8';

--- a/packages/powersync/lib/src/web/sync_worker.dart
+++ b/packages/powersync/lib/src/web/sync_worker.dart
@@ -85,6 +85,11 @@ class _ConnectedClient {
                 final encodedAppMetadata => Map<String, String>.from(
                     jsonDecode(encodedAppMetadata) as Map<String, dynamic>),
               },
+              headers: switch (request.headersEncoded) {
+                null => null,
+                final encodedHeaders => Map<String, String>.from(
+                    jsonDecode(encodedHeaders) as Map<String, dynamic>),
+              },
             );
 
             _runner = _worker._referenceSyncTask(

--- a/packages/powersync/lib/src/web/sync_worker_protocol.dart
+++ b/packages/powersync/lib/src/web/sync_worker_protocol.dart
@@ -81,6 +81,7 @@ extension type StartSynchronization._(JSObject _) implements JSObject {
     String? syncParamsEncoded,
     UpdateSubscriptions? subscriptions,
     String? appMetadataEncoded,
+    String? headersEncoded,
   });
 
   external String get databaseName;
@@ -92,6 +93,7 @@ extension type StartSynchronization._(JSObject _) implements JSObject {
   external String? get syncParamsEncoded;
   external UpdateSubscriptions? get subscriptions;
   external String? get appMetadataEncoded;
+  external String? get headersEncoded;
 }
 
 @anonymous
@@ -488,6 +490,10 @@ final class WorkerCommunicationChannel {
         appMetadataEncoded: switch (options.source.appMetadata) {
           null => null,
           final appMetadata => jsonEncode(appMetadata),
+        },
+        headersEncoded: switch (options.source.headers) {
+          null => null,
+          final headers => jsonEncode(headers),
         },
       ),
     ));

--- a/packages/powersync/test/connected_test.dart
+++ b/packages/powersync/test/connected_test.dart
@@ -66,6 +66,43 @@ void main() {
       await db.disconnect();
     });
 
+    test('should send custom headers on sync stream requests', () async {
+      final testServer = await createTestServer();
+      final connector = TestConnector(() async {
+        return PowerSyncCredentials(
+            endpoint: testServer.uri.toString(),
+            token: 'token not used here',
+            expiresAt: DateTime.now());
+      });
+
+      final db = PowerSyncDatabase.withFactory(
+          await testUtils.testFactory(path: path),
+          schema: defaultSchema,
+          maxReaders: 3);
+      addTearDown(() => {db.close()});
+      await db.initialize();
+
+      testServer.addEvent('{"token_expires_in": 3600}\n');
+
+      await db.connect(
+        connector: connector,
+        options: SyncOptions(headers: {
+          'CF-Access-Client-Id': 'test-client-id',
+          'CF-Access-Client-Secret': 'test-client-secret',
+          // Should be ignored: protocol headers always win.
+          'Authorization': 'Token bogus',
+        }),
+      );
+
+      final request = await testServer.service.waitForListener;
+      expect(request.headers['cf-access-client-id'], 'test-client-id');
+      expect(request.headers['cf-access-client-secret'], 'test-client-secret');
+      // The user's Authorization must not override the credentials.
+      expect(request.headers['authorization'], 'Token token not used here');
+
+      await db.disconnect();
+    });
+
     test('should trigger uploads when connection is re-established', () async {
       int uploadCounter = 0;
       var uploadTriggeredCompleter = Completer<void>();

--- a/packages/powersync/test/sync/options_test.dart
+++ b/packages/powersync/test/sync/options_test.dart
@@ -33,5 +33,30 @@ void main() {
 
       expect(didChange, isFalse);
     });
+
+    test('headers default to an empty map', () {
+      final resolved = ResolvedSyncOptions(SyncOptions());
+      expect(resolved.headers, isEmpty);
+    });
+
+    test('headers are preserved through resolve', () {
+      final resolved = ResolvedSyncOptions(SyncOptions(
+        headers: {'CF-Access-Client-Id': 'abc'},
+      ));
+      expect(resolved.headers, {'CF-Access-Client-Id': 'abc'});
+    });
+
+    test('changing headers triggers a reconnect', () {
+      final a = ResolvedSyncOptions(SyncOptions(
+        headers: {'CF-Access-Client-Id': 'abc'},
+      ));
+
+      final (b, didChange) = a.applyFrom(SyncOptions(
+        headers: {'CF-Access-Client-Id': 'xyz'},
+      ));
+
+      expect(b.headers, {'CF-Access-Client-Id': 'xyz'});
+      expect(didChange, isTrue);
+    });
   });
 }


### PR DESCRIPTION
Adds `SyncOptions.headers` a `Map<String, String>?` of HTTP headers attached to every request the sync client makes to the PowerSync service.

    await db.connect(
      connector: connector,
      options: SyncOptions(
        headers: {
          'CF-Access-Client-Id': '...',
          'CF-Access-Client-Secret': '...',
        },
      ),
    );

Currently, the sync HTTP client is constructed internally with no header-injection hook (`http.Client()` and `BrowserClient()` are hardcoded). That blocks deployments behind corporate proxies, zero-trust gateways, or anything requiring per-request middleware (like Cloudflare Access).

The Supabase Flutter SDK already supports this via `Supabase.initialize(headers: ...)`, but PowerSync has no equivalent.

A Client Function() factory would be more flexible (cert pinning, retry policy, interceptors) but closures cannot cross the web worker postMessage boundary.

No public API breaking changes, the field is optional and defaults to null. The `DevConnector` API calls in `lib/src/connector.dart` are out of scope.

I also let Claude add a couple tests to the PR. Tell me what you think. Thanks.