### PR TITLE
Don't create sync status entries in Dart

### DIFF
--- a/demos/supabase-todolist-drift/lib/powersync/powersync.dart
+++ b/demos/supabase-todolist-drift/lib/powersync/powersync.dart
@@ -54,8 +54,9 @@ final _syncStatusInternal = StreamProvider<SyncStatus?>((ref) {
 });
 
 final syncStatus = Provider((ref) {
-  // ignore: invalid_use_of_internal_member
-  return ref.watch(_syncStatusInternal).value ?? const SyncStatus();
+  return ref.watch(_syncStatusInternal).value ??
+      // ignore: invalid_use_of_internal_member
+      const SyncStatus.uninitialized();
 });
 
 @riverpod

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.2 (unreleased)
+
+- Fix state after calling `disconnect()` not consistently representing the correct sync status.
+
 ## 2.3.1
 
 - Fix `BucketStorage.select()` acquiring a write lock for read-only queries.

--- a/packages/powersync/lib/src/database/native/native_powersync_database.dart
+++ b/packages/powersync/lib/src/database/native/native_powersync_database.dart
@@ -74,8 +74,6 @@ final class NativePowerSyncDatabase extends BasePowerSyncDatabase {
       receiveExit.close();
       mutexServer.handleChildIsolateExit();
 
-      // Clear status apart from lastSyncedAt
-      setStatus(SyncStatus(lastSyncedAt: currentStatus.lastSyncedAt));
       abort.completeAbort();
     }
 

--- a/packages/powersync/lib/src/database/powersync_database.dart
+++ b/packages/powersync/lib/src/database/powersync_database.dart
@@ -265,10 +265,11 @@ abstract base class PowerSyncDatabase extends SqliteConnection {
   Future<void> close() async {
     // Don't close in the middle of the initialization process.
     await isInitialized;
-    // Disconnect any active sync connection.
-    await disconnect();
 
     if (!database.closed) {
+      // Disconnect any active sync connection.
+      await disconnect();
+
       devtools.handleClosed(this);
 
       // Now we can close the database
@@ -354,8 +355,7 @@ abstract base class PowerSyncDatabase extends SqliteConnection {
     await writeTransaction((tx) async {
       await tx.execute('select powersync_clear(?)', [clearLocal ? 1 : 0]);
     });
-    // The data has been deleted - reset these
-    setStatus(SyncStatus(lastSyncedAt: null, hasSynced: false));
+    await _connections.resolveOfflineSyncStatus();
   }
 
   @Deprecated('Use [disconnectAndClear] instead.')

--- a/packages/powersync/lib/src/devtools/protocol.dart
+++ b/packages/powersync/lib/src/devtools/protocol.dart
@@ -34,7 +34,6 @@ Object? serializeSyncStatus(SyncStatus status) {
     },
     'uploading': status.uploading,
     'lastSyncedAt': status.lastSyncedAt?.millisecondsSinceEpoch,
-    'hasSynced': status.hasSynced,
     'uploadError': status.uploadError?.toString(),
     'downloadError': status.downloadError?.toString(),
     'priorityStatusEntries': [

--- a/packages/powersync/lib/src/devtools/protocol.dart
+++ b/packages/powersync/lib/src/devtools/protocol.dart
@@ -71,7 +71,6 @@ SyncStatus deserializeSyncStatus(Map<String, Object?> serialized) {
     },
     uploading: serialized['uploading'] as bool,
     lastSyncedAt: readDateTime(serialized['lastSyncedAt'] as int?),
-    hasSynced: serialized['hasSynced'] as bool?,
     uploadError: serialized['uploadError'],
     downloadError: serialized['downloadError'],
     priorityStatusEntries: [

--- a/packages/powersync/lib/src/sync/connection_manager.dart
+++ b/packages/powersync/lib/src/sync/connection_manager.dart
@@ -78,9 +78,9 @@ final class ConnectionManager {
       await _abortCurrentSync();
       _subscriptionsChanged?.close();
       _subscriptionsChanged = null;
-    });
 
-    await resolveOfflineSyncStatus();
+      await resolveOfflineSyncStatus();
+    });
   }
 
   Future<void> firstStatusMatching(bool Function(SyncStatus) predicate) async {

--- a/packages/powersync/lib/src/sync/connection_manager.dart
+++ b/packages/powersync/lib/src/sync/connection_manager.dart
@@ -35,8 +35,7 @@ final class ConnectionManager {
   /// while we're connected.
   StreamController<void>? _subscriptionsChanged;
 
-  SyncStatus _currentStatus =
-      const SyncStatus(connected: false, lastSyncedAt: null);
+  SyncStatus _currentStatus = const SyncStatus.uninitialized();
 
   SyncStatus get currentStatus => _currentStatus;
   Stream<SyncStatus> get statusStream => _statusController.stream;
@@ -81,8 +80,7 @@ final class ConnectionManager {
       _subscriptionsChanged = null;
     });
 
-    manuallyChangeSyncStatus(
-        SyncStatus(connected: false, lastSyncedAt: currentStatus.lastSyncedAt));
+    await resolveOfflineSyncStatus();
   }
 
   Future<void> firstStatusMatching(bool Function(SyncStatus) predicate) async {
@@ -181,32 +179,8 @@ final class ConnectionManager {
 
   void manuallyChangeSyncStatus(SyncStatus status) {
     if (status != currentStatus) {
-      final newStatus = SyncStatus(
-        connected: status.connected,
-        downloading: status.downloading,
-        uploading: status.uploading,
-        connecting: status.connecting,
-        uploadError: status.uploadError,
-        downloadError: status.downloadError,
-        priorityStatusEntries: status.priorityStatusEntries,
-        downloadProgress: status.downloadProgress,
-        // Note that currently the streaming sync implementation will never set
-        // hasSynced. lastSyncedAt implies that syncing has completed at some
-        // point (hasSynced = true).
-        // The previous values of hasSynced should be preserved here.
-        lastSyncedAt: status.lastSyncedAt ?? currentStatus.lastSyncedAt,
-        hasSynced: status.lastSyncedAt != null
-            ? true
-            : status.hasSynced ?? currentStatus.hasSynced,
-        streamSubscriptions: status.internalSubscriptions,
-      );
-
-      // If the absence of hasSynced was the only difference, the new states
-      // would be equal and don't require an event. So, check again.
-      if (newStatus != currentStatus) {
-        _currentStatus = newStatus;
-        _statusController.add(_currentStatus);
-      }
+      _currentStatus = status;
+      _statusController.add(_currentStatus);
     }
   }
 
@@ -291,8 +265,8 @@ final class ConnectionManager {
     final status = CoreSyncStatus.fromJson(
         json.decode(row['r'] as String) as Map<String, Object?>);
 
-    manuallyChangeSyncStatus((MutableSyncStatus()..applyFromCore(status))
-        .immutableSnapshot(setLastSynced: true));
+    manuallyChangeSyncStatus(
+        (MutableSyncStatus()..applyFromCore(status)).immutableSnapshot());
   }
 
   SyncStream syncStream(String name, Map<String, Object?>? parameters) {

--- a/packages/powersync/lib/src/sync/mutable_sync_status.dart
+++ b/packages/powersync/lib/src/sync/mutable_sync_status.dart
@@ -49,7 +49,7 @@ final class MutableSyncStatus {
     streams = status.streams;
   }
 
-  SyncStatus immutableSnapshot({bool setLastSynced = false}) {
+  SyncStatus immutableSnapshot() {
     return SyncStatus(
       connected: connected,
       connecting: connecting,
@@ -58,7 +58,6 @@ final class MutableSyncStatus {
       downloadProgress: downloadProgress?.asSyncDownloadProgress,
       priorityStatusEntries: UnmodifiableListView(priorityStatusEntries),
       lastSyncedAt: lastSyncedAt,
-      hasSynced: setLastSynced ? lastSyncedAt != null : null,
       uploadError: uploadError,
       downloadError: downloadError,
       streamSubscriptions: streams,
@@ -68,7 +67,7 @@ final class MutableSyncStatus {
 
 final class SyncStatusStateStream {
   final MutableSyncStatus status = MutableSyncStatus();
-  SyncStatus _lastPublishedStatus = const SyncStatus();
+  SyncStatus _lastPublishedStatus = const SyncStatus.uninitialized();
 
   final StreamController<SyncStatus> _statusStreamController =
       StreamController<SyncStatus>.broadcast();

--- a/packages/powersync/lib/src/sync/sync_status.dart
+++ b/packages/powersync/lib/src/sync/sync_status.dart
@@ -1,3 +1,6 @@
+/// @docImport '../connector.dart';
+library;
+
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 
@@ -55,18 +58,32 @@ final class SyncStatus {
 
   @internal
   const SyncStatus({
-    this.connected = false,
-    this.connecting = false,
-    this.lastSyncedAt,
-    this.hasSynced,
-    this.downloadProgress,
-    this.downloading = false,
-    this.uploading = false,
-    this.downloadError,
-    this.uploadError,
-    this.priorityStatusEntries = const [],
-    List<CoreActiveStreamSubscription>? streamSubscriptions,
-  }) : _internalSubscriptions = streamSubscriptions;
+    required this.connected,
+    required this.connecting,
+    required this.lastSyncedAt,
+    required this.downloadProgress,
+    required this.downloading,
+    required this.uploading,
+    required this.downloadError,
+    required this.uploadError,
+    required this.priorityStatusEntries,
+    required List<CoreActiveStreamSubscription>? streamSubscriptions,
+  })  : hasSynced = lastSyncedAt != null,
+        _internalSubscriptions = streamSubscriptions;
+
+  @internal
+  const SyncStatus.uninitialized()
+      : connected = false,
+        connecting = false,
+        lastSyncedAt = null,
+        downloadProgress = null,
+        downloading = false,
+        uploading = false,
+        uploadError = null,
+        downloadError = null,
+        priorityStatusEntries = const [],
+        _internalSubscriptions = null,
+        hasSynced = null;
 
   @override
   bool operator ==(Object other) {
@@ -96,7 +113,6 @@ final class SyncStatus {
     Object? uploadError,
     Object? downloadError,
     DateTime? lastSyncedAt,
-    bool? hasSynced,
     List<SyncPriorityStatus>? priorityStatusEntries,
   }) {
     return SyncStatus(
@@ -107,9 +123,10 @@ final class SyncStatus {
       uploadError: uploadError ?? this.uploadError,
       downloadError: downloadError ?? this.downloadError,
       lastSyncedAt: lastSyncedAt ?? this.lastSyncedAt,
-      hasSynced: hasSynced ?? this.hasSynced,
       priorityStatusEntries:
           priorityStatusEntries ?? this.priorityStatusEntries,
+      downloadProgress: downloadProgress,
+      streamSubscriptions: _internalSubscriptions,
     );
   }
 

--- a/packages/powersync/lib/src/version.dart
+++ b/packages/powersync/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String libraryVersion = '2.3.1';
+const String libraryVersion = '2.3.2';

--- a/packages/powersync/lib/src/web/sync_worker_protocol.dart
+++ b/packages/powersync/lib/src/web/sync_worker_protocol.dart
@@ -316,6 +316,7 @@ extension type SerializedSyncStatus._(JSObject _) implements JSObject {
   external bool get downloading;
   external bool get uploading;
   external int? lastSyncedAt;
+  @Deprecated('Only included for backwards compatibility')
   external bool? hasSynced;
   external String? uploadError;
   external String? downloadError;

--- a/packages/powersync/lib/src/web/sync_worker_protocol.dart
+++ b/packages/powersync/lib/src/web/sync_worker_protocol.dart
@@ -334,7 +334,6 @@ extension type SerializedSyncStatus._(JSObject _) implements JSObject {
       lastSyncedAt: lastSyncedAt == null
           ? null
           : DateTime.fromMicrosecondsSinceEpoch(lastSyncedAt!),
-      hasSynced: hasSynced,
       uploadError: uploadError,
       downloadError: downloadError,
       priorityStatusEntries: <SyncPriorityStatus>[

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 2.3.1
+version: 2.3.2
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Dart and Flutter SDK. Sync Postgres, MongoDB, MySQL or SQL Server with SQLite in your app

--- a/packages/powersync/test/powersync_shared_test.dart
+++ b/packages/powersync/test/powersync_shared_test.dart
@@ -1,5 +1,6 @@
 import 'package:logging/logging.dart';
 import 'package:powersync/powersync.dart';
+import 'package:powersync/src/sync/mutable_sync_status.dart';
 import 'package:sqlite_async/sqlite_async.dart';
 import 'package:test/test.dart';
 import 'package:uuid/parsing.dart';
@@ -140,7 +141,10 @@ void main() {
         ),
       );
 
-      final status = SyncStatus(connected: true, lastSyncedAt: DateTime.now());
+      final status = (MutableSyncStatus()
+            ..connected = true
+            ..lastSyncedAt = DateTime.now())
+          .immutableSnapshot();
       db.setStatus(status);
       db.setStatus(status); // Should not re-emit!
 

--- a/packages/powersync/test/sync/in_memory_sync_test.dart
+++ b/packages/powersync/test/sync/in_memory_sync_test.dart
@@ -6,7 +6,6 @@ import 'package:logging/logging.dart';
 import 'package:powersync/powersync.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf_router/shelf_router.dart';
-import 'package:sqlite3/common.dart';
 import 'package:test/test.dart';
 
 import '../server/sync_server/in_memory_sync_server.dart';
@@ -38,7 +37,6 @@ void _declareTests(String name, SyncOptions options, bool bson) {
   group(name, () {
     late final testUtils = TestUtils();
 
-    late CommonDatabase raw;
     late TestDatabase database;
     late MockSyncService syncService;
     late Logger logger;
@@ -72,7 +70,7 @@ void _declareTests(String name, SyncOptions options, bool bson) {
       credentialsCallbackCount = 0;
       syncService = MockSyncService(useBson: bson);
 
-      (raw, database) = await testUtils.openInMemoryDatabase();
+      (_, database) = await testUtils.openInMemoryDatabase();
       await database.initialize();
     });
 
@@ -130,7 +128,11 @@ void _declareTests(String name, SyncOptions options, bool bson) {
           status, emits(isSyncStatus(downloading: false, hasSynced: true)));
       await database.disconnect();
 
-      final independentDb = testUtils.wrapRaw(raw, logger: ignoredLogger);
+      final independentDb = TestDatabase(
+        database: database.database,
+        logger: ignoredLogger,
+        schema: schema,
+      );
       addTearDown(independentDb.close);
       // Even though this database doesn't have a sync client attached to it,
       // is should reconstruct hasSynced from the database.
@@ -432,8 +434,13 @@ void _declareTests(String name, SyncOptions options, bool bson) {
         await database.waitForFirstSync(priority: StreamPriority(1));
         expect(database.currentStatus.hasSynced, isFalse);
         await database.disconnect();
+        expect(database.currentStatus.connected, isFalse);
 
-        final independentDb = testUtils.wrapRaw(raw, logger: ignoredLogger);
+        final independentDb = TestDatabase(
+          database: database.database,
+          logger: Logger.detached('PowerSync.test'),
+          schema: schema,
+        );
         addTearDown(independentDb.close);
         await independentDb.initialize();
         expect(independentDb.currentStatus.hasSynced, isFalse);

--- a/packages/powersync/test/sync/sync_status_test.dart
+++ b/packages/powersync/test/sync/sync_status_test.dart
@@ -1,40 +1,56 @@
 import 'package:powersync/powersync.dart';
+import 'package:powersync/src/sync/mutable_sync_status.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('SyncStatus.toString', () {
     test('default', () {
-      expect(SyncStatus().toString(),
+      expect(SyncStatus.uninitialized().toString(),
           'SyncStatus<connected: offline (not connecting) downloading: false (progress: null) uploading: false lastSyncedAt: null hasSynced: null error: null>');
     });
 
     test('connection status', () {
-      expect(SyncStatus(connected: true).toString(),
+      expect(
+          (MutableSyncStatus()..connected = true)
+              .immutableSnapshot()
+              .toString(),
           contains('SyncStatus<connected: true'));
-      expect(SyncStatus(connected: false, connecting: true).toString(),
+      expect(
+          (MutableSyncStatus()..connecting = true)
+              .immutableSnapshot()
+              .toString(),
           contains('SyncStatus<connected: connecting'));
-      expect(SyncStatus().toString(),
+      expect((MutableSyncStatus()).immutableSnapshot().toString(),
           contains('SyncStatus<connected: offline (not connecting)'));
     });
 
     group('errors', () {
       test('upload error', () {
-        expect(SyncStatus(uploadError: 'test').toString(),
-            contains('uploadError: test'));
+        final status =
+            (MutableSyncStatus()..uploadError = 'test').immutableSnapshot();
+
+        expect(status.toString(), contains('uploadError: test'));
       });
 
       test('download error', () {
-        expect(SyncStatus(downloadError: 'test').toString(),
-            contains('downloadError: test'));
+        final status =
+            (MutableSyncStatus()..downloadError = 'test').immutableSnapshot();
+
+        expect(status.toString(), contains('downloadError: test'));
       });
 
       test('both upload and download error', () {
-        expect(SyncStatus(uploadError: 'a', downloadError: 'b').toString(),
-            contains('downloadError: b uploadError: a'));
+        final status = (MutableSyncStatus()
+              ..uploadError = 'a'
+              ..downloadError = 'b')
+            .immutableSnapshot();
+
+        expect(status.toString(), contains('downloadError: b uploadError: a'));
       });
 
       test('no error', () {
-        expect(SyncStatus().toString(), contains('error: null'));
+        expect(MutableSyncStatus().immutableSnapshot().toString(),
+            contains('error: null'));
       });
     });
   });


### PR DESCRIPTION
With the Rust sync client, `SyncStatus` is supposed to to be managed by the core extension (apart from upload and download errors).

Still, we had a few places where we'd emit a fake sync status resetting all fields apart from `lastSyncedAt`. This is wrong, it resets sync streams even though those are still there after disconnecting and in the case of `disconnectAndClear`, it could actually cause us to report a database as synced when it's not.

To fix this, this PR:

1. Makes it much more annoying to create `SyncStatus` entries by marking all fields as required. The only place in the SDK (apart from tests) where we create a sync status now is when mapping from core state to Dart, which is the only place where we're supposed to do that.
2. Explicitly loads the offline sync status after disconnecting or clearing the database to make sure the reported sync status reflects the actual state.

AI use: Changes are manual, I ran a `/review` in Claude Code and manually fixed findings before marking this PR as ready for review.

Closes https://github.com/powersync-ja/powersync.dart/issues/440.