### PR TITLE
Allow calling `disconnect()` on closed databases

### DIFF
--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.3.3
 
+- Restore the ability to call `disconnect()` on closed databases.
 - Internal: Update PowerSync SQLite core extension to latest version.
 
 ## 2.3.2

--- a/packages/powersync/lib/src/database/powersync_database.dart
+++ b/packages/powersync/lib/src/database/powersync_database.dart
@@ -339,7 +339,9 @@ abstract base class PowerSyncDatabase extends SqliteConnection {
   ///
   /// Use [connect] to connect again.
   Future<void> disconnect() async {
-    await _connections.disconnect();
+    if (!database.closed) {
+      await _connections.disconnect();
+    }
   }
 
   /// Disconnect and clear the database.

--- a/packages/powersync/test/sync/in_memory_sync_test.dart
+++ b/packages/powersync/test/sync/in_memory_sync_test.dart
@@ -988,5 +988,16 @@ void _declareTests(String name, SyncOptions options, bool bson) {
         expect(database.currentStatus.anyError, isNull);
       });
     });
+
+    test('can call disconnect on closed database', () async {
+      // Regression test for https://github.com/powersync-ja/powersync.dart/issues/448,
+      // calling disconnect() on a closed database should be a harmless no-op.
+      final status = await waitForConnection();
+      await database.close();
+      await expectLater(status, emitsThrough(isSyncStatus(connected: false)));
+      await expectLater(status, emitsDone);
+
+      await database.disconnect();
+    });
   });
 }


### PR DESCRIPTION
In https://github.com/powersync-ja/powersync.dart/pull/441, we've started calling the `powersync_offline_sync_status()` SQL function after disconnecting to fetch the updated sync status which is disconnected, but still contains current sync streams. That broke the ability to call `disconnect()` on closed databases, which worked before.

We disconnect in `close()` and a closed database can't be connected, so doing nothing restores the old behavior.

Closes https://github.com/powersync-ja/powersync.dart/issues/448