### PR TITLE
Upgrade Flutter

### DIFF
--- a/demos/benchmarks/lib/main.dart
+++ b/demos/benchmarks/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:logging/logging.dart';
 
 import './powersync.dart';

--- a/demos/benchmarks/lib/widgets/benchmark_item_widget.dart
+++ b/demos/benchmarks/lib/widgets/benchmark_item_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../models/benchmark_item.dart';
 

--- a/demos/benchmarks/lib/widgets/benchmark_items_page.dart
+++ b/demos/benchmarks/lib/widgets/benchmark_items_page.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import 'benchmark_item_widget.dart';
 import '../main.dart';

--- a/demos/benchmarks/lib/widgets/query_widget.dart
+++ b/demos/benchmarks/lib/widgets/query_widget.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:sqlite3/common.dart' as sqlite;
 
 import './resultset_table.dart';

--- a/demos/benchmarks/lib/widgets/resultset_table.dart
+++ b/demos/benchmarks/lib/widgets/resultset_table.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:sqlite3/common.dart' as sqlite;
 
 /// Stateless DataTable rendering results from a SQLite query

--- a/demos/benchmarks/lib/widgets/status_app_bar.dart
+++ b/demos/benchmarks/lib/widgets/status_app_bar.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:powersync/powersync.dart';
 import '../powersync.dart';
 

--- a/demos/benchmarks/pubspec.yaml
+++ b/demos/benchmarks/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   sqlite_async: ^0.14.0
   sqlite3: ^3.2.0
   http: ^1.2.2
+  material_ui: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/demos/django-todolist/lib/main.dart
+++ b/demos/django-todolist/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:logging/logging.dart';
 import 'package:powersync_django_todolist_demo/models/schema.dart';
 

--- a/demos/django-todolist/lib/widgets/fts_search_delegate.dart
+++ b/demos/django-todolist/lib/widgets/fts_search_delegate.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:logging/logging.dart';
 import 'package:powersync_django_todolist_demo/fts_helpers.dart' as fts_helpers;
 import 'package:powersync_django_todolist_demo/models/todo_list.dart';

--- a/demos/django-todolist/lib/widgets/guard_by_sync.dart
+++ b/demos/django-todolist/lib/widgets/guard_by_sync.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:powersync/powersync.dart' hide Column;
 import 'package:powersync_django_todolist_demo/powersync.dart';
 

--- a/demos/django-todolist/lib/widgets/list_item.dart
+++ b/demos/django-todolist/lib/widgets/list_item.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import './todo_list_page.dart';
 import '../models/todo_list.dart';

--- a/demos/django-todolist/lib/widgets/list_item_dialog.dart
+++ b/demos/django-todolist/lib/widgets/list_item_dialog.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../models/todo_list.dart';
 

--- a/demos/django-todolist/lib/widgets/lists_page.dart
+++ b/demos/django-todolist/lib/widgets/lists_page.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import './list_item.dart';
 import './list_item_dialog.dart';

--- a/demos/django-todolist/lib/widgets/login_page.dart
+++ b/demos/django-todolist/lib/widgets/login_page.dart
@@ -1,5 +1,5 @@
 import 'dart:convert';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:powersync_django_todolist_demo/api_client.dart';
 import 'package:powersync_django_todolist_demo/app_config.dart';
 import 'package:powersync_django_todolist_demo/powersync.dart';

--- a/demos/django-todolist/lib/widgets/query_widget.dart
+++ b/demos/django-todolist/lib/widgets/query_widget.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:sqlite3/common.dart' as sqlite;
 
 import './resultset_table.dart';

--- a/demos/django-todolist/lib/widgets/resultset_table.dart
+++ b/demos/django-todolist/lib/widgets/resultset_table.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:sqlite3/common.dart' as sqlite;
 
 /// Stateless DataTable rendering results from a SQLite query

--- a/demos/django-todolist/lib/widgets/status_app_bar.dart
+++ b/demos/django-todolist/lib/widgets/status_app_bar.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:powersync/powersync.dart';
 import 'package:powersync_django_todolist_demo/widgets/fts_search_delegate.dart';
 import '../powersync.dart';

--- a/demos/django-todolist/lib/widgets/todo_item_dialog.dart
+++ b/demos/django-todolist/lib/widgets/todo_item_dialog.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../models/todo_list.dart';
 

--- a/demos/django-todolist/lib/widgets/todo_item_widget.dart
+++ b/demos/django-todolist/lib/widgets/todo_item_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../models/todo_item.dart';
 

--- a/demos/django-todolist/lib/widgets/todo_list_page.dart
+++ b/demos/django-todolist/lib/widgets/todo_list_page.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import './status_app_bar.dart';
 import './todo_item_dialog.dart';

--- a/demos/django-todolist/pubspec.yaml
+++ b/demos/django-todolist/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   sqlite3:  ^3.2.0
   http: ^1.2.1
   shared_preferences: ^2.2.3
+  material_ui: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/demos/firebase-nodejs-todolist/lib/main.dart
+++ b/demos/firebase-nodejs-todolist/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:logging/logging.dart';
 import './powersync.dart';
 

--- a/demos/firebase-nodejs-todolist/lib/widgets/list_item.dart
+++ b/demos/firebase-nodejs-todolist/lib/widgets/list_item.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import './todo_list_page.dart';
 import '../models/todo_list.dart';

--- a/demos/firebase-nodejs-todolist/lib/widgets/list_item_dialog.dart
+++ b/demos/firebase-nodejs-todolist/lib/widgets/list_item_dialog.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../models/todo_list.dart';
 

--- a/demos/firebase-nodejs-todolist/lib/widgets/lists_page.dart
+++ b/demos/firebase-nodejs-todolist/lib/widgets/lists_page.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../powersync.dart';
 import './list_item.dart';

--- a/demos/firebase-nodejs-todolist/lib/widgets/login_page.dart
+++ b/demos/firebase-nodejs-todolist/lib/widgets/login_page.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../main.dart';
 

--- a/demos/firebase-nodejs-todolist/lib/widgets/query_widget.dart
+++ b/demos/firebase-nodejs-todolist/lib/widgets/query_widget.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:sqlite3/common.dart' as sqlite;
 
 import './resultset_table.dart';

--- a/demos/firebase-nodejs-todolist/lib/widgets/resultset_table.dart
+++ b/demos/firebase-nodejs-todolist/lib/widgets/resultset_table.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:sqlite3/common.dart' as sqlite;
 
 /// Stateless DataTable rendering results from a SQLite query

--- a/demos/firebase-nodejs-todolist/lib/widgets/signup_page.dart
+++ b/demos/firebase-nodejs-todolist/lib/widgets/signup_page.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../main.dart';
 

--- a/demos/firebase-nodejs-todolist/lib/widgets/status_app_bar.dart
+++ b/demos/firebase-nodejs-todolist/lib/widgets/status_app_bar.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:powersync/powersync.dart';
 import '../powersync.dart';
 

--- a/demos/firebase-nodejs-todolist/lib/widgets/todo_item_dialog.dart
+++ b/demos/firebase-nodejs-todolist/lib/widgets/todo_item_dialog.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../models/todo_list.dart';
 

--- a/demos/firebase-nodejs-todolist/lib/widgets/todo_item_widget.dart
+++ b/demos/firebase-nodejs-todolist/lib/widgets/todo_item_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../models/todo_item.dart';
 

--- a/demos/firebase-nodejs-todolist/lib/widgets/todo_list_page.dart
+++ b/demos/firebase-nodejs-todolist/lib/widgets/todo_list_page.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import './status_app_bar.dart';
 import './todo_item_dialog.dart';

--- a/demos/firebase-nodejs-todolist/pubspec.yaml
+++ b/demos/firebase-nodejs-todolist/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   firebase_core: ^4.6.0
   firebase_auth: ^6.3.0
   http: ^1.2.2
+  material_ui: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/demos/supabase-anonymous-auth/lib/main.dart
+++ b/demos/supabase-anonymous-auth/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:logging/logging.dart';
 
 import './powersync.dart';

--- a/demos/supabase-anonymous-auth/lib/widgets/home_page.dart
+++ b/demos/supabase-anonymous-auth/lib/widgets/home_page.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../main.dart';
 

--- a/demos/supabase-anonymous-auth/lib/widgets/status_app_bar.dart
+++ b/demos/supabase-anonymous-auth/lib/widgets/status_app_bar.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:powersync/powersync.dart';
 import '../powersync.dart';
 

--- a/demos/supabase-anonymous-auth/pubspec.yaml
+++ b/demos/supabase-anonymous-auth/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   logging: ^1.2.0
   sqlite_async: ^0.14.0
   universal_io: ^2.2.2
+  material_ui: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/demos/supabase-edge-function-auth/lib/main.dart
+++ b/demos/supabase-edge-function-auth/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:logging/logging.dart';
 import 'package:supabase_jwt_auth/widgets/home_page.dart';
 

--- a/demos/supabase-edge-function-auth/lib/widgets/home_page.dart
+++ b/demos/supabase-edge-function-auth/lib/widgets/home_page.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../main.dart';
 

--- a/demos/supabase-edge-function-auth/lib/widgets/login_page.dart
+++ b/demos/supabase-edge-function-auth/lib/widgets/login_page.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../main.dart';

--- a/demos/supabase-edge-function-auth/lib/widgets/signup_page.dart
+++ b/demos/supabase-edge-function-auth/lib/widgets/signup_page.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../main.dart';

--- a/demos/supabase-edge-function-auth/lib/widgets/status_app_bar.dart
+++ b/demos/supabase-edge-function-auth/lib/widgets/status_app_bar.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:powersync/powersync.dart';
 import '../powersync.dart';
 

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   logging: ^1.2.0
   sqlite_async: ^0.14.0
   universal_io: ^2.2.2
+  material_ui: any
 
 dev_dependencies:
   flutter_test:

--- a/demos/supabase-edge-function-auth/pubspec.yaml
+++ b/demos/supabase-edge-function-auth/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   logging: ^1.2.0
   sqlite_async: ^0.14.0
   universal_io: ^2.2.2
-  material_ui: any
+  material_ui: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/demos/supabase-simple-chat/lib/main.dart
+++ b/demos/supabase-simple-chat/lib/main.dart
@@ -1,6 +1,6 @@
 // ignore_for_file: avoid_print
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import './utils/constants.dart';
 import './pages/splash_page.dart';
 import './powersync.dart';

--- a/demos/supabase-simple-chat/lib/pages/chat_page.dart
+++ b/demos/supabase-simple-chat/lib/pages/chat_page.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../models/message.dart';
 import '../models/profile.dart';

--- a/demos/supabase-simple-chat/lib/pages/login_page.dart
+++ b/demos/supabase-simple-chat/lib/pages/login_page.dart
@@ -1,6 +1,6 @@
 // ignore_for_file: use_build_context_synchronously
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import './chat_page.dart';
 import '../utils/constants.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';

--- a/demos/supabase-simple-chat/lib/pages/register_page.dart
+++ b/demos/supabase-simple-chat/lib/pages/register_page.dart
@@ -1,6 +1,6 @@
 // ignore_for_file: use_build_context_synchronously
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import './chat_page.dart';
 import './login_page.dart';
 import '../utils/constants.dart';

--- a/demos/supabase-simple-chat/lib/pages/splash_page.dart
+++ b/demos/supabase-simple-chat/lib/pages/splash_page.dart
@@ -1,6 +1,6 @@
 // ignore_for_file: use_build_context_synchronously
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import './chat_page.dart';
 import './register_page.dart';
 import '../utils/constants.dart';

--- a/demos/supabase-simple-chat/lib/utils/constants.dart
+++ b/demos/supabase-simple-chat/lib/utils/constants.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 /// Supabase client

--- a/demos/supabase-simple-chat/pubspec.yaml
+++ b/demos/supabase-simple-chat/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   path: ^1.8.3
   logging: ^1.2.0
   universal_io: ^2.2.2
+  material_ui: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/demos/supabase-todolist-drift/lib/components/app_bar.dart
+++ b/demos/supabase-todolist-drift/lib/components/app_bar.dart
@@ -1,6 +1,6 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:powersync/powersync.dart';
 

--- a/demos/supabase-todolist-drift/lib/components/app_bar.dart
+++ b/demos/supabase-todolist-drift/lib/components/app_bar.dart
@@ -74,3 +74,71 @@ Widget _getStatusIcon(SyncStatus status) {
     return _makeIcon('Connected', Icons.cloud_queue);
   }
 }
+
+/// A port of `auto_route`'s` `AutoLeadingButton` that works with the standalone
+/// `material_ui` package.
+class AutoLeadingButton extends StatefulWidget {
+  const AutoLeadingButton({super.key});
+
+  @override
+  State<AutoLeadingButton> createState() => _AutoLeadingButtonState();
+}
+
+class _AutoLeadingButtonState extends State<AutoLeadingButton> {
+  late final PagelessRoutesObserver _pagelessRoutesObserver;
+
+  @override
+  void initState() {
+    super.initState();
+    _pagelessRoutesObserver = AutoRouter.of(context).pagelessRoutesObserver;
+    _pagelessRoutesObserver.addListener(_handleRebuild);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _pagelessRoutesObserver.removeListener(_handleRebuild);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scope = RouterScope.of(context, watch: true);
+    Widget? leading;
+    if (scope.controller.canPop()) {
+      final topPage = scope.controller.topPage;
+      final useCloseButton = topPage?.fullscreenDialog ?? false;
+      leading = useCloseButton
+          ? CloseButton(
+              key: const ValueKey(LeadingType.close),
+              onPressed: scope.controller.maybePopTop,
+            )
+          : BackButton(
+              key: const ValueKey(LeadingType.back),
+              onPressed: scope.controller.maybePopTop,
+            );
+    }
+    final ScaffoldState? scaffold = Scaffold.maybeOf(context);
+    if (scaffold?.hasDrawer == true) {
+      leading = IconButton(
+        key: const ValueKey(LeadingType.drawer),
+        icon: const Icon(Icons.menu),
+        iconSize: Theme.of(context).iconTheme.size ?? 24,
+        onPressed: _handleDrawerButton,
+        tooltip: MaterialLocalizations.of(context).openAppDrawerTooltip,
+      );
+    }
+
+    return leading ??
+        const SizedBox.shrink(
+          key: ValueKey(LeadingType.noLeading),
+        );
+  }
+
+  void _handleDrawerButton() {
+    Scaffold.of(context).openDrawer();
+  }
+
+  void _handleRebuild() {
+    setState(() {});
+  }
+}

--- a/demos/supabase-todolist-drift/lib/components/page_layout.dart
+++ b/demos/supabase-todolist-drift/lib/components/page_layout.dart
@@ -1,5 +1,5 @@
 import 'package:auto_route/auto_route.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../navigation.gr.dart';

--- a/demos/supabase-todolist-drift/lib/components/photo_widget.dart
+++ b/demos/supabase-todolist-drift/lib/components/photo_widget.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:auto_route/auto_route.dart';
 import 'package:camera/camera.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:powersync_attachments_helper/powersync_attachments_helper.dart';

--- a/demos/supabase-todolist-drift/lib/main.dart
+++ b/demos/supabase-todolist-drift/lib/main.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:logging/logging.dart';

--- a/demos/supabase-todolist-drift/lib/navigation.dart
+++ b/demos/supabase-todolist-drift/lib/navigation.dart
@@ -1,5 +1,5 @@
 import 'package:auto_route/auto_route.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'navigation.gr.dart';

--- a/demos/supabase-todolist-drift/lib/powersync/database.drift.dart
+++ b/demos/supabase-todolist-drift/lib/powersync/database.drift.dart
@@ -41,13 +41,7 @@ final class $$TodoItemsTableReferences extends i0
   static i1.$ListItemsTable _listIdTable(i0.GeneratedDatabase db) =>
       i3.ReadDatabaseContainer(db)
           .resultSet<i1.$ListItemsTable>('lists')
-          .createAlias(i0.$_aliasNameGenerator(
-              i3.ReadDatabaseContainer(db)
-                  .resultSet<i1.$TodoItemsTable>('todos')
-                  .listId,
-              i3.ReadDatabaseContainer(db)
-                  .resultSet<i1.$ListItemsTable>('lists')
-                  .id));
+          .createAlias('todos__list_id__lists__id');
 
   i1.$$ListItemsTableProcessedTableManager get listId {
     final $_column = $_itemColumn<String>('list_id')!;
@@ -395,13 +389,7 @@ final class $$ListItemsTableReferences extends i0
           i0.MultiTypedResultKey.fromTable(
               i3.ReadDatabaseContainer(db)
                   .resultSet<i1.$TodoItemsTable>('todos'),
-              aliasName: i0.$_aliasNameGenerator(
-                  i3.ReadDatabaseContainer(db)
-                      .resultSet<i1.$ListItemsTable>('lists')
-                      .id,
-                  i3.ReadDatabaseContainer(db)
-                      .resultSet<i1.$TodoItemsTable>('todos')
-                      .listId));
+              aliasName: 'lists__id__todos__list_id');
 
   i1.$$TodoItemsTableProcessedTableManager get todoItemsRefs {
     final manager = i1

--- a/demos/supabase-todolist-drift/lib/screens/add_item_dialog.dart
+++ b/demos/supabase-todolist-drift/lib/screens/add_item_dialog.dart
@@ -1,5 +1,5 @@
 import 'package:auto_route/auto_route.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 

--- a/demos/supabase-todolist-drift/lib/screens/add_list_dialog.dart
+++ b/demos/supabase-todolist-drift/lib/screens/add_list_dialog.dart
@@ -1,5 +1,5 @@
 import 'package:auto_route/auto_route.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 

--- a/demos/supabase-todolist-drift/lib/screens/list_details.dart
+++ b/demos/supabase-todolist-drift/lib/screens/list_details.dart
@@ -1,5 +1,5 @@
 import 'package:auto_route/auto_route.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../app_config.dart';

--- a/demos/supabase-todolist-drift/lib/screens/lists.dart
+++ b/demos/supabase-todolist-drift/lib/screens/lists.dart
@@ -1,5 +1,5 @@
 import 'package:auto_route/auto_route.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:powersync/powersync.dart' hide Column;
 

--- a/demos/supabase-todolist-drift/lib/screens/login.dart
+++ b/demos/supabase-todolist-drift/lib/screens/login.dart
@@ -1,5 +1,5 @@
 import 'package:auto_route/annotations.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 

--- a/demos/supabase-todolist-drift/lib/screens/search.dart
+++ b/demos/supabase-todolist-drift/lib/screens/search.dart
@@ -1,5 +1,5 @@
 import 'package:auto_route/auto_route.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';

--- a/demos/supabase-todolist-drift/lib/screens/signup.dart
+++ b/demos/supabase-todolist-drift/lib/screens/signup.dart
@@ -1,5 +1,5 @@
 import 'package:auto_route/auto_route.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 

--- a/demos/supabase-todolist-drift/lib/screens/sql_console.dart
+++ b/demos/supabase-todolist-drift/lib/screens/sql_console.dart
@@ -1,5 +1,5 @@
 import 'package:auto_route/auto_route.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sqlite3/common.dart' as sqlite;

--- a/demos/supabase-todolist-drift/lib/screens/take_photo.dart
+++ b/demos/supabase-todolist-drift/lib/screens/take_photo.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:auto_route/auto_route.dart';
 import 'package:camera/camera.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:powersync/powersync.dart' as powersync;

--- a/demos/supabase-todolist-drift/lib/stores/items.g.dart
+++ b/demos/supabase-todolist-drift/lib/stores/items.g.dart
@@ -82,14 +82,14 @@ abstract class _$ItemsNotifier extends $StreamNotifier<List<TodoItem>> {
   );
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<List<TodoItem>>, List<TodoItem>>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AsyncValue<List<TodoItem>>, List<TodoItem>>,
         AsyncValue<List<TodoItem>>,
         Object?,
         Object?>;
-    element.handleCreate(
+    return element.handleCreate(
         ref,
         () => build(
               _$args,

--- a/demos/supabase-todolist-drift/lib/stores/lists.g.dart
+++ b/demos/supabase-todolist-drift/lib/stores/lists.g.dart
@@ -40,7 +40,7 @@ abstract class _$ListsNotifier
   Stream<List<ListItemWithStats>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref
         as $Ref<AsyncValue<List<ListItemWithStats>>, List<ListItemWithStats>>;
     final element = ref.element as $ClassProviderElement<
@@ -49,6 +49,6 @@ abstract class _$ListsNotifier
         AsyncValue<List<ListItemWithStats>>,
         Object?,
         Object?>;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/demos/supabase-todolist-drift/lib/supabase.g.dart
+++ b/demos/supabase-todolist-drift/lib/supabase.g.dart
@@ -161,10 +161,10 @@ abstract class _$AuthNotifier extends $Notifier<AuthState> {
   AuthState build();
   @$mustCallSuper
   @override
-  void runBuild() {
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AuthState, AuthState>;
     final element = ref.element as $ClassProviderElement<
         AnyNotifier<AuthState, AuthState>, AuthState, Object?, Object?>;
-    element.handleCreate(ref, build);
+    return element.handleCreate(ref, build);
   }
 }

--- a/demos/supabase-todolist-drift/pubspec.yaml
+++ b/demos/supabase-todolist-drift/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   flutter_riverpod: ^3.3.1
   auto_route: ^11.0.1
   stream_transform: ^2.1.1
+  material_ui: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/demos/supabase-todolist-optional-sync/lib/main.dart
+++ b/demos/supabase-todolist-optional-sync/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:logging/logging.dart';
 import 'package:powersync_flutter_supabase_todolist_optional_sync_demo/app_config.dart';
 import 'package:powersync_flutter_supabase_todolist_optional_sync_demo/models/schema.dart';

--- a/demos/supabase-todolist-optional-sync/lib/widgets/list_item.dart
+++ b/demos/supabase-todolist-optional-sync/lib/widgets/list_item.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import './todo_list_page.dart';
 import '../models/todo_list.dart';

--- a/demos/supabase-todolist-optional-sync/lib/widgets/list_item_dialog.dart
+++ b/demos/supabase-todolist-optional-sync/lib/widgets/list_item_dialog.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../models/todo_list.dart';
 

--- a/demos/supabase-todolist-optional-sync/lib/widgets/lists_page.dart
+++ b/demos/supabase-todolist-optional-sync/lib/widgets/lists_page.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import './list_item.dart';
 import './list_item_dialog.dart';

--- a/demos/supabase-todolist-optional-sync/lib/widgets/login_page.dart
+++ b/demos/supabase-todolist-optional-sync/lib/widgets/login_page.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:powersync_flutter_supabase_todolist_optional_sync_demo/powersync.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 

--- a/demos/supabase-todolist-optional-sync/lib/widgets/query_widget.dart
+++ b/demos/supabase-todolist-optional-sync/lib/widgets/query_widget.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:sqlite3/common.dart' as sqlite;
 
 import './resultset_table.dart';

--- a/demos/supabase-todolist-optional-sync/lib/widgets/resultset_table.dart
+++ b/demos/supabase-todolist-optional-sync/lib/widgets/resultset_table.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:sqlite3/common.dart' as sqlite;
 
 /// Stateless DataTable rendering results from a SQLite query

--- a/demos/supabase-todolist-optional-sync/lib/widgets/signup_page.dart
+++ b/demos/supabase-todolist-optional-sync/lib/widgets/signup_page.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:powersync_flutter_supabase_todolist_optional_sync_demo/powersync.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 

--- a/demos/supabase-todolist-optional-sync/lib/widgets/status_app_bar.dart
+++ b/demos/supabase-todolist-optional-sync/lib/widgets/status_app_bar.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:powersync/powersync.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import '../powersync.dart';

--- a/demos/supabase-todolist-optional-sync/lib/widgets/todo_item_dialog.dart
+++ b/demos/supabase-todolist-optional-sync/lib/widgets/todo_item_dialog.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../models/todo_list.dart';
 

--- a/demos/supabase-todolist-optional-sync/lib/widgets/todo_item_widget.dart
+++ b/demos/supabase-todolist-optional-sync/lib/widgets/todo_item_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../models/todo_item.dart';
 

--- a/demos/supabase-todolist-optional-sync/lib/widgets/todo_list_page.dart
+++ b/demos/supabase-todolist-optional-sync/lib/widgets/todo_list_page.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:powersync_flutter_supabase_todolist_optional_sync_demo/models/todo_item.dart';
 
 import './status_app_bar.dart';

--- a/demos/supabase-todolist-optional-sync/pubspec.yaml
+++ b/demos/supabase-todolist-optional-sync/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   image: ^4.1.3
   universal_io: ^2.2.2
   sqlite_async: ^0.14.0
+  material_ui: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/demos/supabase-todolist/lib/attachments/photo_capture_widget.dart
+++ b/demos/supabase-todolist/lib/attachments/photo_capture_widget.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 import 'package:camera/camera.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:logging/logging.dart';
 import 'package:powersync_flutter_demo/attachments/queue.dart';
 

--- a/demos/supabase-todolist/lib/attachments/photo_widget.dart
+++ b/demos/supabase-todolist/lib/attachments/photo_widget.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as p;
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:powersync/attachments/attachments.dart';
 import 'package:powersync_flutter_demo/attachments/camera_helpers.dart';
 import 'package:powersync_flutter_demo/attachments/photo_capture_widget.dart';

--- a/demos/supabase-todolist/lib/main.dart
+++ b/demos/supabase-todolist/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:logging/logging.dart';
 import 'package:powersync_flutter_demo/app_config.dart';
 import 'package:powersync_flutter_demo/attachments/queue.dart';

--- a/demos/supabase-todolist/lib/widgets/fts_search_delegate.dart
+++ b/demos/supabase-todolist/lib/widgets/fts_search_delegate.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:logging/logging.dart';
 import 'package:powersync_flutter_demo/fts_helpers.dart' as fts_helpers;
 import 'package:powersync_flutter_demo/models/todo_list.dart';

--- a/demos/supabase-todolist/lib/widgets/guard_by_sync.dart
+++ b/demos/supabase-todolist/lib/widgets/guard_by_sync.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:powersync/powersync.dart' hide Column;
 import 'package:powersync_flutter_demo/powersync.dart';
 

--- a/demos/supabase-todolist/lib/widgets/list_item.dart
+++ b/demos/supabase-todolist/lib/widgets/list_item.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import './todo_list_page.dart';
 import '../models/todo_list.dart';

--- a/demos/supabase-todolist/lib/widgets/list_item_dialog.dart
+++ b/demos/supabase-todolist/lib/widgets/list_item_dialog.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../models/todo_list.dart';
 

--- a/demos/supabase-todolist/lib/widgets/list_item_sync_stream.dart
+++ b/demos/supabase-todolist/lib/widgets/list_item_sync_stream.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../powersync.dart';
 import './todo_list_page.dart';

--- a/demos/supabase-todolist/lib/widgets/lists_page.dart
+++ b/demos/supabase-todolist/lib/widgets/lists_page.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:powersync/powersync.dart';
 
 import '../app_config.dart';

--- a/demos/supabase-todolist/lib/widgets/login_page.dart
+++ b/demos/supabase-todolist/lib/widgets/login_page.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../main.dart';

--- a/demos/supabase-todolist/lib/widgets/query_widget.dart
+++ b/demos/supabase-todolist/lib/widgets/query_widget.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:sqlite3/common.dart' as sqlite;
 
 import './resultset_table.dart';

--- a/demos/supabase-todolist/lib/widgets/resultset_table.dart
+++ b/demos/supabase-todolist/lib/widgets/resultset_table.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:sqlite3/common.dart' as sqlite;
 
 /// Stateless DataTable rendering results from a SQLite query

--- a/demos/supabase-todolist/lib/widgets/signup_page.dart
+++ b/demos/supabase-todolist/lib/widgets/signup_page.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../main.dart';

--- a/demos/supabase-todolist/lib/widgets/status_app_bar.dart
+++ b/demos/supabase-todolist/lib/widgets/status_app_bar.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:powersync/powersync.dart';
 import 'package:powersync_flutter_demo/widgets/fts_search_delegate.dart';
 import '../powersync.dart';

--- a/demos/supabase-todolist/lib/widgets/todo_item_dialog.dart
+++ b/demos/supabase-todolist/lib/widgets/todo_item_dialog.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../models/todo_list.dart';
 

--- a/demos/supabase-todolist/lib/widgets/todo_item_widget.dart
+++ b/demos/supabase-todolist/lib/widgets/todo_item_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:powersync_flutter_demo/app_config.dart';
 import 'package:powersync_flutter_demo/attachments/photo_widget.dart';
 import 'package:powersync_flutter_demo/attachments/queue.dart';

--- a/demos/supabase-todolist/lib/widgets/todo_list_page.dart
+++ b/demos/supabase-todolist/lib/widgets/todo_list_page.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:powersync/powersync.dart';
 
 import '../app_config.dart';

--- a/demos/supabase-todolist/pubspec.yaml
+++ b/demos/supabase-todolist/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   universal_io: ^2.2.2
   sqlite_async: ^0.14.0
   sqlite3: ^3.2.0
+  material_ui: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/demos/supabase-trello/lib/utils/service.dart
+++ b/demos/supabase-trello/lib/utils/service.dart
@@ -557,8 +557,7 @@ mixin Service {
   }
 
   Future<void> uploadFile(Cardlist crd) async {
-    FilePickerResult? result =
-        await FilePicker.platform.pickFiles(allowMultiple: false);
+    FilePickerResult? result = await FilePicker.pickFiles(allowMultiple: false);
     if (result != null) {
       addAttachment(result.files[0].path ?? "", crd);
     }

--- a/demos/supabase-trello/pubspec.yaml
+++ b/demos/supabase-trello/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   material_design_icons_flutter: ^7.0.7296
   provider: ^6.1.2
   image_picker: ^1.1.2
-  file_picker: ^10.3.10
+  file_picker: ^11.0.3
   random_name_generator: ^1.5.0
   flutter_dotenv: ^6.0.0
   logging: ^1.3.0

--- a/packages/powersync_attachments_helper/lib/src/attachments_queue_table.dart
+++ b/packages/powersync_attachments_helper/lib/src/attachments_queue_table.dart
@@ -73,19 +73,18 @@ final class AttachmentsQueueTable extends Table {
   AttachmentsQueueTable(
       {String attachmentsQueueTableName = defaultAttachmentsQueueTableName,
       List<Column> additionalColumns = const [],
-      List<Index> indexes = const [],
-      String? viewName})
+      super.indexes,
+      super.viewName})
       : super.localOnly(
-            attachmentsQueueTableName,
-            [
-              const Column.text('filename'),
-              const Column.text('local_uri'),
-              const Column.integer('timestamp'),
-              const Column.integer('size'),
-              const Column.text('media_type'),
-              const Column.integer('state'),
-              ...additionalColumns,
-            ],
-            viewName: viewName,
-            indexes: indexes);
+          attachmentsQueueTableName,
+          [
+            const Column.text('filename'),
+            const Column.text('local_uri'),
+            const Column.integer('timestamp'),
+            const Column.integer('size'),
+            const Column.text('media_type'),
+            const Column.integer('state'),
+            ...additionalColumns,
+          ],
+        );
 }

--- a/packages/powersync_devtools_extension/lib/main.dart
+++ b/packages/powersync_devtools_extension/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:devtools_extensions/devtools_extensions.dart';
-import 'package:material_ui/material_ui.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:powersync_devtools_extension/ui/appbar.dart';
 

--- a/packages/powersync_devtools_extension/lib/main.dart
+++ b/packages/powersync_devtools_extension/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:devtools_extensions/devtools_extensions.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:powersync_devtools_extension/ui/appbar.dart';
 

--- a/packages/powersync_devtools_extension/lib/ui/appbar.dart
+++ b/packages/powersync_devtools_extension/lib/ui/appbar.dart
@@ -1,6 +1,6 @@
 import 'dart:js_interop';
 
-import 'package:material_ui/material_ui.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:web/web.dart' as web;
 

--- a/packages/powersync_devtools_extension/lib/ui/appbar.dart
+++ b/packages/powersync_devtools_extension/lib/ui/appbar.dart
@@ -1,6 +1,6 @@
 import 'dart:js_interop';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:web/web.dart' as web;
 

--- a/packages/powersync_devtools_extension/lib/ui/common.dart
+++ b/packages/powersync_devtools_extension/lib/ui/common.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:powersync_devtools_extension/state/databases.dart';
 
 final class HasDatabaseGuard extends ConsumerWidget {

--- a/packages/powersync_devtools_extension/lib/ui/common.dart
+++ b/packages/powersync_devtools_extension/lib/ui/common.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:material_ui/material_ui.dart';
+import 'package:flutter/material.dart';
 import 'package:powersync_devtools_extension/state/databases.dart';
 
 final class HasDatabaseGuard extends ConsumerWidget {

--- a/packages/powersync_devtools_extension/lib/ui/overview.dart
+++ b/packages/powersync_devtools_extension/lib/ui/overview.dart
@@ -1,7 +1,7 @@
 import 'package:devtools_app_shared/ui.dart';
 import 'package:devtools_app_shared/utils.dart';
 import 'package:devtools_extensions/devtools_extensions.dart';
-import 'package:material_ui/material_ui.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:powersync/powersync.dart' hide Column;
 import 'package:powersync_devtools_extension/state/databases.dart';

--- a/packages/powersync_devtools_extension/lib/ui/overview.dart
+++ b/packages/powersync_devtools_extension/lib/ui/overview.dart
@@ -1,7 +1,7 @@
 import 'package:devtools_app_shared/ui.dart';
 import 'package:devtools_app_shared/utils.dart';
 import 'package:devtools_extensions/devtools_extensions.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:powersync/powersync.dart' hide Column;
 import 'package:powersync_devtools_extension/state/databases.dart';

--- a/packages/powersync_devtools_extension/lib/ui/sql.dart
+++ b/packages/powersync_devtools_extension/lib/ui/sql.dart
@@ -1,5 +1,5 @@
 import 'package:devtools_app_shared/ui.dart';
-import 'package:material_ui/material_ui.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';

--- a/packages/powersync_devtools_extension/lib/ui/sql.dart
+++ b/packages/powersync_devtools_extension/lib/ui/sql.dart
@@ -1,5 +1,5 @@
 import 'package:devtools_app_shared/ui.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_riverpod/legacy.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';

--- a/packages/powersync_devtools_extension/pubspec.yaml
+++ b/packages/powersync_devtools_extension/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
   powersync:
   hooks_riverpod: ^3.3.1
   flutter_hooks: ^0.21.3+1
-  material_ui: any
 
 dev_dependencies:
   flutter_test:

--- a/packages/powersync_devtools_extension/pubspec.yaml
+++ b/packages/powersync_devtools_extension/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   powersync:
   hooks_riverpod: ^3.3.1
   flutter_hooks: ^0.21.3+1
+  material_ui: any
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,34 +5,34 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "3b19a47f6ea7c2632760777c78174f47f6aec1e05f0cd611380d4593b8af1dbc"
+      sha256: cd6add6f846f35fb79f3c315296703c1a24f3cfd7f4739d91a74961c1c7e9f1b
       url: "https://pub.dev"
     source: hosted
-    version: "96.0.0"
+    version: "100.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "0d1f0adfabbab9f46a1a80ce84a4d8b852b6e4dbf53ce413b30e0cf7d3631b71"
+      sha256: "6727cf2ced9b104abca9daa278380be2eca2b98ce33d4b46f11708e387dc6b4d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.72"
+    version: "1.3.76"
   analyzer:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: analyzer
-      sha256: "0c516bc4ad36a1a75759e54d5047cb9d15cded4459df01aa35a0b5ec7db2c2a0"
+      sha256: "6ba98576948803398b69e3a444df24eacdbe12ed699c7014e120ea38552debbf"
       url: "https://pub.dev"
     source: hosted
-    version: "10.2.0"
+    version: "13.0.0"
   analyzer_buffer:
     dependency: transitive
     description:
       name: analyzer_buffer
-      sha256: bf559bc54530827a92cc4d9ee340fc76b4f17f386218c2b9e7cd33ed468a7e4d
+      sha256: "445b77e2054fa3e8c8a8ef1b5e9e6b23bb8028fffd34b5e60eaef315b7750674"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.2"
+    version: "0.3.3"
   ansi_styles:
     dependency: transitive
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: app_links
-      sha256: a350a5b37579b7227aaf9a59c07114617cd4283852e193f743b2b3d2d7483c18
+      sha256: f8db46d2ea9ff6f3a37191a7fd5b7813da1253ace8c32c1b9eadace41d1188ea
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.1"
+    version: "7.2.1"
   app_links_linux:
     dependency: transitive
     description:
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: app_links_platform_interface
-      sha256: "05f5379577c513b534a29ddea68176a4d4802c46180ee8e2e966257158772a3f"
+      sha256: "7546f09a6e93f4a2df2fe2bd40a5c6c64310ac461b036d82b43033be7a59f809"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.4"
   app_links_web:
     dependency: transitive
     description:
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: auto_route_generator
-      sha256: "7aa0e90874928e78709f0a21a69fb5bc2ae1aa932dec862930d2af85c40adb01"
+      sha256: f58fdb20c51b36afe7bf8a162aea3b22dff580a8a0b5c35e8e3a91367121c8f1
       url: "https://pub.dev"
     source: hosted
-    version: "10.5.0"
+    version: "10.6.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -141,34 +141,34 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: a156715e7cd728130c592f30552575908aae5b100005fbc1f0fb16b3c03a3d10
+      sha256: "45d14a0fb23e018d8287c32fc98d726ce466b231928ed9b9200f29bd3ccd39ae"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.6"
+    version: "4.0.7"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
+      sha256: "94eaf6708fe64408c632ef2689ca3777b112f9421306ccf4f8c84d7c5c9f83f8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.2"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
+      sha256: "79e05eaf15a48d7230b053a4363b8eaac0cc234bbd0134c3229455481f55cbc6"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.1"
+    version: "4.1.5"
   build_runner:
     dependency: transitive
     description:
       name: build_runner
-      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
+      sha256: "5367e521935b102bdf1e735d2aab461e36b2edca6517662d088dd04cc39f8d16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.0"
+    version: "2.15.1"
   built_collection:
     dependency: transitive
     description:
@@ -181,50 +181,50 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56"
+      sha256: "31b24be6615ec7fcf70b3aa5a7469fe35826485e639a16dd7eb83ba30e4cc6a8"
       url: "https://pub.dev"
     source: hosted
-    version: "8.12.6"
+    version: "8.12.7"
   camera:
     dependency: transitive
     description:
       name: camera
-      sha256: "034c38cb8014d29698dcae6d20276688a1bf74e6487dfeb274d70ea05d5f7777"
+      sha256: "558230d6ce6ccea856b32d390db7e7b557adf4d9320aa614481bd3f2f608953f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.0+1"
+    version: "0.12.0+2"
   camera_android_camerax:
     dependency: transitive
     description:
       name: camera_android_camerax
-      sha256: e20c1e92ce6797d9ae9b1db1e09a4c1039a04827d0b24985f5da3840b96948ac
+      sha256: "6d8dd23f8ad52c36ae3da7417a59b3c3faa3d1e1b83c983a04ca8383f001233c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2+1"
+    version: "0.7.4+5"
   camera_avfoundation:
     dependency: transitive
     description:
       name: camera_avfoundation
-      sha256: "90e4cc3fde331581a3b2d35d83be41dbb7393af0ab857eb27b732174289cb96d"
+      sha256: "866e9cd8370f8055d005c0413937a52dc1d7a472687f0ee3ce02392955aababa"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.1"
+    version: "0.10.2"
   camera_platform_interface:
     dependency: transitive
     description:
       name: camera_platform_interface
-      sha256: "7ac852d77699acee79f0d438b793feee26721841e50973576419ff5c6d95e9b7"
+      sha256: "4524ca6eb4176b066864036ad4fe02c3e4863e63b77eadc21a5bf56824f43498"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   camera_web:
     dependency: transitive
     description:
       name: camera_web
-      sha256: "57f49a635c8bf249d07fb95eb693d7e4dda6796dedb3777f9127fb54847beba7"
+      sha256: "081441bd2f92b5841aa70ff4d6eddfe34078d97f9d085cc9e0f9d0102f145925"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5+3"
+    version: "0.3.5+5"
   characters:
     dependency: transitive
     description:
@@ -261,18 +261,18 @@ packages:
     dependency: transitive
     description:
       name: cli_launcher
-      sha256: "35cf15a3ffaeb9c11849eaa0afba761bb76dceb42d050532bfd3e1299c9748cd"
+      sha256: "96883f87648524292e24e2cc6a369fbdf64883473fe3e3ddadd3d857bf16a484"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3+1"
+    version: "0.3.3+2"
   cli_util:
     dependency: transitive
     description:
       name: cli_util
-      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
+      sha256: "71e43f1976c3eae2d9468a5b4d6600bf8cae61508b87f27fa1799228935d48ab"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.2"
+    version: "0.5.2"
   clock:
     dependency: transitive
     description:
@@ -333,10 +333,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5+2"
+    version: "0.3.5+4"
   crypto:
     dependency: transitive
     description:
@@ -389,10 +389,10 @@ packages:
     dependency: transitive
     description:
       name: dbus
-      sha256: "0ce9b0a839e6dee59a37a623d2fc26a35bbbe6404213e419b0d6411023d62645"
+      sha256: "792974a4007974fbc5c1b5433eb2330a9db3e368c3f906253af4c007d0f49a91"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.14"
+    version: "0.7.13"
   dds_service_extensions:
     dependency: transitive
     description:
@@ -405,10 +405,10 @@ packages:
     dependency: transitive
     description:
       name: decimal
-      sha256: fc706a5618b81e5b367b01dd62621def37abc096f2b46a9bd9068b64c1fa36d0
+      sha256: "2c3c8b74f2948066d3f42585477aec9cfc48fefd7a723a4d4274a6c71a5c0df7"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.4"
+    version: "3.2.6"
   devtools_app_shared:
     dependency: transitive
     description:
@@ -429,26 +429,26 @@ packages:
     dependency: transitive
     description:
       name: devtools_shared
-      sha256: "5ab724cfd36ef4b0e47ef4719527be61ba262c5cfdb8522535f9bad7aa862556"
+      sha256: "13df2c17d5f21dd7c92d08145386d45e1153364c04e531e994afb0ee7b67554b"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.1"
+    version: "13.1.0"
   drift:
     dependency: transitive
     description:
       name: drift
-      sha256: "8033500116b24398fba0cca0369cc31678cd627c01e41753a61186911cea743e"
+      sha256: "3a3f1f6f905037d7426e4c445854139fd6a3d592135f7c96d7931682b73d16f4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.33.0"
+    version: "2.34.3"
   drift_dev:
     dependency: transitive
     description:
       name: drift_dev
-      sha256: b3dd5b75e30522a91da8abda9f5bb17230cb038097f6d15fa75d42bb563428aa
+      sha256: "735aad3c34215805c66bd518c8812fa4f83b5534b2c13c4092c970c04a7e9983"
       url: "https://pub.dev"
     source: hosted
-    version: "2.33.0"
+    version: "2.34.5"
   drift_sqlite_async:
     dependency: transitive
     description:
@@ -501,10 +501,10 @@ packages:
     dependency: transitive
     description:
       name: file_picker
-      sha256: "57d9a1dd5063f85fa3107fb42d1faffda52fdc948cefd5fe5ea85267a5fc7343"
+      sha256: "29cc1fdb20613876cc7afc529738c1c0f11a9ca159b010edad0c566ac330847e"
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.10"
+    version: "11.0.3"
   file_selector_linux:
     dependency: transitive
     description:
@@ -541,50 +541,50 @@ packages:
     dependency: transitive
     description:
       name: firebase_auth
-      sha256: "9905a315f1235a649e29df19b246adde7350a11234837cd605254b8e25144711"
+      sha256: "366b8edc0bbce7880a62dbf0f566fadd809ee69e6e345b7e7cae2080443acbfd"
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.2"
+    version: "6.5.7"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
-      sha256: f757dc5636ce2b204a82383f7246ef0d9c925f9e96c8c9a4a6c315d673d662bb
+      sha256: "314b7bd0bf8545cbd3e779bad294a811d09de5d25d5c88a00e6e48a6bded6368"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.2"
+    version: "9.0.6"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
-      sha256: "1c44330eef3c82068e0c2919b6b015897d49211dcccdf64f90a2ed73ce216ecb"
+      sha256: "209f60c3e4bc44ce23b167b2361883bc15a012b027ffcb773ccd81fcaebc718b"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.2"
+    version: "6.2.6"
   firebase_core:
     dependency: transitive
     description:
       name: firebase_core
-      sha256: ec46a100a560d3bd5f97f2d89ba7492cb09b6dd0a4a28753d1258f360d6bd9f9
+      sha256: "9478ca6700c02d315c6aba37e206e612317f98bb4f335bb1cbd6e0ce67dcf764"
       url: "https://pub.dev"
     source: hosted
-    version: "4.10.0"
+    version: "4.13.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: "4a120366dbf7d5a8ee9438978530b664b855728fb8dcc3a201017660817e555b"
+      sha256: e28f9afdcb5b0f0a8ea74ea3b322f5a7592c81cb45dd9d189913bdae08a2089a
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.1"
+    version: "8.1.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: "5ad1be848692ec148f2d6a8ad2a3838cb852ea5f3c9e6479a7afce479e1854f8"
+      sha256: f471a288b0101a45567548322ac4a5ad31e3ecbf87a576dcc0e424e6a11e04ea
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.0"
+    version: "3.10.0"
   fixnum:
     dependency: transitive
     description:
@@ -642,10 +642,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_riverpod
-      sha256: "9255e1e3ad6e38906a1b4f8287678f95f378744c5b46b1985588543f3f19046e"
+      sha256: "56e81e662e6e54e59b231da57e90ac0d06ac67d8e3f2273c129a37ae6282b40c"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.2"
+    version: "3.4.2"
   flutter_test:
     dependency: transitive
     description: flutter
@@ -676,10 +676,10 @@ packages:
     dependency: transitive
     description:
       name: functions_client
-      sha256: "94bde5b8062b1c498795ce509cbe7e83417e171eb55c2c611da64c15034b7851"
+      sha256: "931e822688d2e97867b2300e2fdbb08c9db73f8653fc83efc7a259d2e0cca769"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.7.1"
   glob:
     dependency: transitive
     description:
@@ -692,18 +692,18 @@ packages:
     dependency: transitive
     description:
       name: google_fonts
-      sha256: "4e9391085e524954a51e3625b7c9c7e9851dc3f376603208bb45c24b9a66255d"
+      sha256: e3cb3ee6b47fd2472c23de6da5744796a4da195137759ddb3fbcc9467b7b3c7d
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.0"
+    version: "8.2.1"
   gotrue:
     dependency: transitive
     description:
       name: gotrue
-      sha256: "22f0a6ea86c8024de6b164a49a213cfa60a23f19df26e5bca8d6eb7e087fdf17"
+      sha256: f6f42ea035953b2439664c1afb46630460edbb917093843a3a0618bfa45619f6
       url: "https://pub.dev"
     source: hosted
-    version: "2.21.0"
+    version: "2.27.1"
   graphs:
     dependency: transitive
     description:
@@ -724,18 +724,18 @@ packages:
     dependency: transitive
     description:
       name: hooks
-      sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
+      sha256: "03a564c3704524ee0f7fc56fc621e8796cc2eb8c24d1f1a33b34979815b285c4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.0"
   hooks_riverpod:
     dependency: transitive
     description:
       name: hooks_riverpod
-      sha256: dcaf59f0f41489ff08ce61438ada564d67f40cfa37cc7c8589da78fb600c2edc
+      sha256: fce693abc6289c8bb42348eae520b979f7edbaae0c1b77b946ef058d0693f6f6
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.2"
+    version: "3.4.2"
   hotreloader:
     dependency: transitive
     description:
@@ -780,18 +780,18 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce
+      sha256: "6300175e00616bbc832e2fc91bfa4d776af5402c81c7151bee6905bb08473c52"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.9.1"
   image_picker:
     dependency: transitive
     description:
       name: image_picker
-      sha256: "91c025426c2881c551100bce834e201c835a170151545f58d17da5180ca7d9ac"
+      sha256: d8402284df184bc05f4a2210c6c23983b0720f4cd87cbd05c5390a78af602667
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.3"
   image_picker_android:
     dependency: transitive
     description:
@@ -852,10 +852,10 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   io:
     dependency: transitive
     description:
@@ -868,18 +868,26 @@ packages:
     dependency: transitive
     description:
       name: jni
-      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      sha256: f038e58b4dc2c9037f50e233175086337e0b305e356d28211bf55f21c504cbd3
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.3"
   jni_flutter:
     dependency: transitive
     description:
       name: jni_flutter
-      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
+      sha256: "7b717011ea40d04fd47c2731d3d1d36eb99eba3435c2753d62489e8c3c9991d5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
+  jni_util:
+    dependency: transitive
+    description:
+      name: jni_util
+      sha256: "1ba86da04a5f2bf18fde2edb235587e70c5b0fc5bd4ba955f46b00942c3fc35f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   json_annotation:
     dependency: transitive
     description:
@@ -896,14 +904,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
-  jwt_decode:
-    dependency: transitive
-    description:
-      name: jwt_decode
-      sha256: d2e9f68c052b2225130977429d30f187aa1981d789c76ad104a32243cfdebfbb
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.1"
   leak_tracker:
     dependency: transitive
     description:
@@ -932,10 +932,10 @@ packages:
     dependency: transitive
     description:
       name: lean_builder
-      sha256: c16e95ddf7b2d49dd551357b7212fe2ce9f13ec7ad1b1e660c157184031e96c0
+      sha256: "123eef9fba96ec12a18b8eb4889850368d78e8c0a6a63eaa45ec4cf3e73fbded"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.10"
+    version: "1.2.0"
   lints:
     dependency: "direct main"
     description:
@@ -944,6 +944,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  listen:
+    dependency: transitive
+    description:
+      name: listen
+      sha256: "47501a08016a43fcad79252439d723f50f14f88fa7bfd8a177e0a417e5c9e1f2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   logging:
     dependency: transitive
     description:
@@ -956,10 +964,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -980,18 +988,18 @@ packages:
     dependency: "direct main"
     description:
       name: melos
-      sha256: b40731f34d3aacb199641a9b4955e52a866b0b0bc93ffc5c8ff21bffc6593134
+      sha256: "2d588cd21b34ea4cadf5a20542bcd5042a60833aa3eae09ecdc319291cd06f69"
       url: "https://pub.dev"
     source: hosted
-    version: "7.8.1"
+    version: "8.2.2"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -1020,10 +1028,10 @@ packages:
     dependency: transitive
     description:
       name: native_toolchain_c
-      sha256: f59351d28f49520cd3a74eb1f41c5f19ae15e53c65a3231d14af672e46510a96
+      sha256: a1c26117c48cebe5677b0cf0e33a980a79a7c5577effc86f52e5a0d309cdcb60
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.1"
+    version: "0.19.3"
   nested:
     dependency: transitive
     description:
@@ -1044,10 +1052,10 @@ packages:
     dependency: transitive
     description:
       name: objective_c
-      sha256: "6cb691c686fa2838c6deb34980d426145c2a5d537491cb83d463c33cdbc726ed"
+      sha256: b7fb95a6d9a4f009edd63dc5ac69f07420b23a16161c6dd8660290b59c602e8e
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.1"
+    version: "9.5.0"
   package_config:
     dependency: transitive
     description:
@@ -1064,6 +1072,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.2"
+  passkeys_platform_interface:
+    dependency: transitive
+    description:
+      name: passkeys_platform_interface
+      sha256: e810520c7b79dca629fdc266958564eedd77dc85a955f5e94430dfccb92eef68
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.0"
   path:
     dependency: "direct main"
     description:
@@ -1076,10 +1092,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider
-      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      sha256: a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.6"
   path_provider_android:
     dependency: transitive
     description:
@@ -1100,18 +1116,18 @@ packages:
     dependency: transitive
     description:
       name: path_provider_linux
-      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      sha256: "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      sha256: "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   path_provider_windows:
     dependency: transitive
     description:
@@ -1196,18 +1212,18 @@ packages:
     dependency: transitive
     description:
       name: posix
-      sha256: "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07"
+      sha256: bc1bad54ad2b735816e31f8d4600cfde6c7839975085ddfbca48b6c9f7c4044e
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.0"
+    version: "6.5.2"
   postgrest:
     dependency: transitive
     description:
       name: postgrest
-      sha256: dbe357f9eacac45a98cd70194006e59c44c8ce6de0fafbdfef1f0c397c20f5de
+      sha256: b7f957273ba6a1c26cefa987ac524f4138e9ab7542fbb9e6abdfddacb9895a21
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.1"
+    version: "2.9.1"
   power_extensions:
     dependency: transitive
     description:
@@ -1284,10 +1300,10 @@ packages:
     dependency: transitive
     description:
       name: realtime_client
-      sha256: ae16ad5bbd9f77a025ae1042b0310bc9440902e51d62ffd761a6691788af9ae9
+      sha256: ff731ce21fd775e0d7accfb1eaccdcf47b687610720822ba8b9fd8f5bccb2bd9
       url: "https://pub.dev"
     source: hosted
-    version: "2.7.4"
+    version: "2.13.0"
   recase:
     dependency: transitive
     description:
@@ -1300,58 +1316,42 @@ packages:
     dependency: transitive
     description:
       name: record_use
-      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
+      sha256: "3b4ab682aff40175afca6ff090cc5aa7ce9dafe8dfbae1537a6c678e6678baee"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
-  retry:
-    dependency: transitive
-    description:
-      name: retry
-      sha256: "822e118d5b3aafed083109c72d5f484c6dc66707885e07c0fbcb8b986bba7efc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.2"
+    version: "1.1.0"
   riverpod:
     dependency: transitive
     description:
       name: riverpod
-      sha256: "17100416c51db7810c71a7bb2c34d1f881faa0074fd452afb0c4db6f8f126c76"
+      sha256: "84351b3472a447f7b89f961f95c73287009d58c59d8cc1267425d995f78e50f1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.2"
+    version: "3.4.2"
   riverpod_analyzer_utils:
     dependency: transitive
     description:
       name: riverpod_analyzer_utils
-      sha256: "3e275138862ccc22ed61444a1f9a840f753094c367f28f4123f50289cd204d68"
+      sha256: "46a8dd0461080fde8f886f65f87580758dae8495e352f9ea6a09953abc3df7bd"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0-dev.10"
+    version: "1.0.0-dev.11"
   riverpod_annotation:
     dependency: transitive
     description:
       name: riverpod_annotation
-      sha256: "674dbb26e2db3d9253166faf4758c796af14146b8fbcf5e7102bc8a04cd359b8"
+      sha256: dd043c75eb3cea2654f5dca51234413ac04bd092ccc73e747fd73cae37ac5360
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.3"
+    version: "4.0.6"
   riverpod_generator:
     dependency: transitive
     description:
       name: riverpod_generator
-      sha256: "54d790c3fee1ae281c448801bfdbfaa9fd961a9d3998494e0fcd9ee32184d7eb"
+      sha256: "2e66b5691cf5d50d6a409904b0477e869e0ecbdd5ada1535d263a95d44439e75"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.4"
-  rxdart:
-    dependency: transitive
-    description:
-      name: rxdart
-      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.28.0"
+    version: "4.0.8"
   shared_preferences:
     dependency: transitive
     description:
@@ -1364,10 +1364,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "93ae5884a9df5d3bb696825bceb3a17590754548b5d740eba51500afc8d088f5"
+      sha256: "0634e64bd719f89c012f392938e173521f535d3ecaf66558fa94a056d22b5cc7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.26"
+    version: "2.4.27"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -1457,10 +1457,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: ec37cc0e6694374cbef59ed79685572c870a54ede6fa30a3e420feb3adffea02
+      sha256: a603f1fb984a7391ae5978d1b92bfaaa08b350dca5c825256f925818f7943bf5
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.3"
+    version: "4.2.4"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -1497,18 +1497,18 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: c73fd75df1332d76a6257f4823ae4df9c791f522b97e4a60cbcad214de1becf4
+      sha256: "64b2c63c8232dd20d14b34105a81ebfd74320442e8451f836179ec89986aa478"
       url: "https://pub.dev"
     source: hosted
-    version: "3.5.0"
+    version: "3.5.1"
   sqlite3_connection_pool:
     dependency: transitive
     description:
       name: sqlite3_connection_pool
-      sha256: ad51972d37bdf82929888e4c85e722bd9a0b5ff8ad389f89b1b00d19603c0d2d
+      sha256: "8f2df36dc9f0f51ec04506b90848769b5a4538a9f937472147a274910a92e7ee"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.7"
+    version: "0.2.9"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
@@ -1537,10 +1537,10 @@ packages:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: ecdc06d4a7d79dcbc928d99afd2f7f5b0f98a637c46f89be83d911617f759978
+      sha256: "772bb2f6f5bce0631a60f26b57d6e8882e1105c22345b05c163ee6ee5d7ba32d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.44.4"
+    version: "0.45.0"
   sse:
     dependency: transitive
     description:
@@ -1569,10 +1569,10 @@ packages:
     dependency: transitive
     description:
       name: storage_client
-      sha256: "05b04c3a1578b5469b8e1f51670feb4e183e8b1be20d9b47e7882bf7048777b5"
+      sha256: b16aaaadcef812fda31fca056f50fb3485afe64f94e5d537d30f485ed55dec5e
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.6"
+    version: "2.8.0"
   stream_channel:
     dependency: transitive
     description:
@@ -1601,18 +1601,26 @@ packages:
     dependency: transitive
     description:
       name: supabase
-      sha256: ebae283b56df8a97491b8484aa34b60115c60bc612de24bd83b4918c85a14f31
+      sha256: eeea4f5edefd95977aa16045c3c4c8020aa31c87818669b8eb887ccb68805964
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.2"
+    version: "2.16.0"
+  supabase_common:
+    dependency: transitive
+    description:
+      name: supabase_common
+      sha256: a7961a44953cf8d9da049381fc3377516348255042fbb12b9d4f8540816f2fe9
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   supabase_flutter:
     dependency: transitive
     description:
       name: supabase_flutter
-      sha256: "205f732f0e75163b197a7c4da8ee6654c792ace1efb15643e82d5b9bced5e94d"
+      sha256: "0ef08709e72ef15b98b3b935864cc8e84b12ecc374e31091edd8be4e16e125c7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.14.2"
+    version: "2.17.1"
   term_glyph:
     dependency: transitive
     description:
@@ -1625,26 +1633,26 @@ packages:
     dependency: "direct main"
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.31.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.18"
   test_descriptor:
     dependency: transitive
     description:
@@ -1673,10 +1681,10 @@ packages:
     dependency: transitive
     description:
       name: unified_analytics
-      sha256: "406724e9231f8e30119673133c1087f9b24e2a75ba7111ea071253d57bb8f3b9"
+      sha256: "0917e37f5cd9d70dfd23889b6738b160affc6021861403524ceca94ab5fb0e21"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.14"
+    version: "8.0.16"
   universal_io:
     dependency: transitive
     description:
@@ -1753,18 +1761,18 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.3"
+    version: "4.6.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:
@@ -1833,10 +1841,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.1"
+    version: "7.0.1"
   xxh3:
     dependency: transitive
     description:
@@ -1865,10 +1873,10 @@ packages:
     dependency: transitive
     description:
       name: yet_another_json_isolate
-      sha256: fe45897501fa156ccefbfb9359c9462ce5dec092f05e8a56109db30be864f01e
+      sha256: eaa26beb5990b25a49d942374fd5a0c5aa67a837e03b14b4c26134aaa1ed01a9
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
   dart: ">=3.12.0 <4.0.0"
   flutter: ">=3.44.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -353,6 +353,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  cupertino_ui:
+    dependency: transitive
+    description:
+      name: cupertino_ui
+      sha256: "7ed8ce4159d342eec4c65f4ea6eec57adaf9365404378541f38efc1da20a5b3d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   dap:
     dependency: transitive
     description:
@@ -630,6 +638,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_localizations:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -984,6 +997,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.7296"
+  material_ui:
+    dependency: transitive
+    description:
+      name: material_ui
+      sha256: d9b4f6c69b80bc83d0a14357c86e4c14c8076e807ae73cf2960c8560f623995f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   melos:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,8 +47,8 @@ melos:
 
     prepare:demos:
       description: Download SQLite3 wasm for demos
-      run: dart run powersync:setup_web --no-worker
       exec:
+        command: dart run powersync:setup_web --no-worker
         concurrency: 1
       packageFilters:
         private: true
@@ -57,8 +57,8 @@ melos:
 
     prepare:assets:
       description: Download Sqlite3 WASM for tests
-      run: dart ./bin/setup_web.dart --no-worker --output-dir ../powersync/assets
       exec:
+        command: dart ./bin/setup_web.dart --no-worker --output-dir ../powersync/assets
         concurrency: 1
       packageFilters:
         scope: powersync

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ workspace:
 
 dependencies:
   lints: ^6.1.0
-  melos: ^7.5.0
+  melos: ^8.2.2
   test: ^1.25.0
   path: ^1.0.0
   yaml: ^3.1.2
@@ -35,12 +35,6 @@ hooks:
       # To run PowerSync encryption tests, replace this with sqlite3mc or sqlcipher and run
       # dart test -P encryption
       source: sqlite3
-
-dependency_overrides:
-  # The only drift version with support for version 3.x of the sqlite3 package
-  # needs this analyzer, but riverpod doesn't support it yet:
-  # https://github.com/rrousselGit/riverpod/pull/4680
-  analyzer: ^10.0.0
 
 melos:
   repository: https://github.com/powersync-ja/powersync.dart


### PR DESCRIPTION
This updates dependencies and adds support for the latest Flutter version:

- Migrate demos from `package:flutter/material.dart` to `package:material_ui` (these fixes were auto-generated with `dart fix`). The `supabase-trello` demo and the devtools extension has dependencies not supporting the new package yet, so I've left those unchanged. `supabase_todolist_drift` depends on `auto_route` which doesn't support `material_ui` either, but there are workarounds for that.
- Upgrade melos to 8.x and migrate the syntax for scripts.
- Remove dependency overrides that are no longer necessary, upgrade code generators and re-run the build in `supabase_todolist_drift`.

I have manually tested the two `supabase_todolist` packages.