### PR TITLE
Dont crash on unsendable errors

### DIFF
--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.3.4 (unreleased)
 
 - Reduce log noise from attachments service ([#408](https://github.com/powersync-ja/powersync.dart/issues/408)).
+- Fix errors that can't be sent across isolates disrupting the sync isolate.
 
 ## 2.3.3
 

--- a/packages/powersync/lib/src/database/native/native_powersync_database.dart
+++ b/packages/powersync/lib/src/database/native/native_powersync_database.dart
@@ -114,7 +114,25 @@ final class NativePowerSyncDatabase extends BasePowerSyncDatabase {
             await connector.uploadData(this);
           });
         case SyncIsolateToClientMessageType.status:
-          setStatus(payload as SyncStatus);
+          final original = payload as SyncStatus;
+          final recoveredDownloadError = switch (original.downloadError) {
+            final SerializedError e => e.recoverError(),
+            _ => null,
+          };
+          final recoveredUploadError = switch (original.uploadError) {
+            final SerializedError e => e.recoverError(),
+            _ => null,
+          };
+
+          if (recoveredUploadError != null || recoveredDownloadError != null) {
+            setStatus(payload.changeErrors(
+              uploadError: recoveredUploadError ?? payload.uploadError,
+              downloadError: recoveredDownloadError ?? payload.downloadError,
+            ));
+          } else {
+            setStatus(payload);
+          }
+
         case SyncIsolateToClientMessageType.log:
           LogRecord record = payload as LogRecord;
           logger.log(

--- a/packages/powersync/lib/src/database/native/native_powersync_database.dart
+++ b/packages/powersync/lib/src/database/native/native_powersync_database.dart
@@ -233,11 +233,14 @@ Future<void> _syncIsolate(_PowerSyncDatabaseIsolateArgs args) async {
   Future<void> shutdown() {
     if (!shutdownCompleter.isCompleted) {
       shutdownCompleter.complete(Future(() async {
+        // Closing this makes pending requests complete with an exception. Good,
+        // we only use this to acquire mutexes and interact with backend
+        // connectors, and we're about to abort that anyway.
+        results.close();
+
         await openedStreamingSync?.abort();
         await database.close();
-
         rPort.close();
-        results.close();
       }));
     }
 

--- a/packages/powersync/lib/src/database/native/native_powersync_database.dart
+++ b/packages/powersync/lib/src/database/native/native_powersync_database.dart
@@ -233,14 +233,11 @@ Future<void> _syncIsolate(_PowerSyncDatabaseIsolateArgs args) async {
   Future<void> shutdown() {
     if (!shutdownCompleter.isCompleted) {
       shutdownCompleter.complete(Future(() async {
-        // Closing this makes pending requests complete with an exception. Good,
-        // we only use this to acquire mutexes and interact with backend
-        // connectors, and we're about to abort that anyway.
-        results.close();
-
         await openedStreamingSync?.abort();
         await database.close();
+
         rPort.close();
+        results.close();
       }));
     }
 

--- a/packages/powersync/lib/src/isolate_completer.dart
+++ b/packages/powersync/lib/src/isolate_completer.dart
@@ -62,17 +62,63 @@ class IsolateResult<T> {
 
 const abortedResponse = 'aborted';
 
+/// An exception or error that couldn't be sent across isolates and thus needs
+/// to be serialized.
+///
+/// For these errors, we send their [Object.toString] representation across
+/// isolates, along with a [Capability] that stays the same when sent across
+/// ports (and, on the isolate originally throwing the error, can be used to
+/// reconstruct the error).
+final class SerializedError {
+  /// A capability, owned by the isolate on which the error was thrown, that can
+  /// be used to reconstruct the original error.
+  final Capability token;
+
+  /// The original error message of the error.
+  final String message;
+
+  SerializedError._(this.token, this.message);
+
+  factory SerializedError(Object error) {
+    final cap = Capability();
+    _capturedErrors[cap] = error;
+
+    return SerializedError._(cap, error.toString());
+  }
+
+  @override
+  String toString() => message;
+
+  /// Attempts to recover the original error object that couldn't be serialized.
+  ///
+  /// When called on the isolate where the error was first thrown, this can
+  /// return the original error (instead of just having the message available).
+  Object? recoverError() {
+    return _capturedErrors[token];
+  }
+
+  // Weak map from capabilities created on this isolate to the error they
+  // represent.
+  static final _capturedErrors = Expando();
+}
+
 class PortCompleter<T> {
   final SendPort sendPort;
 
   PortCompleter(this.sendPort);
 
-  void complete([FutureOr<T>? value]) {
+  void complete([T? value]) {
     sendPort.send(PortResult.success(value));
   }
 
   void completeError(Object error, [StackTrace? stackTrace]) {
-    sendPort.send(PortResult<void>.error(error, stackTrace));
+    try {
+      sendPort.send(PortResult<void>.error(error, stackTrace));
+    } on Object {
+      // The error can't be sent across ports directly. Send a serialized copy
+      // of it instead.
+      sendPort.send(PortResult<void>.error(SerializedError(error), stackTrace));
+    }
   }
 
   Future<void> handle(FutureOr<T> Function() callback,

--- a/packages/powersync/lib/src/sync/sync_status.dart
+++ b/packages/powersync/lib/src/sync/sync_status.dart
@@ -258,6 +258,22 @@ final class SyncStatus {
 extension InternalSyncStatusAccess on SyncStatus {
   List<CoreActiveStreamSubscription>? get internalSubscriptions =>
       _internalSubscriptions;
+
+  SyncStatus changeErrors(
+      {required Object? downloadError, required Object? uploadError}) {
+    return SyncStatus(
+      connected: connected,
+      connecting: connecting,
+      lastSyncedAt: lastSyncedAt,
+      downloadProgress: downloadProgress,
+      downloading: downloading,
+      uploading: uploading,
+      downloadError: downloadError,
+      uploadError: uploadError,
+      priorityStatusEntries: priorityStatusEntries,
+      streamSubscriptions: _internalSubscriptions,
+    );
+  }
 }
 
 /// Current information about a [SyncStream] that the sync client is subscribed

--- a/packages/powersync/test/isolate_completer_test.dart
+++ b/packages/powersync/test/isolate_completer_test.dart
@@ -84,5 +84,31 @@ void main() {
 
       await expectLater(result.future, throwsArgumentError);
     });
+
+    test('can serialize unsendable exceptions', () async {
+      final result = collection.createPending<int>();
+      final unsendable = _UnsendableException();
+      result.completer.completeError(unsendable);
+
+      final SerializedError caught;
+      try {
+        await result.future;
+        fail('Expected error');
+      } on SerializedError catch (e) {
+        caught = e;
+      }
+
+      // Should forward inner error.
+      expect(caught.toString(), 'unsendable error');
+      expect(caught.recoverError(), unsendable);
+    });
   });
+}
+
+class _UnsendableException implements Exception {
+  // ignore: unused_field
+  final Object _unsendable = Completer<void>();
+
+  @override
+  String toString() => 'unsendable error';
 }

--- a/packages/powersync/test/sync/streaming_sync_test.dart
+++ b/packages/powersync/test/sync/streaming_sync_test.dart
@@ -256,6 +256,35 @@ void main() {
 
       expect(pdb.currentStatus.downloadError, exception);
     });
+
+    test('recovers from stuck fetchCredentials call', () async {
+      final pdb = await testUtils.setupPowerSync(path: path);
+      final server = await createServer();
+      final statusChanges = StreamQueue(pdb.statusStream);
+
+      // First, connect with a broken connector that never completes its
+      // fetchCredentials call.
+      await pdb.connect(
+        connector:
+            TestConnector(() => Completer<PowerSyncCredentials>().future),
+      );
+      await expectLater(
+          statusChanges,
+          emitsThrough(isA<SyncStatus>()
+              .having((e) => e.connecting, 'connecting', isTrue)));
+
+      // Disconnect in this stuck state, then reconnect with a proper connector.
+      await pdb.disconnect();
+      await pdb.connect(
+          connector: TestConnector(() async =>
+              PowerSyncCredentials(endpoint: server.endpoint, token: 'token')));
+
+      await expectLater(
+          statusChanges,
+          emitsThrough(isA<SyncStatus>()
+              .having((e) => e.connected, 'connected', isTrue)));
+      await statusChanges.cancel();
+    });
   });
 }
 

--- a/packages/powersync/test/sync/streaming_sync_test.dart
+++ b/packages/powersync/test/sync/streaming_sync_test.dart
@@ -256,35 +256,6 @@ void main() {
 
       expect(pdb.currentStatus.downloadError, exception);
     });
-
-    test('recovers from stuck fetchCredentials call', () async {
-      final pdb = await testUtils.setupPowerSync(path: path);
-      final server = await createServer();
-      final statusChanges = StreamQueue(pdb.statusStream);
-
-      // First, connect with a broken connector that never completes its
-      // fetchCredentials call.
-      await pdb.connect(
-        connector:
-            TestConnector(() => Completer<PowerSyncCredentials>().future),
-      );
-      await expectLater(
-          statusChanges,
-          emitsThrough(isA<SyncStatus>()
-              .having((e) => e.connecting, 'connecting', isTrue)));
-
-      // Disconnect in this stuck state, then reconnect with a proper connector.
-      await pdb.disconnect();
-      await pdb.connect(
-          connector: TestConnector(() async =>
-              PowerSyncCredentials(endpoint: server.endpoint, token: 'token')));
-
-      await expectLater(
-          statusChanges,
-          emitsThrough(isA<SyncStatus>()
-              .having((e) => e.connected, 'connected', isTrue)));
-      await statusChanges.cancel();
-    });
   });
 }
 

--- a/packages/powersync/test/sync/streaming_sync_test.dart
+++ b/packages/powersync/test/sync/streaming_sync_test.dart
@@ -5,6 +5,7 @@ library;
 import 'dart:async';
 import 'dart:math';
 
+import 'package:async/async.dart';
 import 'package:logging/logging.dart';
 import 'package:powersync/powersync.dart';
 import 'package:test/test.dart';
@@ -239,5 +240,29 @@ void main() {
 
       server.close();
     });
+
+    test('can report unsendable errors in sync status', () async {
+      final pdb = await testUtils.setupPowerSync(path: path);
+      final exception = _UnsendableException();
+
+      final connector = TestConnector(() async => throw exception);
+      final statusChanges = StreamQueue(pdb.statusStream);
+      await pdb.connect(connector: connector);
+      await expectLater(
+          statusChanges,
+          emitsThrough(isA<SyncStatus>()
+              .having((e) => e.downloadError, 'downloadError', isNotNull)));
+      await statusChanges.cancel();
+
+      expect(pdb.currentStatus.downloadError, exception);
+    });
   });
+}
+
+class _UnsendableException implements Exception {
+  // ignore: unused_field
+  final Object _unsendable = Completer<void>();
+
+  @override
+  String toString() => 'fetchCredentials failed';
 }


### PR DESCRIPTION
This fixes an issue where a backend connector throwing an exception that can't be sent across isolates causes the sync isolate to become stuck.

This can happen for errors that include an asynchronous primitive like `Completer`, which is the case for some errors thrown by the popular `dio` package for http requests. Sending these across ports throws, so `PortCompleter.completeError` would fail without ever sending the error to the sync isolate. That then causes the sync isolate to wait for a response indefinitely, blocking even `disconnect()` requests.

To fix this, we send a serialized `toString()` representation if the original error is unsendable. We also use capabilities (a special object that comes back unchanged when sent across isolates) and a weak map to recover the underlying error on the main isolate after it shows up as an `uploadError` / `downloadError`. 

