### PR TITLE
Improve tab close detection for shared sync worker

### DIFF
--- a/packages/powersync/lib/src/web/sync_controller.dart
+++ b/packages/powersync/lib/src/web/sync_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:js_interop';
 
+import 'package:meta/meta.dart';
 import 'package:powersync/src/web/worker_utils.dart';
 import 'package:sqlite_async/web.dart';
 import 'package:web/web.dart';
@@ -21,17 +22,20 @@ class SyncWorkerHandle implements StreamingSync {
 
   final StreamController<SyncStatus> _status = StreamController.broadcast();
 
-  SyncWorkerHandle._({
+  @visibleForTesting
+  SyncWorkerHandle({
     required this.database,
     required this.connector,
     required this.options,
     required MessagePort sendToWorker,
-    required SharedWorker worker,
+    required SharedWorker? worker,
     required this.subscriptions,
   }) {
     _channel = WorkerCommunicationChannel(
       port: sendToWorker,
-      errors: EventStreamProviders.errorEvent.forTarget(worker),
+      errors: worker != null
+          ? EventStreamProviders.errorEvent.forTarget(worker)
+          : null,
       logger: database.logger,
       requestHandler: (type, payload) async {
         switch (type) {
@@ -102,7 +106,7 @@ class SyncWorkerHandle implements StreamingSync {
       [port2].toJS,
     );
 
-    final handle = SyncWorkerHandle._(
+    final handle = SyncWorkerHandle(
       options: options,
       database: database,
       connector: connector,
@@ -119,7 +123,12 @@ class SyncWorkerHandle implements StreamingSync {
 
   Future<void> close() async {
     await abort();
-    await _channel.close();
+    await closeChannel();
+  }
+
+  @visibleForTesting
+  Future<void> closeChannel() {
+    return _channel.close();
   }
 
   @override
@@ -131,9 +140,9 @@ class SyncWorkerHandle implements StreamingSync {
   Stream<SyncStatus> get statusStream => _status.stream;
 
   @override
-  Future<void> streamingSync() async {
+  Future<void> streamingSync([String? databaseName]) async {
     await _channel.startSynchronization(
-      database.database.openFactory.path,
+      databaseName ?? database.database.openFactory.path,
       ResolvedSyncOptions(options),
       database.schema,
       subscriptions,

--- a/packages/powersync/lib/src/web/sync_controller.dart
+++ b/packages/powersync/lib/src/web/sync_controller.dart
@@ -140,9 +140,9 @@ class SyncWorkerHandle implements StreamingSync {
   Stream<SyncStatus> get statusStream => _status.stream;
 
   @override
-  Future<void> streamingSync([String? databaseName]) async {
+  Future<void> streamingSync() async {
     await _channel.startSynchronization(
-      databaseName ?? database.database.openFactory.path,
+      database.database.openFactory.path,
       ResolvedSyncOptions(options),
       database.schema,
       subscriptions,

--- a/packages/powersync/lib/src/web/sync_worker.dart
+++ b/packages/powersync/lib/src/web/sync_worker.dart
@@ -1,6 +1,7 @@
 /// This file needs to be compiled to JavaScript with the command
 /// dart compile js -O4 packages/powersync/lib/src/web/sync_worker.dart -o assets/powersync_sync.worker.js
 /// The output should then be included in each project's `web` directory
+@internal
 library;
 
 import 'dart:async';
@@ -11,6 +12,7 @@ import 'package:async/async.dart';
 import 'package:collection/collection.dart';
 import 'package:http/browser_client.dart';
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 import 'package:powersync/powersync.dart';
 import 'package:sqlite_async/sqlite_async.dart';
 import 'package:powersync/src/sync/internal_connector.dart';
@@ -26,20 +28,21 @@ import 'web_bucket_storage.dart';
 final _logger = autoLogger;
 
 class SyncWorker {
-  final Map<String, _SyncRunner> _requestedSyncTasks = {};
+  @visibleForTesting
+  final Map<String, SyncRunner> requestedSyncTasks = {};
 
   void trackPort(MessagePort port) {
-    _ConnectedClient(port, this);
+    ConnectedClient(port, this);
   }
 
-  _SyncRunner _referenceSyncTask(
+  SyncRunner _referenceSyncTask(
       String databaseIdentifier,
       SyncOptions options,
       String schemaJson,
       List<SubscribedStream> subscriptions,
-      _ConnectedClient client) {
-    return _requestedSyncTasks.putIfAbsent(databaseIdentifier, () {
-      return _SyncRunner(databaseIdentifier);
+      ConnectedClient client) {
+    return requestedSyncTasks.putIfAbsent(databaseIdentifier, () {
+      return SyncRunner(databaseIdentifier);
     })
       ..registerClient(
         client,
@@ -50,20 +53,23 @@ class SyncWorker {
   }
 }
 
-class _ConnectedClient {
+@visibleForTesting
+class ConnectedClient {
   late WorkerCommunicationChannel channel;
   final SyncWorker _worker;
 
-  _SyncRunner? _runner;
+  SyncRunner? _runner;
   StreamSubscription<LogRecord>? _logSubscription;
 
-  _ConnectedClient(MessagePort port, this._worker) {
+  ConnectedClient(MessagePort port, this._worker) {
     channel = WorkerCommunicationChannel(
       port: port,
       requestHandler: (type, payload) async {
         switch (type) {
           case SyncWorkerMessageType.startSynchronization:
             final request = payload as StartSynchronization;
+            channel.observeRemoteLockName(request.lockName);
+
             final recoveredOptions = SyncOptions(
               crudThrottleTime:
                   Duration(milliseconds: request.crudThrottleTimeMs),
@@ -108,6 +114,7 @@ class _ConnectedClient {
         }
       },
     );
+    channel.closed.whenComplete(markClosed);
 
     _logSubscription = _logger.onRecord.listen((record) {
       final msg = StringBuffer(
@@ -139,7 +146,8 @@ class _ConnectedClient {
   }
 }
 
-class _SyncRunner {
+@visibleForTesting
+class SyncRunner {
   final String identifier;
   ResolvedSyncOptions options = ResolvedSyncOptions(SyncOptions());
   String schemaJson = '{}';
@@ -149,11 +157,11 @@ class _SyncRunner {
 
   StreamingSyncImplementation? sync;
   SyncStatus? _lastSyncStatus;
-  _ConnectedClient? databaseHost;
-  final connections = <_ConnectedClient, List<SubscribedStream>>{};
+  ConnectedClient? databaseHost;
+  final connections = <ConnectedClient, List<SubscribedStream>>{};
   List<SubscribedStream> currentStreams = [];
 
-  _SyncRunner(this.identifier) {
+  SyncRunner(this.identifier) {
     _group.add(_mainEvents.stream);
 
     Future(() async {
@@ -186,32 +194,18 @@ class _SyncRunner {
               if (_lastSyncStatus case final status?) {
                 client.sendSyncStatus(SerializedSyncStatus.from(status));
               }
-
             case _RemoveConnection(:final client):
               connections.remove(client);
               if (connections.isEmpty) {
                 await sync?.abort();
                 sync = null;
+              } else if (client == databaseHost) {
+                await _activeClientHasClosed();
               }
             case _DisconnectClient(:final client):
               connections.remove(client);
               await sync?.abort();
               sync = null;
-            case _ActiveDatabaseClosed():
-              _logger.info('Remote database closed, finding a new client');
-              sync?.abort();
-              sync = null;
-
-              // The only reliable notification we get for a client closing is
-              // when that client is currently hosting the database. Use the
-              // opportunity to check whether secondary clients have also closed
-              // in the meantime.
-              final newHost = await _collectActiveClients();
-              if (newHost == null) {
-                _logger.info('No client remains');
-              } else {
-                await _requestDatabase(newHost);
-              }
             case _ClientSubscriptionsChanged(
                 :final client,
                 :final subscriptions
@@ -224,6 +218,19 @@ class _SyncRunner {
         }
       }
     });
+  }
+
+  Future<void> _activeClientHasClosed() async {
+    _logger.info('Remote database closed, finding a new client');
+    await sync?.abort();
+    sync = null;
+
+    final newHost = await _collectActiveClients();
+    if (newHost == null) {
+      _logger.info('No client remains');
+    } else {
+      await _requestDatabase(newHost);
+    }
   }
 
   /// Updates [currentStreams] to the union of values in [connections].
@@ -242,13 +249,13 @@ class _SyncRunner {
   /// (as they are likely closed tabs as well).
   ///
   /// Returns the first client that responds (without waiting for others).
-  Future<_ConnectedClient?> _collectActiveClients() async {
+  Future<ConnectedClient?> _collectActiveClients() async {
     final candidates = connections.keys.toList();
     if (candidates.isEmpty) {
       return null;
     }
 
-    final firstResponder = Completer<_ConnectedClient?>();
+    final firstResponder = Completer<ConnectedClient?>();
     var pendingRequests = candidates.length;
 
     for (final candidate in candidates) {
@@ -270,7 +277,7 @@ class _SyncRunner {
     return firstResponder.future;
   }
 
-  Future<void> _requestDatabase(_ConnectedClient client) async {
+  Future<void> _requestDatabase(ConnectedClient client) async {
     _logger.info('Sync setup: Requesting database');
 
     // This is the first client, ask for a database connection
@@ -287,12 +294,6 @@ class _SyncRunner {
     database.closedFuture.then((_) {
       _logger.fine('Detected closed client');
       client.markClosed();
-
-      if (client == databaseHost) {
-        _logger
-            .info('Tab providing sync database has gone down, reconnecting...');
-        _mainEvents.add(const _ActiveDatabaseClosed());
-      }
     });
 
     final tables = ['ps_crud'];
@@ -336,23 +337,23 @@ class _SyncRunner {
     sync!.streamingSync();
   }
 
-  void registerClient(_ConnectedClient client, SyncOptions options,
+  void registerClient(ConnectedClient client, SyncOptions options,
       String schemaJson, List<SubscribedStream> subscriptions) {
     _mainEvents.add(_AddConnection(client, options, schemaJson, subscriptions));
   }
 
   /// Remove a client, disconnecting if no clients remain..
-  void unregisterClient(_ConnectedClient client) {
+  void unregisterClient(ConnectedClient client) {
     _mainEvents.add(_RemoveConnection(client));
   }
 
   /// Remove a client, and immediately disconnect.
-  void disconnectClient(_ConnectedClient client) {
+  void disconnectClient(ConnectedClient client) {
     _mainEvents.add(_DisconnectClient(client));
   }
 
   void updateClientSubscriptions(
-      _ConnectedClient client, List<SubscribedStream> subscriptions) {
+      ConnectedClient client, List<SubscribedStream> subscriptions) {
     _mainEvents.add(_ClientSubscriptionsChanged(client, subscriptions));
   }
 }
@@ -360,7 +361,7 @@ class _SyncRunner {
 sealed class _RunnerEvent {}
 
 final class _AddConnection implements _RunnerEvent {
-  final _ConnectedClient client;
+  final ConnectedClient client;
   final SyncOptions options;
   final String schemaJson;
   final List<SubscribedStream> subscriptions;
@@ -370,24 +371,20 @@ final class _AddConnection implements _RunnerEvent {
 }
 
 final class _RemoveConnection implements _RunnerEvent {
-  final _ConnectedClient client;
+  final ConnectedClient client;
 
   _RemoveConnection(this.client);
 }
 
 final class _DisconnectClient implements _RunnerEvent {
-  final _ConnectedClient client;
+  final ConnectedClient client;
 
   _DisconnectClient(this.client);
 }
 
 final class _ClientSubscriptionsChanged implements _RunnerEvent {
-  final _ConnectedClient client;
+  final ConnectedClient client;
   final List<SubscribedStream> subscriptions;
 
   _ClientSubscriptionsChanged(this.client, this.subscriptions);
-}
-
-final class _ActiveDatabaseClosed implements _RunnerEvent {
-  const _ActiveDatabaseClosed();
 }

--- a/packages/powersync/lib/src/web/sync_worker_protocol.dart
+++ b/packages/powersync/lib/src/web/sync_worker_protocol.dart
@@ -582,7 +582,7 @@ final class WorkerCommunicationChannel {
 
   static String _generateRandomLockName() {
     final crypto = (globalContext['crypto'] as Crypto);
-    return 'http-remote-${crypto.randomUUID()}';
+    return 'powersync-worker-keepalive-${crypto.randomUUID()}';
   }
 }
 

--- a/packages/powersync/lib/src/web/sync_worker_protocol.dart
+++ b/packages/powersync/lib/src/web/sync_worker_protocol.dart
@@ -1,15 +1,17 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 
 import 'package:logging/logging.dart';
 import 'package:powersync/src/schema.dart';
 import 'package:powersync/src/sync/options.dart';
 import 'package:powersync/src/sync/stream.dart';
-import 'package:web/web.dart';
+import 'package:web/web.dart' hide HttpRequest, Client;
 
 import '../connector.dart';
 import '../log.dart';
+import '../platform_specific/web.dart';
 import '../sync/streaming_sync.dart';
 import '../sync/sync_status.dart';
 
@@ -78,6 +80,7 @@ extension type StartSynchronization._(JSObject _) implements JSObject {
     required int retryDelayMs,
     required String implementationName,
     required String schemaJson,
+    required String lockName,
     String? syncParamsEncoded,
     UpdateSubscriptions? subscriptions,
     String? appMetadataEncoded,
@@ -92,6 +95,7 @@ extension type StartSynchronization._(JSObject _) implements JSObject {
   external String? get syncParamsEncoded;
   external UpdateSubscriptions? get subscriptions;
   external String? get appMetadataEncoded;
+  external String get lockName;
 }
 
 @anonymous
@@ -341,10 +345,16 @@ extension type SerializedSyncStatus._(JSObject _) implements JSObject {
 
 final class WorkerCommunicationChannel {
   final Map<int, Completer<JSAny?>> _pendingRequests = {};
+  final Completer<void> _closed = Completer();
   int _nextRequestId = 0;
   bool _hasError = false;
+  bool _hasReceivedRemoteLockName = false;
   StreamSubscription<MessageEvent>? _incomingMessages;
   StreamSubscription<Event>? _incomingErrors;
+
+  /// The name of a navigator lock held by this channel, it's sent to the remote
+  /// when requested so that it can detect when this channel is closed.
+  late final Future<String> _lockName = _acquireLock();
 
   final MessagePort port;
   final FutureOr<(JSAny?, JSArray?)> Function(SyncWorkerMessageType, JSAny)
@@ -354,6 +364,8 @@ final class WorkerCommunicationChannel {
   final Logger _logger;
 
   Stream<(SyncWorkerMessageType, JSAny)> get events => _events.stream;
+
+  Future<void> get closed => _closed.future;
 
   WorkerCommunicationChannel({
     required this.port,
@@ -382,11 +394,7 @@ final class WorkerCommunicationChannel {
       switch (type) {
         case SyncWorkerMessageType.ping:
           requestId = (message.payload as JSNumber).toDartInt;
-          port.postMessage(SyncWorkerMessage(
-            type: SyncWorkerMessageType.okResponse.name,
-            payload: OkResponse(requestId: requestId, payload: null),
-          ));
-          return;
+          return _respond(requestId, () async => (null, null));
         case SyncWorkerMessageType.startSynchronization:
           requestId = (message.payload as StartSynchronization).requestId;
         case SyncWorkerMessageType.updateSubscriptions:
@@ -416,31 +424,35 @@ final class WorkerCommunicationChannel {
           return;
       }
 
-      try {
-        final (response, transfer) =
-            await requestHandler(type, message.payload);
-        final responseMessage = SyncWorkerMessage(
-          type: SyncWorkerMessageType.okResponse.name,
-          payload: OkResponse(requestId: requestId, payload: response),
-        );
-
-        if (transfer != null) {
-          port.postMessage(responseMessage, transfer);
-        } else {
-          port.postMessage(responseMessage);
-        }
-      } catch (e) {
-        port.postMessage(SyncWorkerMessage(
-          type: SyncWorkerMessageType.errorResponse.name,
-          payload: ErrorResponse(
-              requestId: requestId, errorMessage: e.toString().toJS),
-        ));
-      }
+      await _respond(requestId, () => requestHandler(type, message.payload));
     });
   }
 
+  Future<void> _respond(int requestId,
+      FutureOr<(JSAny?, JSArray?)> Function() generateResponse) async {
+    try {
+      final (response, transfer) = await generateResponse();
+      final responseMessage = SyncWorkerMessage(
+        type: SyncWorkerMessageType.okResponse.name,
+        payload: OkResponse(requestId: requestId, payload: response),
+      );
+
+      if (transfer != null) {
+        port.postMessage(responseMessage, transfer);
+      } else {
+        port.postMessage(responseMessage);
+      }
+    } catch (e) {
+      port.postMessage(SyncWorkerMessage(
+        type: SyncWorkerMessageType.errorResponse.name,
+        payload: ErrorResponse(
+            requestId: requestId, errorMessage: e.toString().toJS),
+      ));
+    }
+  }
+
   (int, Future<JSAny?>) _newRequest() {
-    if (_hasError) {
+    if (_hasError || _closed.isCompleted) {
       throw StateError('Channel has error, cannot send new requests');
     }
 
@@ -462,6 +474,14 @@ final class WorkerCommunicationChannel {
 
   Future<void> ping() async {
     await _numericRequest(SyncWorkerMessageType.ping);
+  }
+
+  void observeRemoteLockName(String name) {
+    if (!_hasReceivedRemoteLockName) {
+      _hasReceivedRemoteLockName = true;
+      // Once we're able to acquire this lock, we know the remote has closed.
+      potentiallySharedMutex(name).lock(close);
+    }
   }
 
   Future<void> startSynchronization(
@@ -489,6 +509,7 @@ final class WorkerCommunicationChannel {
           null => null,
           final appMetadata => jsonEncode(appMetadata),
         },
+        lockName: await _lockName,
       ),
     ));
     await completion;
@@ -534,8 +555,42 @@ final class WorkerCommunicationChannel {
   }
 
   Future<void> close() async {
-    _incomingMessages?.cancel();
-    _incomingErrors?.cancel();
-    port.close();
+    if (!_closed.isCompleted) {
+      _incomingMessages?.cancel();
+      _incomingErrors?.cancel();
+      port.close();
+
+      for (final pending in _pendingRequests.values) {
+        pending.completeError(const ChannelClosedException());
+      }
+
+      _closed.complete();
+    }
+  }
+
+  Future<String> _acquireLock() async {
+    final name = _generateRandomLockName();
+    final hasLock = Completer<void>.sync();
+    potentiallySharedMutex(name).lock(() async {
+      hasLock.complete();
+      return _closed.future;
+    });
+
+    await hasLock.future;
+    return name;
+  }
+
+  static String _generateRandomLockName() {
+    final crypto = (globalContext['crypto'] as Crypto);
+    return 'http-remote-${crypto.randomUUID()}';
+  }
+}
+
+final class ChannelClosedException implements Exception {
+  const ChannelClosedException();
+
+  @override
+  String toString() {
+    return 'Worker communication channel closed';
   }
 }

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   sqlite_async: ^0.14.2
-  sqlite3_web: ^0.8.0
+  sqlite3_web: ^0.8.1
   sqlite3: ^3.2.0
   meta: ^1.0.0
   http: ^1.6.0

--- a/packages/powersync/test/web/sync_worker_test.dart
+++ b/packages/powersync/test/web/sync_worker_test.dart
@@ -1,0 +1,82 @@
+@TestOn('browser')
+library;
+
+import 'package:logging/logging.dart';
+import 'package:powersync/powersync.dart';
+import 'package:powersync/src/sync/streaming_sync.dart';
+import 'package:powersync/src/web/sync_controller.dart';
+import 'package:powersync/src/web/sync_worker.dart';
+import 'package:test/test.dart';
+import 'package:web/web.dart' show MessageChannel;
+
+import '../utils/web_test_utils.dart';
+
+void main() {
+  late final TestUtils utils;
+  late SyncWorker syncWorker;
+  late PowerSyncDatabase db;
+
+  setUpAll(() async {
+    utils = TestUtils();
+  });
+
+  setUp(() async {
+    syncWorker = SyncWorker();
+
+    db = await utils.setupPowerSync(logger: Logger.detached('test_logger'));
+    await db.initialize();
+  });
+
+  SyncWorkerHandle createWorkerHandle({
+    required PowerSyncBackendConnector connector,
+    SyncOptions options = const SyncOptions(),
+    List<SubscribedStream> subscriptions = const [],
+  }) {
+    final rawChannel = MessageChannel();
+    syncWorker.trackPort(rawChannel.port1);
+
+    final handle = SyncWorkerHandle(
+      database: db,
+      connector: connector,
+      options: options,
+      sendToWorker: rawChannel.port2,
+      worker: null,
+      subscriptions: subscriptions,
+    );
+    handle.statusStream.forEach(db.setStatus);
+    return handle;
+  }
+
+  test('aborts sync when database is closed', () async {
+    final handle = createWorkerHandle(connector: _ThrowingBackendConnector());
+    final hasError = expectLater(
+        db.statusStream,
+        emitsThrough(isA<SyncStatus>()
+            .having((e) => e.downloadError, 'downloadError', isNotNull)));
+    await handle.streamingSync('test_database');
+    await hasError;
+
+    expect(db.currentStatus.downloadError.toString(),
+        contains('Expected error from fetchCredentials'));
+    final syncRunner = syncWorker.requestedSyncTasks.values.single;
+    expect(syncRunner.sync, isNotNull);
+    expect(syncRunner.connections, hasLength(1));
+
+    await handle.closeChannel();
+    await pumpEventQueue();
+
+    // This should abort the sync process
+    expect(syncRunner.sync, isNull);
+    expect(syncRunner.connections, isEmpty);
+  });
+}
+
+final class _ThrowingBackendConnector extends PowerSyncBackendConnector {
+  @override
+  Future<PowerSyncCredentials?> fetchCredentials() async {
+    throw UnsupportedError('Expected error from fetchCredentials');
+  }
+
+  @override
+  Future<void> uploadData(PowerSyncDatabase database) async {}
+}

--- a/packages/powersync/test/web/sync_worker_test.dart
+++ b/packages/powersync/test/web/sync_worker_test.dart
@@ -76,7 +76,7 @@ void main() {
     late SyncWorkerHandle handle;
     final didRequestCredentials = Completer<void>();
     handle = createWorkerHandle(connector: _ThrowingBackendConnector(() {
-      // When the fetchCredentials request is sent, ther should be a sync
+      // When the fetchCredentials request is sent, there should be a sync
       // process.
       final syncRunner = syncWorker.requestedSyncTasks.values.single;
       expect(syncRunner.sync, isNotNull);

--- a/packages/powersync/test/web/sync_worker_test.dart
+++ b/packages/powersync/test/web/sync_worker_test.dart
@@ -55,7 +55,7 @@ void main() {
         db.statusStream,
         emitsThrough(isA<SyncStatus>()
             .having((e) => e.downloadError, 'downloadError', isNotNull)));
-    await handle.streamingSync('test_database');
+    await handle.streamingSync();
     await hasError;
 
     expect(db.currentStatus.downloadError.toString(),
@@ -88,7 +88,7 @@ void main() {
       didRequestCredentials.complete();
     }));
 
-    await handle.streamingSync('test_database');
+    await handle.streamingSync();
     await didRequestCredentials.future;
     await pumpEventQueue();
 

--- a/packages/powersync/test/web/sync_worker_test.dart
+++ b/packages/powersync/test/web/sync_worker_test.dart
@@ -1,6 +1,8 @@
 @TestOn('browser')
 library;
 
+import 'dart:async';
+
 import 'package:logging/logging.dart';
 import 'package:powersync/powersync.dart';
 import 'package:powersync/src/sync/streaming_sync.dart';
@@ -69,11 +71,41 @@ void main() {
     expect(syncRunner.sync, isNull);
     expect(syncRunner.connections, isEmpty);
   });
+
+  test('handles tabs closing while serving a request', () async {
+    late SyncWorkerHandle handle;
+    final didRequestCredentials = Completer<void>();
+    handle = createWorkerHandle(connector: _ThrowingBackendConnector(() {
+      // When the fetchCredentials request is sent, ther should be a sync
+      // process.
+      final syncRunner = syncWorker.requestedSyncTasks.values.single;
+      expect(syncRunner.sync, isNotNull);
+      expect(syncRunner.connections, hasLength(1));
+
+      // Close the handle while the fetchCredentials request is active, meaning
+      // the sync worker will never receive a response.
+      handle.closeChannel();
+      didRequestCredentials.complete();
+    }));
+
+    await handle.streamingSync('test_database');
+    await didRequestCredentials.future;
+    await pumpEventQueue();
+
+    final syncRunner = syncWorker.requestedSyncTasks.values.single;
+    expect(syncRunner.sync, isNull);
+    expect(syncRunner.connections, isEmpty);
+  });
 }
 
 final class _ThrowingBackendConnector extends PowerSyncBackendConnector {
+  void Function()? onFetchCredentials;
+
+  _ThrowingBackendConnector([this.onFetchCredentials]);
+
   @override
   Future<PowerSyncCredentials?> fetchCredentials() async {
+    onFetchCredentials?.call();
     throw UnsupportedError('Expected error from fetchCredentials');
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1521,10 +1521,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_web
-      sha256: b539a44e227dc8fd617b56923400a1e8b793325293c05393eab5a24b944cf975
+      sha256: fab6f6921f8fc3f703536c018d709ccb4ad5654d92f53e9b206c222f77c50021
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.8.1"
   sqlite_async:
     dependency: transitive
     description:


### PR DESCRIPTION
Currently, sync workers detect closed tabs by listening on `database.closed` for a database backed by `sqlite3_web` (which internally uses navigator locks to detect closed tabs).

This kind of works, but can lead to deadlocks when a tab is closed while it's serving a request (like a `fetchCredentials` or `requestDatabase` call) that would never complete.

To improve reliability, this adopts the usual navigator locks pattern to our `WorkerCommunicationChannel` as well:

1. Before requesting a sync iteration, tabs acquire a randomly-named lock, and they include that lock name in the request.
2. Like before, the shared sync worker will mark a tab as closed once this lock is available to it. But starting from this PR, it also throws for all pending requests (they would never complete before).

I've also added a small test for the shared sync worker in `sync_worker_test.dart`. It emulates a shared worker by manually passing ports from a `MessageChannel` to it. I've also tested this in a demo app (and actually found an issue in `sqlite3_web`, I'll fix that too).