### PR TITLE
fix(powersync): use read lock for BucketStorage.select()

### DIFF
--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.1 (unreleased)
+
+- Fix `BucketStorage.select()` acquiring a write lock for read-only queries by using `getAll()` instead of `execute()`.
+
 ## 2.3.0
 
 - Add `SyncOptions.httpClient` to `SyncOptions`. It can be set to make PowerSync use a custom HTTP client when connecting to the PowerSync Service.

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.3.1 (unreleased)
 
-- Fix `BucketStorage.select()` acquiring a write lock for read-only queries by using `getAll()` instead of `execute()`.
+- Fix `BucketStorage.select()` acquiring a write lock for read-only queries.
 
 ## 2.3.0
 

--- a/packages/powersync/lib/src/sync/bucket_storage.dart
+++ b/packages/powersync/lib/src/sync/bucket_storage.dart
@@ -18,7 +18,7 @@ class BucketStorage {
   // Use only for read statements
   Future<ResultSet> select(String query,
       [List<Object?> parameters = const []]) async {
-    return await _internalDb.execute(query, parameters);
+    return await _internalDb.getAll(query, parameters);
   }
 
   Future<String> getClientId() async {


### PR DESCRIPTION
Closes #384

### Problem
`BucketStorage.select()` is documented "Use only for read statements", but it calls `_internalDb.execute()`, which acquires a **write lock**. Every caller (`getClientId`, `updateLocalTarget`, `hasCrud`, `getCrudBatch`, …) runs read-only `SELECT`s, so taking a write lock needlessly serializes these reads behind the write lock — notably on web / `SqliteConnectionPool`, where reads and writes can otherwise run concurrently.

@simolus3 confirmed in the issue that this is a bug.

### Fix
Route `select()` through `getAll()`, which acquires a **read lock**, matching the method's documented read-only contract. All existing callers are plain `SELECT`s, so behaviour is unchanged apart from the correct lock type.

### Notes
- One-line behavioural change + CHANGELOG entry (`## 2.3.1 (unreleased)`).
- No public API change.