### PR TITLE
Add npm package exporting wasm and worker files

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Publish dry-run
         run: melos publish --dry-run --yes
 
+      - run: corepack enable
       - uses: actions/setup-node@v6
         with:
           node-version: 26

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -53,6 +53,14 @@ jobs:
       - name: Publish dry-run
         run: melos publish --dry-run --yes
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          cache: pnpm
+          cache-dependency-path: packages/js-assets/pnpm-lock.yaml
+      - run: pnpm build
+        working-directory: packages/js-assets
+
   pana:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
   publish_powersync:
     needs: [setup]
     permissions:
-      id-token: write # Needed to create an OIDC token for pub.dev and npm
+      id-token: write # Needed to create an OIDC token for pub.dev
     if: "${{ startsWith(github.ref_name, 'powersync-') }}"
     runs-on: ubuntu-latest
     steps:
@@ -57,11 +57,6 @@ jobs:
         with:
           flutter-version: "3.x"
           channel: "stable"
-      - run: corepack enable
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 26
-          package-manager-cache: false
       - run: dart pub get
       - run: tool/build.sh
         name: Build and copy devtools extension
@@ -71,6 +66,24 @@ jobs:
         run: dart pub publish -f
         working-directory: packages/powersync
 
+  publish_npm:
+    needs: [setup]
+    permissions:
+      id-token: write # Needed to create an OIDC token for npm
+    if: "${{ startsWith(github.ref_name, 'powersync-') }}"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/prepare
+
+      - run: corepack enable
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          package-manager-cache: false
       - run: pnpm build
         working-directory: packages/js-assets
       - run: pnpm publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
   publish_powersync:
     needs: [setup]
     permissions:
-      id-token: write # Needed to create an OIDC token for pub.dev
+      id-token: write # Needed to create an OIDC token for pub.dev and npm
     if: "${{ startsWith(github.ref_name, 'powersync-') }}"
     runs-on: ubuntu-latest
     steps:
@@ -57,6 +57,11 @@ jobs:
         with:
           flutter-version: "3.x"
           channel: "stable"
+      - run: corepack enable
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          package-manager-cache: false
       - run: dart pub get
       - run: tool/build.sh
         name: Build and copy devtools extension
@@ -65,6 +70,11 @@ jobs:
       - name: Publish to pub.dev
         run: dart pub publish -f
         working-directory: packages/powersync
+
+      - run: pnpm build
+        working-directory: packages/js-assets
+      - run: pnpm publish
+        working-directory: packages/js-assets
 
   publish_powersync_flutter_libs:
     permissions:

--- a/packages/js-assets/.gitignore
+++ b/packages/js-assets/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/packages/js-assets/LICENSE
+++ b/packages/js-assets/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/packages/js-assets/README.md
+++ b/packages/js-assets/README.md
@@ -1,0 +1,5 @@
+This JavaScript package is only meant to be used internally by PowerSync SDKs.
+
+It bundles the `sqlite3.wasm` and `powersync_db.worker.js` files from the
+[PowerSync Dart SDK](https://github.com/powersync-ja/powersync.dart) for use with other
+targets where consuming NPM dependencies is the most convenient way to include bundles.

--- a/packages/js-assets/package.json
+++ b/packages/js-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powersync/dart-sdk-assets",
-  "version": "0.0.1",
+  "version": "2.3.1",
   "description": "Pre-compiled PowerSync Dart SDK assets.",
   "type": "module",
   "exports": {

--- a/packages/js-assets/package.json
+++ b/packages/js-assets/package.json
@@ -3,6 +3,10 @@
   "version": "2.3.1",
   "description": "Pre-compiled PowerSync Dart SDK assets.",
   "type": "module",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
   "exports": {
     "./worker.js": "./dist/powersync_db.worker.js",
     "./sqlite3.wasm": "./dist/sqlite3.wasm",
@@ -22,6 +26,7 @@
   "author": "PowerSync",
   "license": "Apache-2.0",
   "repository": "https://github.com/powersync-ja/powersync.dart",
+  "homepage": "https://docs.powersync.com",
   "bugs": {
     "url": "https://github.com/powersync-ja/powersync.dart/issues"
   },

--- a/packages/js-assets/package.json
+++ b/packages/js-assets/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@powersync/dart-sdk-assets",
+  "version": "0.0.1",
+  "description": "Pre-compiled PowerSync Dart SDK assets.",
+  "scripts": {
+    "copy:assets": "cp -r ../powersync/assets/ dist",
+    "build": "pnpm copy:assets"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "package.json"
+  ],
+  "keywords": [],
+  "author": "PowerSync",
+  "license": "Apache-2.0",
+  "repository": "https://github.com/powersync-ja/powersync.dart",
+  "bugs": {
+    "url": "https://github.com/powersync-ja/powersync.dart/issues"
+  },
+  "packageManager": "pnpm@11.11.0+sha512.4463f65fd80ed80d69bc1d4bf163ee94f605c7380fc318bb5b2ebe15f8cd12d49c51a4d59e951b401e764d3b6ca751cbf51bc50ed7001a6bcb4935e684c34882"
+}

--- a/packages/js-assets/package.json
+++ b/packages/js-assets/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@powersync/dart-sdk-assets",
+  "name": "@powersync/dart-wasm-bundles",
   "version": "2.3.1",
   "description": "Pre-compiled PowerSync Dart SDK assets.",
   "type": "module",

--- a/packages/js-assets/package.json
+++ b/packages/js-assets/package.json
@@ -2,6 +2,12 @@
   "name": "@powersync/dart-sdk-assets",
   "version": "0.0.1",
   "description": "Pre-compiled PowerSync Dart SDK assets.",
+  "type": "module",
+  "exports": {
+    "./worker.js": "./dist/powersync_db.worker.js",
+    "./sqlite3.wasm": "./dist/sqlite3.wasm",
+    "./sqlite3mc.wasm": "./dist/sqlite3mc.wasm"
+  },
   "scripts": {
     "copy:assets": "cp -r ../powersync/assets/ dist",
     "build": "pnpm copy:assets"

--- a/packages/js-assets/pnpm-lock.yaml
+++ b/packages/js-assets/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.3.2 (unreleased)
+## 2.3.2
 
 - Fix state after calling `disconnect()` not consistently representing the correct sync status.
 

--- a/packages/powersync/lib/src/open_factory/web/web_open_factory.dart
+++ b/packages/powersync/lib/src/open_factory/web/web_open_factory.dart
@@ -31,11 +31,10 @@ base class WebPowerSyncOpenFactory extends WebSqliteOpenFactory {
   @override
   Future<ConnectToRecommendedResult> connectToWorker(
       WebSqlite sqlite, String name) {
-    return sqlite.connectToRecommended(
-      name,
-      additionalOptions: PowerSyncAdditionalOpenOptions(
-          useMultipleCiphersVfs: encryptionOptions != null),
-    );
+    return sqlite.connectToRecommended(name,
+        additionalOptions: PowerSyncAdditionalOpenOptions(
+            useMultipleCiphersVfs: encryptionOptions != null),
+        preparedStatementCacheSize: sqliteOptions.preparedStatementCacheSize);
   }
 
   @override

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.6.0
 
 dependencies:
-  sqlite_async: ^0.14.3
+  sqlite_async: ^0.14.4
   sqlite3_web: ^0.9.0
   sqlite3: ^3.3.3
   meta: ^1.0.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1497,18 +1497,18 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "37356bcb56ce0d9404d602c41e4bdb7765e7e9732a3e47adb3d98c556a6abdad"
+      sha256: c73fd75df1332d76a6257f4823ae4df9c791f522b97e4a60cbcad214de1becf4
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.3"
+    version: "3.5.0"
   sqlite3_connection_pool:
     dependency: transitive
     description:
       name: sqlite3_connection_pool
-      sha256: "9d2b3b398b03c96743fd071521fc665be73c33c9cd5c56d87196baff8d8b4398"
+      sha256: ad51972d37bdf82929888e4c85e722bd9a0b5ff8ad389f89b1b00d19603c0d2d
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.6"
+    version: "0.2.7"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
@@ -1521,18 +1521,18 @@ packages:
     dependency: transitive
     description:
       name: sqlite3_web
-      sha256: "183cd6e1523dd4c9097c0f8e8e3e92da2d852f9c680df441c53626444d6d8dce"
+      sha256: aa6af15ef8bf8551d3a84203e3cbc022990567372e46ef98f91bdb2018fcfb0e
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.0"
+    version: "0.9.4"
   sqlite_async:
     dependency: transitive
     description:
       name: sqlite_async
-      sha256: "17176f00a10e5b8ba6e0205e42de1c15a94ff8762745fed19750b44b6bbd5649"
+      sha256: "83aff15d2bb3b296d35e15419a85c3207df3baca62b64b778958a59eb291502d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.3"
+    version: "0.14.4"
   sqlparser:
     dependency: transitive
     description:

--- a/tool/update_version.dart
+++ b/tool/update_version.dart
@@ -9,4 +9,15 @@ void main() {
 
   final versionFile = File('packages/powersync/lib/src/version.dart');
   versionFile.writeAsStringSync("const String libraryVersion = '$version';\n");
+
+  final packageJson = File('packages/js-assets/package.json');
+
+  String transformPackageJson(String originalContents) {
+    final versionLine = RegExp('"version": ".*"');
+
+    return originalContents.replaceFirst(versionLine, '"version": "$version"');
+  }
+
+  packageJson
+      .writeAsStringSync(transformPackageJson(packageJson.readAsStringSync()));
 }


### PR DESCRIPTION
This adds an npm package exporting the `powersync_db.worker.js` file along with `sqlite3.wasm` and `sqlite3mc.wasm`. This helps with Kotlin web support: Because Kotlin web apps can [have npm dependencies](https://kotlinlang.org/docs/using-packages-from-npm.html) and are [bundled with webpack](https://kotlinlang.org/docs/js-project-setup.html#webpack-bundling), adding an npm package makes it easy to import them in Kotlin. Using `new URL('@powersync/dart-sdk-assets', import.meta.url)` will be recognized by webpack to bundle the asset. We want to use the Dart worker and WebAssembly files in Kotlin to avoid having to write yet another sync worker (the JavaScript worker relies on Comlink and doesn't have a stable protocol).

We actually [had this package before](https://github.com/powersync-ja/powersync.dart/pull/233), to use jsdelivr as a CDN for FlutterFlow apps. We removed that package after it wasn't used anymore, but now we need it again for Kotlin web.

Kotlin PR for context: https://github.com/powersync-ja/powersync-kotlin/pull/361