### PR TITLE
chore(demos): rename supabaseAnonKey to supabasePublishableKey

### DIFF
--- a/demos/supabase-anonymous-auth/lib/app_config_template.dart
+++ b/demos/supabase-anonymous-auth/lib/app_config_template.dart
@@ -2,5 +2,5 @@
 // Edit lib/app_config.dart and enter your Supabase and PowerSync project details.
 class AppConfig {
   static const String supabaseUrl = 'https://foo.supabase.co';
-  static const String supabaseAnonKey = 'foo';
+  static const String supabasePublishableKey = 'foo';
 }

--- a/demos/supabase-anonymous-auth/lib/supabase.dart
+++ b/demos/supabase-anonymous-auth/lib/supabase.dart
@@ -5,6 +5,6 @@ import './app_config.dart';
 Future<void> loadSupabase() async {
   await Supabase.initialize(
     url: AppConfig.supabaseUrl,
-    publishableKey: AppConfig.supabaseAnonKey,
+    publishableKey: AppConfig.supabasePublishableKey,
   );
 }

--- a/demos/supabase-edge-function-auth/lib/app_config_template.dart
+++ b/demos/supabase-edge-function-auth/lib/app_config_template.dart
@@ -2,5 +2,5 @@
 // Edit lib/app_config.dart and enter your Supabase and PowerSync project details.
 class AppConfig {
   static const String supabaseUrl = 'https://foo.supabase.co';
-  static const String supabaseAnonKey = 'foo';
+  static const String supabasePublishableKey = 'foo';
 }

--- a/demos/supabase-edge-function-auth/lib/supabase.dart
+++ b/demos/supabase-edge-function-auth/lib/supabase.dart
@@ -5,6 +5,6 @@ import './app_config.dart';
 Future<void> loadSupabase() async {
   await Supabase.initialize(
     url: AppConfig.supabaseUrl,
-    publishableKey: AppConfig.supabaseAnonKey,
+    publishableKey: AppConfig.supabasePublishableKey,
   );
 }

--- a/demos/supabase-simple-chat/lib/app_config_template.dart
+++ b/demos/supabase-simple-chat/lib/app_config_template.dart
@@ -2,6 +2,6 @@
 // Edit lib/app_config.dart and enter your Supabase and PowerSync project details.
 class AppConfig {
   static const String supabaseUrl = 'https://foo.supabase.co';
-  static const String supabaseAnonKey = 'foo';
+  static const String supabasePublishableKey = 'foo';
   static const String powersyncUrl = 'https://foo.powersync.journeyapps.com';
 }

--- a/demos/supabase-simple-chat/lib/supabase.dart
+++ b/demos/supabase-simple-chat/lib/supabase.dart
@@ -5,6 +5,6 @@ import './app_config.dart';
 Future<void> loadSupabase() async {
   await Supabase.initialize(
     url: AppConfig.supabaseUrl,
-    publishableKey: AppConfig.supabaseAnonKey,
+    publishableKey: AppConfig.supabasePublishableKey,
   );
 }

--- a/demos/supabase-todolist-drift/lib/app_config_template.dart
+++ b/demos/supabase-todolist-drift/lib/app_config_template.dart
@@ -2,7 +2,7 @@
 // Edit lib/app_config.dart and enter your Supabase and PowerSync project details.
 class AppConfig {
   static const String supabaseUrl = 'https://foo.supabase.co';
-  static const String supabaseAnonKey = 'foo';
+  static const String supabasePublishableKey = 'foo';
   static const String powersyncUrl = 'https://foo.powersync.journeyapps.com';
   static const String supabaseStorageBucket =
       ''; // Optional. Only required when syncing attachments and using Supabase Storage. See packages/powersync_attachments_helper.

--- a/demos/supabase-todolist-drift/lib/supabase.dart
+++ b/demos/supabase-todolist-drift/lib/supabase.dart
@@ -12,7 +12,7 @@ part 'supabase.g.dart';
 Future<void> loadSupabase() async {
   await Supabase.initialize(
     url: AppConfig.supabaseUrl,
-    publishableKey: AppConfig.supabaseAnonKey,
+    publishableKey: AppConfig.supabasePublishableKey,
   );
 }
 

--- a/demos/supabase-todolist-optional-sync/lib/app_config.dart
+++ b/demos/supabase-todolist-optional-sync/lib/app_config.dart
@@ -1,6 +1,6 @@
 // Enter your Supabase and PowerSync project details.
 class AppConfig {
   static const String supabaseUrl = 'https://foo.supabase.co';
-  static const String supabaseAnonKey = 'foo';
+  static const String supabasePublishableKey = 'foo';
   static const String powersyncUrl = 'https://foo.powersync.journeyapps.com';
 }

--- a/demos/supabase-todolist-optional-sync/lib/supabase.dart
+++ b/demos/supabase-todolist-optional-sync/lib/supabase.dart
@@ -5,6 +5,6 @@ import './app_config.dart';
 Future<void> loadSupabase() async {
   await Supabase.initialize(
     url: AppConfig.supabaseUrl,
-    publishableKey: AppConfig.supabaseAnonKey,
+    publishableKey: AppConfig.supabasePublishableKey,
   );
 }

--- a/demos/supabase-todolist/lib/app_config_template.dart
+++ b/demos/supabase-todolist/lib/app_config_template.dart
@@ -2,7 +2,7 @@
 // Edit lib/app_config.dart and enter your Supabase and PowerSync project details.
 class AppConfig {
   static const String supabaseUrl = 'https://foo.supabase.co';
-  static const String supabaseAnonKey = 'foo';
+  static const String supabasePublishableKey = 'foo';
   static const String powersyncUrl = 'https://foo.powersync.journeyapps.com';
   static const String supabaseStorageBucket =
       ''; // Optional. Only required when syncing attachments and using Supabase Storage. See packages/powersync_attachments_helper.

--- a/demos/supabase-todolist/lib/supabase.dart
+++ b/demos/supabase-todolist/lib/supabase.dart
@@ -5,6 +5,6 @@ import './app_config.dart';
 Future<void> loadSupabase() async {
   await Supabase.initialize(
     url: AppConfig.supabaseUrl,
-    publishableKey: AppConfig.supabaseAnonKey,
+    publishableKey: AppConfig.supabasePublishableKey,
   );
 }


### PR DESCRIPTION
Supabase is [deprecating anonymous keys](https://github.com/supabase/supabase-flutter/pull/1360) in favor of "publishable keys". This updates the Supabase demos so the `AppConfig` field and its references use the new terminology.

- Rename `AppConfig.supabaseAnonKey` → `AppConfig.supabasePublishableKey` in each demo's `app_config_template.dart` / `app_config.dart`.
- Update the `supabase.dart` references accordingly. The `Supabase.initialize` call already passes `publishableKey:`, so this aligns the field name with how it's consumed.

Pure rename across 6 demos (12 files), no behavior change.

Fixes #430