### PR TITLE
Support immutable releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,9 +35,10 @@ jobs:
           changes=$(awk "/## $version/{flag=1;next}/##/{flag=0}flag" packages/powersync/CHANGELOG.md)
           body="Release $tag
           $changes"
-          gh release create "$tag" --title "$tag" --notes "$body"
-          gh release upload "${GITHUB_REF_NAME}" packages/powersync/assets/*.wasm
-          gh release upload "${GITHUB_REF_NAME}" packages/powersync/assets/powersync_db.worker.js
+          gh release create "$tag" --title "$tag" --notes "$body" --draft
+          gh release upload "$tag" packages/powersync/assets/*.wasm
+          gh release upload "$tag" packages/powersync/assets/powersync_db.worker.js
+          gh release edit "$tag" --draft=false
 
   publish_powersync:
     needs: [setup]


### PR DESCRIPTION
Currently, we upload files after creating a release on GitHub. This is incompatible with immutable releases, which only allow changing attachments while in a draft state.

This changes the release process to first create a draft release, then upload the relevant files, and finally clear the draft status.