### PR TITLE
Fix npm package publishing

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -59,8 +59,10 @@ jobs:
           node-version: 26
           cache: pnpm
           cache-dependency-path: packages/js-assets/pnpm-lock.yaml
-      - run: pnpm build
-        working-directory: packages/js-assets
+      - working-directory: packages/js-assets
+        run: |
+          pnpm build
+          pnpm pack
 
   pana:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,8 @@ on:
       - "powersync-v[0-9]+.[0-9]+.[0-9]+*"
       - "powersync_attachments_helper-v[0-9]+.[0-9]+.[0-9]+*"
       - "powersync_flutter_libs-v[0-9]+.[0-9]+.[0-9]+*"
+    branches:
+      - pnpm-publish-no-git-checks
   workflow_dispatch:
 
 permissions: {}
@@ -70,7 +72,7 @@ jobs:
     needs: [setup]
     permissions:
       id-token: write # Needed to create an OIDC token for npm
-    if: "${{ startsWith(github.ref_name, 'powersync-') }}"
+    #if: "${{ startsWith(github.ref_name, 'powersync-') }}"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -86,7 +88,7 @@ jobs:
           package-manager-cache: false
       - run: pnpm build
         working-directory: packages/js-assets
-      - run: pnpm publish
+      - run: pnpm publish --no-git-checks
         working-directory: packages/js-assets
 
   publish_powersync_flutter_libs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,8 +5,6 @@ on:
       - "powersync-v[0-9]+.[0-9]+.[0-9]+*"
       - "powersync_attachments_helper-v[0-9]+.[0-9]+.[0-9]+*"
       - "powersync_flutter_libs-v[0-9]+.[0-9]+.[0-9]+*"
-    branches:
-      - pnpm-publish-no-git-checks
   workflow_dispatch:
 
 permissions: {}
@@ -72,7 +70,7 @@ jobs:
     needs: [setup]
     permissions:
       id-token: write # Needed to create an OIDC token for npm
-    #if: "${{ startsWith(github.ref_name, 'powersync-') }}"
+    if: "${{ startsWith(github.ref_name, 'powersync-') }}"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,8 +88,10 @@ jobs:
           package-manager-cache: false
       - run: pnpm build
         working-directory: packages/js-assets
-      - run: pnpm publish --no-git-checks
-        working-directory: packages/js-assets
+      - working-directory: packages/js-assets
+        run: |
+          pnpm pack
+          npm publish powersync-dart-wasm-bundles-*.tgz
 
   publish_powersync_flutter_libs:
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,8 @@ on:
       - "powersync-v[0-9]+.[0-9]+.[0-9]+*"
       - "powersync_attachments_helper-v[0-9]+.[0-9]+.[0-9]+*"
       - "powersync_flutter_libs-v[0-9]+.[0-9]+.[0-9]+*"
+    branches:
+      - pnpm-publish-no-git-checks
   workflow_dispatch:
 
 permissions: {}
@@ -70,7 +72,7 @@ jobs:
     needs: [setup]
     permissions:
       id-token: write # Needed to create an OIDC token for npm
-    if: "${{ startsWith(github.ref_name, 'powersync-') }}"
+    #if: "${{ startsWith(github.ref_name, 'powersync-') }}"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,10 +88,8 @@ jobs:
           package-manager-cache: false
       - run: pnpm build
         working-directory: packages/js-assets
-      - working-directory: packages/js-assets
-        run: |
-          pnpm pack
-          npm publish powersync-dart-wasm-bundles-*.tgz
+      - run: pnpm publish --no-git-checks
+        working-directory: packages/js-assets
 
   publish_powersync_flutter_libs:
     permissions:

--- a/packages/js-assets/package.json
+++ b/packages/js-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powersync/dart-wasm-bundles",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Pre-compiled PowerSync Dart SDK assets.",
   "type": "module",
   "publishConfig": {
@@ -13,7 +13,7 @@
     "./sqlite3mc.wasm": "./dist/sqlite3mc.wasm"
   },
   "scripts": {
-    "copy:assets": "cp -r ../powersync/assets/ dist",
+    "copy:assets": "cp -r ../powersync/assets/* dist",
     "build": "pnpm copy:assets"
   },
   "files": [

--- a/packages/js-assets/package.json
+++ b/packages/js-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powersync/dart-wasm-bundles",
-  "version": "2.3.2",
+  "version": "2.3.1",
   "description": "Pre-compiled PowerSync Dart SDK assets.",
   "type": "module",
   "publishConfig": {


### PR DESCRIPTION
Jus before we publish the npm package, we copy compiled workers and WebAssembly modules into `dist/`. `pnpm publish` checks for a clean git state by default, which doesn't work with the copied assets. This adds `--no-git-checks` to allow publishing.

This also fixes the build script to copy assets directly into `dist` instead of an `assets` subdirectory. The original command worked with fish when building the package locally, but doesn't seem to work in CI. 