### PR TITLE
Support new checkpoint request protocol

### DIFF
--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,5 +1,7 @@
-## 2.3.4 (unreleased)
+## 2.4.0 (unreleased)
 
+- Add `SyncOptions.checkpointMode`, which can be used to replace a legacy implementation for write checkpoints
+  with a newer and more efficient endpoint.
 - Reduce log noise from attachments service ([#408](https://github.com/powersync-ja/powersync.dart/issues/408)).
 - Fix errors that can't be sent across isolates disrupting the sync isolate.
 - Update PowerSync SQLite core extension to 0.5.3, improving error messages for failed internal SQL statements.

--- a/packages/powersync/lib/powersync.dart
+++ b/packages/powersync/lib/powersync.dart
@@ -1,4 +1,4 @@
-/// PowerSync Flutter SDK.
+/// PowerSync Dart and Flutter SDK.
 ///
 /// Use [PowerSyncDatabase] to open a database.
 library;
@@ -11,7 +11,8 @@ export 'src/database/encryption_options.dart';
 export 'src/exceptions.dart';
 export 'src/log.dart';
 export 'src/schema.dart';
-export 'src/sync/options.dart' hide ResolvedSyncOptions;
+export 'src/sync/options.dart'
+    hide ResolvedSyncOptions, LegacyCheckpointMode, RequestsCheckpointMode;
 export 'src/sync/stream.dart' hide CoreActiveStreamSubscription;
 export 'src/sync/sync_status.dart'
     hide BucketProgress, InternalSyncDownloadProgress, InternalSyncStatusAccess;

--- a/packages/powersync/lib/src/connector.dart
+++ b/packages/powersync/lib/src/connector.dart
@@ -1,5 +1,9 @@
+/// @docImport 'sync/options.dart';
+library;
+
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import 'package:meta/meta.dart';
 import 'database/powersync_database.dart';
 
 /// Implement this to connect an app backend.
@@ -67,6 +71,31 @@ abstract class PowerSyncBackendConnector {
   ///
   /// Any thrown errors will result in a retry after the configured wait period (default: 5 seconds).
   Future<void> uploadData(PowerSyncDatabase database);
+}
+
+/// A [PowerSyncBackendConnector] capable of requesting checkpoints.
+///
+/// Mix in this class in your backend connector implementations when uploads are
+/// processed asynchronously by the backend (for example through a message
+/// queue): The sync client as part of the PowerSync Dart SDK generates a
+/// checkpoint request id and hands it to your backend via
+/// [postCheckpointRequest], which is responsible for creating a matching
+/// checkpoint once the uploads preceeding the request have been processed.
+///
+/// For more details, see [asynchronous backend uploads](https://docs.powersync.com/client-sdks/advanced/checkpoint-requests#asynchronous-upload-backends).
+///
+/// To use this connector, using [CheckpointMode.requests] is required. Note
+/// that this requires PowerSync service version 1.24.0 or later.
+@experimental
+abstract mixin class CustomCheckpointRequestConnector
+    implements PowerSyncBackendConnector {
+  /// Posts a client-generated checkpoint request to the backend and returns the
+  /// effective checkpoint request state.
+  ///
+  /// [clientId] is a random uuid generated for this device, and [requestId] is
+  /// an incrementing 64-bit integer (encoded as a string to avoid precision
+  /// issues with JavaScript targets).
+  Future<String> postCheckpointRequest(String clientId, String requestId);
 }
 
 /// Temporary credentials to connect to the PowerSync service.

--- a/packages/powersync/lib/src/database/native/native_powersync_database.dart
+++ b/packages/powersync/lib/src/database/native/native_powersync_database.dart
@@ -113,6 +113,16 @@ final class NativePowerSyncDatabase extends BasePowerSyncDatabase {
           await (payload as PortCompleter).handle(() async {
             await connector.uploadData(this);
           });
+        case SyncIsolateToClientMessageType.customCheckpointRequest:
+          final (completer, clientId, requestId) =
+              payload as (PortCompleter<String?>, String, String);
+          completer.handle(() async {
+            if (connector is CustomCheckpointRequestConnector) {
+              return connector.postCheckpointRequest(clientId, requestId);
+            } else {
+              return null;
+            }
+          });
         case SyncIsolateToClientMessageType.status:
           final original = payload as SyncStatus;
           final recoveredDownloadError = switch (original.downloadError) {
@@ -305,6 +315,15 @@ Future<void> _syncIsolate(_PowerSyncDatabaseIsolateArgs args) async {
     return r.future;
   }
 
+  Future<String?> postCheckpointRequest(
+    String clientId,
+    String requestId,
+  ) async {
+    final r = results.createPending<String?>();
+    sPort.sendCustomCheckpointRequest(r.completer, clientId, requestId);
+    return r.future;
+  }
+
   runZonedGuarded(
     () async {
       final storage = BucketStorage(database);
@@ -315,6 +334,7 @@ Future<void> _syncIsolate(_PowerSyncDatabaseIsolateArgs args) async {
           getCredentialsCached: getCredentialsCached,
           prefetchCredentials: prefetchCredentials,
           uploadCrud: uploadCrud,
+          postCheckpointRequests: postCheckpointRequest,
         ),
         crudUpdateTriggerStream: database.onChange([
           'ps_crud',

--- a/packages/powersync/lib/src/database/native/native_powersync_database.dart
+++ b/packages/powersync/lib/src/database/native/native_powersync_database.dart
@@ -116,7 +116,7 @@ final class NativePowerSyncDatabase extends BasePowerSyncDatabase {
         case SyncIsolateToClientMessageType.customCheckpointRequest:
           final (completer, clientId, requestId) =
               payload as (PortCompleter<String?>, String, String);
-          completer.handle(() async {
+          await completer.handle(() async {
             if (connector is CustomCheckpointRequestConnector) {
               return connector.postCheckpointRequest(clientId, requestId);
             } else {

--- a/packages/powersync/lib/src/database/native/sync_isolate_protocol.dart
+++ b/packages/powersync/lib/src/database/native/sync_isolate_protocol.dart
@@ -112,7 +112,7 @@ extension type SyncClientPort(SendPort port) {
   }
 
   void sendCustomCheckpointRequest(
-    PortCompleter<void> completer,
+    PortCompleter<String?> completer,
     String clientId,
     String requestId,
   ) {

--- a/packages/powersync/lib/src/database/native/sync_isolate_protocol.dart
+++ b/packages/powersync/lib/src/database/native/sync_isolate_protocol.dart
@@ -30,6 +30,9 @@ enum SyncIsolateToClientMessageType {
   /// Upload the CRUD queue, payload is a [PortCompleter].
   uploadCrud,
 
+  /// Invoke [CustomCheckpointRequestConnector.postCheckpointRequest].
+  customCheckpointRequest,
+
   /// The sync status has changed, payload is a [SyncStatus].
   status,
 
@@ -106,6 +109,18 @@ extension type SyncClientPort(SendPort port) {
 
   void sendUploadCrud(PortCompleter<void> completer) {
     send(SyncIsolateToClientMessageType.uploadCrud, completer);
+  }
+
+  void sendCustomCheckpointRequest(
+    PortCompleter<void> completer,
+    String clientId,
+    String requestId,
+  ) {
+    send(SyncIsolateToClientMessageType.customCheckpointRequest, (
+      completer,
+      clientId,
+      requestId,
+    ));
   }
 
   void sendLog(LogRecord record) {

--- a/packages/powersync/lib/src/database/powersync_database.dart
+++ b/packages/powersync/lib/src/database/powersync_database.dart
@@ -315,6 +315,14 @@ abstract base class PowerSyncDatabase extends SqliteConnection {
       params: params,
     );
 
+    if (resolvedOptions.checkpointMode is! RequestsCheckpointMode &&
+        connector is CustomCheckpointRequestConnector) {
+      logger.warning(
+        'A CustomCheckpointRequestConnector was used with legacy checkpoints, '
+        'postCheckpointRequest will not get called',
+      );
+    }
+
     if (devtools.enable) {
       connector = ExposeCredentialsConnector(connector, this);
     }

--- a/packages/powersync/lib/src/devtools/expose_credentials_connector.dart
+++ b/packages/powersync/lib/src/devtools/expose_credentials_connector.dart
@@ -9,7 +9,16 @@ final class ExposeCredentialsConnector extends PowerSyncBackendConnector {
   final PowerSyncDatabase database;
   final PowerSyncBackendConnector inner;
 
-  ExposeCredentialsConnector(this.inner, this.database);
+  factory ExposeCredentialsConnector(
+    PowerSyncBackendConnector inner,
+    PowerSyncDatabase database,
+  ) {
+    return inner is CustomCheckpointRequestConnector
+        ? _ExposeCustomWriteCheckpointsConnector(inner, database)
+        : ExposeCredentialsConnector._(inner, database);
+  }
+
+  ExposeCredentialsConnector._(this.inner, this.database);
 
   @override
   Future<PowerSyncCredentials?> fetchCredentials() async {
@@ -25,5 +34,21 @@ final class ExposeCredentialsConnector extends PowerSyncBackendConnector {
   @override
   Future<void> uploadData(PowerSyncDatabase database) {
     return inner.uploadData(database);
+  }
+}
+
+final class _ExposeCustomWriteCheckpointsConnector
+    extends ExposeCredentialsConnector
+    with CustomCheckpointRequestConnector {
+  final CustomCheckpointRequestConnector _custom;
+
+  _ExposeCustomWriteCheckpointsConnector(
+    this._custom,
+    PowerSyncDatabase database,
+  ) : super._(_custom, database);
+
+  @override
+  Future<String> postCheckpointRequest(String clientId, String requestId) {
+    return _custom.postCheckpointRequest(clientId, requestId);
   }
 }

--- a/packages/powersync/lib/src/platform_specific/int64.dart
+++ b/packages/powersync/lib/src/platform_specific/int64.dart
@@ -13,7 +13,7 @@ abstract interface class Int64 {
 
   /// Whether the native Dart [int] type is backed by a real 64-bit integer
   /// (that is, we're not compiling to JavaScript).
-  static bool has64BitIntegers = !identical(0, 0.0);
+  static const bool has64BitIntegers = !identical(0, 0.0);
 }
 
 final class NativeInt64 implements Int64 {

--- a/packages/powersync/lib/src/platform_specific/int64.dart
+++ b/packages/powersync/lib/src/platform_specific/int64.dart
@@ -1,0 +1,34 @@
+import 'platform_specific.dart';
+
+/// A signed 64-bit integer.
+///
+/// We can't use [int] values directly because they're backed by [double]s on
+/// the web. At the same time, we want to avoid using [BigInt] on native
+/// platforms. We also don't use `package:fixnum` since it doesn't use the Dart
+/// native implementation when compiled to WebAssembly.
+abstract interface class Int64 {
+  static Int64 parse(String s) => parseInt64(s);
+
+  bool operator >=(Int64 other);
+}
+
+final class NativeInt64 implements Int64 {
+  final int value;
+
+  NativeInt64(this.value);
+
+  static NativeInt64 parse(String s) => NativeInt64(int.parse(s));
+
+  @override
+  bool operator >=(Int64 other) => other is NativeInt64 && value >= other.value;
+
+  @override
+  String toString() => value.toString();
+
+  @override
+  int get hashCode => value.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      other is NativeInt64 && value == other.value;
+}

--- a/packages/powersync/lib/src/platform_specific/int64.dart
+++ b/packages/powersync/lib/src/platform_specific/int64.dart
@@ -10,12 +10,16 @@ abstract interface class Int64 {
   static Int64 parse(String s) => parseInt64(s);
 
   bool operator >=(Int64 other);
+
+  /// Whether the native Dart [int] type is backed by a real 64-bit integer
+  /// (that is, we're not compiling to JavaScript).
+  static bool has64BitIntegers = !identical(0, 0.0);
 }
 
 final class NativeInt64 implements Int64 {
   final int value;
 
-  NativeInt64(this.value);
+  NativeInt64(this.value) : assert(Int64.has64BitIntegers);
 
   static NativeInt64 parse(String s) => NativeInt64(int.parse(s));
 

--- a/packages/powersync/lib/src/platform_specific/native.dart
+++ b/packages/powersync/lib/src/platform_specific/native.dart
@@ -6,6 +6,9 @@ import '../database/native/native_powersync_database.dart';
 import '../database/powersync_database.dart';
 import '../open_factory/native/native_open_factory.dart';
 import '../schema.dart';
+import 'int64.dart';
+
+Int64 parseInt64(String s) => NativeInt64.parse(s);
 
 Mutex potentiallySharedMutex(String identifier) {
   return Mutex.simple();

--- a/packages/powersync/lib/src/platform_specific/unsupported.dart
+++ b/packages/powersync/lib/src/platform_specific/unsupported.dart
@@ -4,10 +4,13 @@ import 'package:sqlite_async/sqlite_async.dart';
 import '../database/encryption_options.dart';
 import '../database/powersync_database.dart';
 import '../schema.dart';
+import 'int64.dart';
 
 Never _unsupportedPlatform() {
   throw UnsupportedError('Unsupported platform for PowerSync SDK');
 }
+
+Int64 parseInt64(String s) => _unsupportedPlatform();
 
 /// Creates a [Mutex] that might be shared across isolates and tabs.
 ///

--- a/packages/powersync/lib/src/platform_specific/web.dart
+++ b/packages/powersync/lib/src/platform_specific/web.dart
@@ -49,7 +49,7 @@ Int64 parseInt64(String s) {
   if (has64BitInts) {
     return NativeInt64.parse(s);
   } else {
-    return JsBigInt64(JsBigInt64._stringToBigInt(s.toJS));
+    return JsBigInt64(_stringToBigInt(s.toJS));
   }
 }
 
@@ -76,13 +76,13 @@ final class JsBigInt64 implements Int64 {
   bool operator ==(Object other) {
     return other is JsBigInt64 && value.strictEquals(other.value).toDart;
   }
-
-  @JS('String')
-  external static JSString _bigIntToString(JSBigInt value);
-
-  @JS('Number')
-  external static JSNumber _bigIntToDouble(JSBigInt value);
-
-  @JS('BigInt')
-  external static JSBigInt _stringToBigInt(JSString value);
 }
+
+@JS('String')
+external JSString _bigIntToString(JSBigInt value);
+
+@JS('Number')
+external JSNumber _bigIntToDouble(JSBigInt value);
+
+@JS('BigInt')
+external JSBigInt _stringToBigInt(JSString value);

--- a/packages/powersync/lib/src/platform_specific/web.dart
+++ b/packages/powersync/lib/src/platform_specific/web.dart
@@ -1,3 +1,5 @@
+import 'dart:js_interop';
+
 import 'package:logging/logging.dart';
 import 'package:sqlite_async/sqlite_async.dart';
 // ignore: implementation_imports
@@ -8,6 +10,7 @@ import '../database/powersync_database.dart';
 import '../database/web/web_powersync_database.dart';
 import '../open_factory/web/web_open_factory.dart';
 import '../schema.dart';
+import 'int64.dart';
 
 /// Creates a [Mutex] that might be shared across isolates and tabs.
 ///
@@ -39,4 +42,47 @@ BasePowerSyncDatabase openPowerSyncDatabase(
     database: database,
     logger: logger,
   );
+}
+
+Int64 parseInt64(String s) {
+  const has64BitInts = !identical(0, 0.0);
+  if (has64BitInts) {
+    return NativeInt64.parse(s);
+  } else {
+    return JsBigInt64(JsBigInt64._stringToBigInt(s.toJS));
+  }
+}
+
+final class JsBigInt64 implements Int64 {
+  final JSBigInt value;
+
+  JsBigInt64(this.value);
+
+  @override
+  bool operator >=(Int64 other) {
+    return other is JsBigInt64 &&
+        value.greaterThanOrEqualTo(other.value).toDart;
+  }
+
+  @override
+  String toString() {
+    return _bigIntToString(value).toDart;
+  }
+
+  @override
+  int get hashCode => _bigIntToDouble(value).toDartInt;
+
+  @override
+  bool operator ==(Object other) {
+    return other is JsBigInt64 && value.strictEquals(other.value).toDart;
+  }
+
+  @JS('String')
+  external static JSString _bigIntToString(JSBigInt value);
+
+  @JS('Number')
+  external static JSNumber _bigIntToDouble(JSBigInt value);
+
+  @JS('BigInt')
+  external static JSBigInt _stringToBigInt(JSString value);
 }

--- a/packages/powersync/lib/src/platform_specific/web.dart
+++ b/packages/powersync/lib/src/platform_specific/web.dart
@@ -45,8 +45,7 @@ BasePowerSyncDatabase openPowerSyncDatabase(
 }
 
 Int64 parseInt64(String s) {
-  const has64BitInts = !identical(0, 0.0);
-  if (has64BitInts) {
+  if (Int64.has64BitIntegers) {
     return NativeInt64.parse(s);
   } else {
     return JsBigInt64(_stringToBigInt(s.toJS));
@@ -56,7 +55,7 @@ Int64 parseInt64(String s) {
 final class JsBigInt64 implements Int64 {
   final JSBigInt value;
 
-  JsBigInt64(this.value);
+  JsBigInt64(this.value) : assert(!Int64.has64BitIntegers);
 
   @override
   bool operator >=(Int64 other) {

--- a/packages/powersync/lib/src/sync/bucket_storage.dart
+++ b/packages/powersync/lib/src/sync/bucket_storage.dart
@@ -184,7 +184,9 @@ extension PowerSyncControl on SqliteReadContext {
 
   /// Increments [currentCheckpointRequestId], used after uploading local
   /// mutations to require a new checkpoint.
-  Future<String?> nextCheckpointRequestId() {
-    return _checkpointRequestId('next', null);
+  Future<String> nextCheckpointRequestId() async {
+    // next_checkpoint_request_id cannot return null, the core extension would
+    // report an error instead.
+    return (await _checkpointRequestId('next', null))!;
   }
 }

--- a/packages/powersync/lib/src/sync/bucket_storage.dart
+++ b/packages/powersync/lib/src/sync/bucket_storage.dart
@@ -25,6 +25,15 @@ extension type BucketStorage(SqliteConnection _internalDb) {
     return rows.first['client_id'] as String;
   }
 
+  Future<T> writeTransaction<T>(
+    Future<T> Function(SqliteWriteContext) run, {
+    required Future<void> onAbort,
+  }) {
+    return _internalDb.abortableWriteLock(abortTrigger: onAbort, (lock) {
+      return lock.writeTransaction(run);
+    });
+  }
+
   Future<bool> updateTargetCheckpointRequest(
     Future<String> Function() checkpointCallback,
   ) async {
@@ -136,6 +145,10 @@ extension PowerSyncControl on SqliteReadContext {
     return row.columnAt(0) as String?;
   }
 
+  Future<String?> _checkpointRequestId(String type, String? update) async {
+    return await _control('${type}_checkpoint_request_id', update);
+  }
+
   /// Reads the current target checkpoint request id, or updates it when an
   /// [update] is supplied.
   ///
@@ -147,7 +160,31 @@ extension PowerSyncControl on SqliteReadContext {
   /// [maxOpId] can be used as a sentinel value in case there are pending
   /// changes that have been uploaded, but for which no checkpoint request has
   /// been created yet.
-  Future<String?> targetCheckpointRequestId([String? update]) async {
-    return await _control('target_checkpoint_request_id', update);
+  Future<String?> targetCheckpointRequestId([String? update]) {
+    return _checkpointRequestId('target', update);
+  }
+
+  /// Reconciles a local checkpoint counter with a response from the service.
+  ///
+  /// Seeding checkpoint requests servces has two purposes:
+  ///
+  ///  1. The service is allowed to forget our checkpoint counter, so we remind
+  ///     it whenever we connect.
+  ///  2. Checkpoint requests are scoped to user and device ids, but our local
+  ///     counter is per-device. Seeding ensures we correctly generate
+  ///     incrementing checkpoint ids after switching accounts.
+  Future<void> seedCheckpointRequestId(String serviceResponse) {
+    return _checkpointRequestId('seed', serviceResponse);
+  }
+
+  /// The highest checkpoint request id that has been requested on this device.
+  Future<String?> currentCheckpointRequestId() {
+    return _checkpointRequestId('current', null);
+  }
+
+  /// Increments [currentCheckpointRequestId], used after uploading local
+  /// mutations to require a new checkpoint.
+  Future<String?> nextCheckpointRequestId() {
+    return _checkpointRequestId('next', null);
   }
 }

--- a/packages/powersync/lib/src/sync/checkpoint_request.dart
+++ b/packages/powersync/lib/src/sync/checkpoint_request.dart
@@ -1,0 +1,26 @@
+import 'package:meta/meta.dart';
+
+/// An exception related to requested checkpoints for PowerSync.
+final class CheckpointRequestException implements Exception {
+  final String _message;
+
+  const CheckpointRequestException._(this._message);
+
+  @override
+  String toString() => _message;
+}
+
+@internal
+const instanceNotSupported = CheckpointRequestException._(
+  'The PowerSync service does not support checkpoint requests. Update to PowerSync service version 1.24.0 or later to use this API.',
+);
+
+@internal
+const disconnected = CheckpointRequestException._(
+  'Cannot request checkpoints, sync client is disconnected',
+);
+
+@internal
+const disabled = CheckpointRequestException._(
+  'Connected with legacy checkpoint mode, cannot request checkpoints',
+);

--- a/packages/powersync/lib/src/sync/checkpoint_state.dart
+++ b/packages/powersync/lib/src/sync/checkpoint_state.dart
@@ -43,12 +43,12 @@ final class CheckpointStateSignals {
     return _waitingForWaiter.future;
   }
 
-  Future<void> markCheckpointsReady(Future<void> initialization) async {
-    final result = await Result.capture(initialization);
-    _updateState(_CheckpointSeeded(result));
+  void markCheckpointsReady() {
+    _updateState(_CheckpointSeeded(Result.value(null)));
+  }
 
-    // Rethrow errors (if there was one).
-    return await result.asFuture;
+  void markCheckpointsFailed(Object error, StackTrace trace) {
+    _updateState(_CheckpointSeeded(Result.error(error, trace)));
   }
 
   /// Waits until a download iteration is active and has seeded the checkpoint

--- a/packages/powersync/lib/src/sync/checkpoint_state.dart
+++ b/packages/powersync/lib/src/sync/checkpoint_state.dart
@@ -1,0 +1,110 @@
+import 'dart:async';
+
+import 'package:async/async.dart';
+import 'package:sqlite_async/sqlite_async.dart' show AbortException;
+
+import 'checkpoint_request.dart';
+
+final class CheckpointStateSignals {
+  _CheckpointState _currentState = const _Pending();
+  final _stateController = StreamController<_CheckpointState>.broadcast();
+
+  Completer<void> _waitingForWaiter = Completer();
+
+  void _updateState(_CheckpointState state) {
+    _currentState = state;
+    _stateController.add(state);
+  }
+
+  /// Marks the current download iteration as ended, blocking new checkpoint
+  /// requests until the seed was performed in the next iteration.
+  ///
+  /// Returns a future that completes early once
+  /// [waitForCheckpointRequestsReady] is called.
+  void downloadIterationEnded() {
+    // Checkpoint waiters called after this should be able to resume the
+    // download iteration.
+    _waitingForWaiter = Completer();
+    _updateState(const _Pending());
+  }
+
+  /// Marks the sync client as disconnected, failing all outstanding checkpoint
+  /// requests and preventing new ones.
+  void disconnect() {
+    _updateState(const _Disconnected());
+  }
+
+  /// Waits for a waiter wanting torequest a checkpoint.
+  ///
+  /// As the waiter is blocked for a seed run we start in the download
+  /// iteration we use this to wake up the download iteration if it's currently
+  /// paused.
+  Future<void> waitForCheckpointWaiter() {
+    return _waitingForWaiter.future;
+  }
+
+  Future<void> markCheckpointsReady(Future<void> initialization) async {
+    final result = await Result.capture(initialization);
+    _updateState(_CheckpointSeeded(result));
+
+    // Rethrow errors (if there was one).
+    return await result.asFuture;
+  }
+
+  /// Waits until a download iteration is active and has seeded the checkpoint
+  /// state, meaning that checkpoint ids can safely be allocated.
+  Future<void> waitForCheckpointRequestsReady({
+    required Future<void> abort,
+    bool wakeDownloadLoop = true,
+  }) {
+    final completer = Completer<void>();
+    final subscription = _stateController.stream.listen(null);
+
+    void handleState(_CheckpointState state) {
+      switch (state) {
+        case _Disconnected():
+          completer.completeError(disconnected);
+          subscription.cancel();
+        case _CheckpointSeeded(:final result):
+          completer.complete(result.asFuture);
+          subscription.cancel();
+        case _Pending():
+          if (wakeDownloadLoop && !_waitingForWaiter.isCompleted) {
+            _waitingForWaiter.complete();
+          }
+      }
+    }
+
+    subscription.onData(handleState);
+    handleState(_currentState);
+
+    abort.whenComplete(() {
+      if (!completer.isCompleted) {
+        completer.completeError(
+          AbortException('waitForCheckpointRequestsReady'),
+        );
+        subscription.cancel();
+      }
+    });
+
+    return completer.future;
+  }
+}
+
+sealed class _CheckpointState {
+  const _CheckpointState();
+}
+
+final class _Pending extends _CheckpointState {
+  const _Pending();
+}
+
+final class _CheckpointSeeded extends _CheckpointState {
+  final Result<void> result;
+
+  _CheckpointSeeded(this.result);
+}
+
+final class _Disconnected extends _CheckpointState {
+  const _Disconnected();
+}

--- a/packages/powersync/lib/src/sync/instruction.dart
+++ b/packages/powersync/lib/src/sync/instruction.dart
@@ -1,3 +1,4 @@
+import '../platform_specific/int64.dart';
 import 'stream.dart';
 import 'sync_status.dart';
 
@@ -45,11 +46,37 @@ final class LogLine implements NonInterruptingInstruction {
 
 final class EstablishSyncStream implements Instruction {
   final Map<String, Object?> request;
+  final CheckpointRequestPayload? checkpointRequest;
 
-  EstablishSyncStream(this.request);
+  EstablishSyncStream(this.request, {this.checkpointRequest});
 
   factory EstablishSyncStream.fromJson(Map<String, Object?> json) {
-    return EstablishSyncStream(json['request'] as Map<String, Object?>);
+    return EstablishSyncStream(
+      json['request'] as Map<String, Object?>,
+      checkpointRequest: switch (json['checkpoint_request']) {
+        null => null,
+        final request => CheckpointRequestPayload.fromJson(
+          request as Map<String, Object?>,
+        ),
+      },
+    );
+  }
+}
+
+final class CheckpointRequestPayload {
+  final String clientId;
+  final String checkpointRequestId;
+
+  CheckpointRequestPayload({
+    required this.clientId,
+    required this.checkpointRequestId,
+  });
+
+  factory CheckpointRequestPayload.fromJson(Map<String, Object?> json) {
+    return CheckpointRequestPayload(
+      clientId: json['client_id'] as String,
+      checkpointRequestId: json['checkpoint_request_id'] as String,
+    );
   }
 }
 
@@ -71,6 +98,7 @@ final class CoreSyncStatus {
   final List<SyncPriorityStatus> priorityStatus;
   final DownloadProgress? downloading;
   final List<CoreActiveStreamSubscription>? streams;
+  final Int64? lastAppliedCheckpointRequestId;
 
   CoreSyncStatus({
     required this.connected,
@@ -78,6 +106,7 @@ final class CoreSyncStatus {
     required this.priorityStatus,
     required this.downloading,
     required this.streams,
+    required this.lastAppliedCheckpointRequestId,
   });
 
   factory CoreSyncStatus.fromJson(Map<String, Object?> json) {
@@ -99,6 +128,12 @@ final class CoreSyncStatus {
             ),
           )
           .toList(),
+      lastAppliedCheckpointRequestId:
+          switch (json['internal_last_applied_checkpoint_request_id']
+              as String?) {
+            null => null,
+            final requestId => Int64.parse(requestId),
+          },
     );
   }
 

--- a/packages/powersync/lib/src/sync/internal_connector.dart
+++ b/packages/powersync/lib/src/sync/internal_connector.dart
@@ -25,17 +25,22 @@ abstract interface class InternalConnector {
   Future<void> uploadCrud();
 
   FutureOr<String?> postCheckpointRequest(
-      String clientId, String checkpointRequestId);
+    String clientId,
+    String checkpointRequestId,
+  );
 
   const factory InternalConnector({
     required Future<PowerSyncCredentials?> Function() getCredentialsCached,
     required Future<PowerSyncCredentials?> Function({required bool invalidate})
-        prefetchCredentials,
+    prefetchCredentials,
     required Future<void> Function() uploadCrud,
+    required Future<String?> Function(String, String) postCheckpointRequests,
   }) = _CallbackConnector;
 
   factory InternalConnector.wrap(
-      PowerSyncBackendConnector connector, PowerSyncDatabase db) {
+    PowerSyncBackendConnector connector,
+    PowerSyncDatabase db,
+  ) {
     return _WrapConnector(connector, db);
   }
 }
@@ -66,7 +71,9 @@ final class _WrapConnector implements InternalConnector {
 
   @override
   FutureOr<String?> postCheckpointRequest(
-      String clientId, String checkpointRequestId) {
+    String clientId,
+    String checkpointRequestId,
+  ) {
     if (connector case final CustomCheckpointRequestConnector custom) {
       return custom.postCheckpointRequest(clientId, checkpointRequestId);
     }
@@ -78,20 +85,20 @@ final class _WrapConnector implements InternalConnector {
 final class _CallbackConnector implements InternalConnector {
   final Future<PowerSyncCredentials?> Function() _getCredentialsCached;
   final Future<PowerSyncCredentials?> Function({required bool invalidate})
-      _prefetchCredentials;
+  _prefetchCredentials;
   final Future<void> Function() _uploadCrud;
-  final Future<String> Function(String, String)? _postCheckpointRequest;
+  final Future<String?> Function(String, String)? _postCheckpointRequest;
 
   const _CallbackConnector({
     required Future<PowerSyncCredentials?> Function() getCredentialsCached,
     required Future<PowerSyncCredentials?> Function({required bool invalidate})
-        prefetchCredentials,
+    prefetchCredentials,
     required Future<void> Function() uploadCrud,
-    Future<String> Function(String, String)? postCheckpointRequests,
-  })  : _getCredentialsCached = getCredentialsCached,
-        _prefetchCredentials = prefetchCredentials,
-        _uploadCrud = uploadCrud,
-        _postCheckpointRequest = postCheckpointRequests;
+    required Future<String?> Function(String, String) postCheckpointRequests,
+  }) : _getCredentialsCached = getCredentialsCached,
+       _prefetchCredentials = prefetchCredentials,
+       _uploadCrud = uploadCrud,
+       _postCheckpointRequest = postCheckpointRequests;
 
   @override
   Future<PowerSyncCredentials?> getCredentialsCached() {
@@ -110,7 +117,9 @@ final class _CallbackConnector implements InternalConnector {
 
   @override
   FutureOr<String?> postCheckpointRequest(
-      String clientId, String checkpointRequestId) {
+    String clientId,
+    String checkpointRequestId,
+  ) {
     if (_postCheckpointRequest case final implementation?) {
       return implementation(clientId, checkpointRequestId);
     }

--- a/packages/powersync/lib/src/sync/internal_connector.dart
+++ b/packages/powersync/lib/src/sync/internal_connector.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:meta/meta.dart';
 
 import '../connector.dart';
@@ -22,17 +24,18 @@ abstract interface class InternalConnector {
   /// Requests the connector to upload a crud batch to the backend.
   Future<void> uploadCrud();
 
+  FutureOr<String?> postCheckpointRequest(
+      String clientId, String checkpointRequestId);
+
   const factory InternalConnector({
     required Future<PowerSyncCredentials?> Function() getCredentialsCached,
     required Future<PowerSyncCredentials?> Function({required bool invalidate})
-    prefetchCredentials,
+        prefetchCredentials,
     required Future<void> Function() uploadCrud,
   }) = _CallbackConnector;
 
   factory InternalConnector.wrap(
-    PowerSyncBackendConnector connector,
-    PowerSyncDatabase db,
-  ) {
+      PowerSyncBackendConnector connector, PowerSyncDatabase db) {
     return _WrapConnector(connector, db);
   }
 }
@@ -60,22 +63,35 @@ final class _WrapConnector implements InternalConnector {
   Future<void> uploadCrud() {
     return connector.uploadData(database);
   }
+
+  @override
+  FutureOr<String?> postCheckpointRequest(
+      String clientId, String checkpointRequestId) {
+    if (connector case final CustomCheckpointRequestConnector custom) {
+      return custom.postCheckpointRequest(clientId, checkpointRequestId);
+    }
+
+    return null;
+  }
 }
 
 final class _CallbackConnector implements InternalConnector {
   final Future<PowerSyncCredentials?> Function() _getCredentialsCached;
   final Future<PowerSyncCredentials?> Function({required bool invalidate})
-  _prefetchCredentials;
+      _prefetchCredentials;
   final Future<void> Function() _uploadCrud;
+  final Future<String> Function(String, String)? _postCheckpointRequest;
 
   const _CallbackConnector({
     required Future<PowerSyncCredentials?> Function() getCredentialsCached,
     required Future<PowerSyncCredentials?> Function({required bool invalidate})
-    prefetchCredentials,
+        prefetchCredentials,
     required Future<void> Function() uploadCrud,
-  }) : _getCredentialsCached = getCredentialsCached,
-       _prefetchCredentials = prefetchCredentials,
-       _uploadCrud = uploadCrud;
+    Future<String> Function(String, String)? postCheckpointRequests,
+  })  : _getCredentialsCached = getCredentialsCached,
+        _prefetchCredentials = prefetchCredentials,
+        _uploadCrud = uploadCrud,
+        _postCheckpointRequest = postCheckpointRequests;
 
   @override
   Future<PowerSyncCredentials?> getCredentialsCached() {
@@ -90,5 +106,15 @@ final class _CallbackConnector implements InternalConnector {
   @override
   Future<void> uploadCrud() {
     return _uploadCrud();
+  }
+
+  @override
+  FutureOr<String?> postCheckpointRequest(
+      String clientId, String checkpointRequestId) {
+    if (_postCheckpointRequest case final implementation?) {
+      return implementation(clientId, checkpointRequestId);
+    }
+
+    return null;
   }
 }

--- a/packages/powersync/lib/src/sync/mutable_sync_status.dart
+++ b/packages/powersync/lib/src/sync/mutable_sync_status.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:collection/collection.dart';
 
+import '../platform_specific/int64.dart';
 import 'instruction.dart';
 import 'stream.dart';
 import 'sync_status.dart';
@@ -15,6 +16,7 @@ final class MutableSyncStatus {
   InternalSyncDownloadProgress? downloadProgress;
   List<SyncPriorityStatus> priorityStatusEntries = const [];
   List<CoreActiveStreamSubscription>? streams;
+  Int64? lastAppliedCheckpointRequestId;
 
   DateTime? lastSyncedAt;
 
@@ -47,6 +49,7 @@ final class MutableSyncStatus {
         .firstWhereOrNull((s) => s.priority == StreamPriority.fullSyncPriority)
         ?.lastSyncedAt;
     streams = status.streams;
+    lastAppliedCheckpointRequestId = status.lastAppliedCheckpointRequestId;
   }
 
   SyncStatus immutableSnapshot() {

--- a/packages/powersync/lib/src/sync/options.dart
+++ b/packages/powersync/lib/src/sync/options.dart
@@ -226,7 +226,7 @@ extension type ResolvedSyncOptions(SyncOptions source) {
           other.includeDefaultStreams ?? includeDefaultStreams,
       appMetadata: other.appMetadata ?? appMetadata,
       httpClient: other.httpClient ?? source.httpClient,
-      checkpointMode: other.checkpointMode ?? source.checkpointMode,
+      checkpointMode: other.checkpointMode ?? checkpointMode,
     );
 
     final didChange =

--- a/packages/powersync/lib/src/sync/options.dart
+++ b/packages/powersync/lib/src/sync/options.dart
@@ -58,6 +58,15 @@ final class SyncOptions {
   /// Note that this function is sent across isolates on native platforms.
   final HttpClientFactory? httpClient;
 
+  /// The [CheckpointMode] used to request checkpoints from the PowerSync
+  /// service.
+  ///
+  /// Checkpoint requests are used to request a confirmation after uploading
+  /// local mutations. This defaults to [CheckpointMode.legacy], but can be set
+  /// to [CheckpointMode.requests] when PowerSync service version 1.24.0 or
+  /// later is used.
+  final CheckpointMode? checkpointMode;
+
   const SyncOptions({
     this.crudThrottleTime,
     this.retryDelay,
@@ -66,6 +75,7 @@ final class SyncOptions {
     this.includeDefaultStreams,
     this.appMetadata,
     this.httpClient,
+    this.checkpointMode,
   });
 
   SyncOptions _copyWith({
@@ -82,8 +92,76 @@ final class SyncOptions {
       includeDefaultStreams: includeDefaultStreams,
       appMetadata: appMetadata ?? this.appMetadata,
       httpClient: httpClient,
+      checkpointMode: checkpointMode,
     );
   }
+}
+
+/// The mechanism to reqeuest checkpoints from the PowerSync service.
+///
+/// Checkpoint requests are used after a client uploads local mutations. The
+/// PowerSync service later references them in downloaded data, allowing the SDK
+/// to assume that uploaded data has been synced down again.
+///
+/// There are two ways to send checkpoint requests: A legacy (but default and
+/// stable) format supported by all PowerSync service versions, and a newer
+/// ([CheckpointMode.requests]) method which is only available from PowerSync
+/// service version 1.24.0 or later.
+final class CheckpointMode {
+  const CheckpointMode._();
+
+  /// Uses an older mechanism for requesting checkpoints supported by all
+  /// PowerSync service versions.
+  const factory CheckpointMode.legacy() = LegacyCheckpointMode;
+
+  /// Uses a newer endpoint supported from PowerSync service 1.24.0 or later.
+  /// This method is more efficient and has better support for switching users
+  /// in your app.
+  ///
+  /// Requested checkpoints are retried automatically, using the configured
+  /// [retryDelay] (which defaults to 10 seconds, but can also be configured to
+  /// use a longer retry interval).
+  @experimental
+  factory CheckpointMode.requests({Duration retryDelay}) =
+      RequestsCheckpointMode;
+}
+
+@internal
+final class LegacyCheckpointMode extends CheckpointMode {
+  const LegacyCheckpointMode() : super._();
+
+  @override
+  bool operator ==(Object other) => other is LegacyCheckpointMode;
+
+  @override
+  int get hashCode => 'legacy'.hashCode;
+}
+
+final class RequestsCheckpointMode extends CheckpointMode {
+  final Duration retryDelay;
+
+  RequestsCheckpointMode({this.retryDelay = _defaultRetryDelay}) : super._() {
+    if (retryDelay < _minimumRetryDelay) {
+      throw ArgumentError.value(
+        retryDelay,
+        'retryDelay',
+        'Must be at least $_minimumRetryDelay',
+      );
+    }
+  }
+
+  @visibleForTesting
+  const RequestsCheckpointMode.unverifiedDuration(this.retryDelay) : super._();
+
+  @override
+  bool operator ==(Object other) =>
+      other is RequestsCheckpointMode && other.retryDelay == retryDelay;
+
+  @override
+  int get hashCode => retryDelay.hashCode;
+
+  static const _minimumRetryDelay = Duration(seconds: 10);
+  static const _defaultRetryDelay = _minimumRetryDelay;
 }
 
 /// Older versions of the PowerSync SDK offered two sync client implementations.
@@ -133,6 +211,9 @@ extension type ResolvedSyncOptions(SyncOptions source) {
 
   bool get includeDefaultStreams => source.includeDefaultStreams ?? true;
 
+  CheckpointMode get checkpointMode =>
+      source.checkpointMode ?? const CheckpointMode.legacy();
+
   Client createHttpClient() => source.httpClient?.call() ?? Client();
 
   (ResolvedSyncOptions, bool) applyFrom(SyncOptions other) {
@@ -145,6 +226,7 @@ extension type ResolvedSyncOptions(SyncOptions source) {
           other.includeDefaultStreams ?? includeDefaultStreams,
       appMetadata: other.appMetadata ?? appMetadata,
       httpClient: other.httpClient ?? source.httpClient,
+      checkpointMode: other.checkpointMode ?? source.checkpointMode,
     );
 
     final didChange =
@@ -153,7 +235,8 @@ extension type ResolvedSyncOptions(SyncOptions source) {
         newOptions.retryDelay != retryDelay ||
         newOptions.syncImplementation != source.syncImplementation ||
         newOptions.includeDefaultStreams != includeDefaultStreams ||
-        !_mapEquality.equals(newOptions.appMetadata, appMetadata);
+        !_mapEquality.equals(newOptions.appMetadata, appMetadata) ||
+        newOptions.checkpointMode != checkpointMode;
     return (ResolvedSyncOptions(newOptions), didChange);
   }
 

--- a/packages/powersync/lib/src/sync/options.dart
+++ b/packages/powersync/lib/src/sync/options.dart
@@ -150,7 +150,6 @@ final class RequestsCheckpointMode extends CheckpointMode {
     }
   }
 
-  @visibleForTesting
   const RequestsCheckpointMode.unverifiedDuration(this.retryDelay) : super._();
 
   @override

--- a/packages/powersync/lib/src/sync/streaming_sync.dart
+++ b/packages/powersync/lib/src/sync/streaming_sync.dart
@@ -658,7 +658,7 @@ final class _ActiveRustStreamingIteration {
         clientId: payload.clientId,
       );
 
-      sync.adapter.writeTransaction(
+      await sync.adapter.writeTransaction(
         (tx) => tx.seedCheckpointRequestId(seed),
         onAbort: abort.onAbort,
       );

--- a/packages/powersync/lib/src/sync/streaming_sync.dart
+++ b/packages/powersync/lib/src/sync/streaming_sync.dart
@@ -188,12 +188,15 @@ class StreamingSyncImplementation implements StreamingSync {
       // On error, wait a little before retrying
       // When aborting, don't wait
       if (!abort.aborted && delayNextIteration) {
-        final (retryDelay, completeEarly) = _delayOr(_retryDelay);
-        _checkpointState.waitForCheckpointWaiter().whenComplete(() {
-          completeEarly();
-        });
+        await abort.scoped((onAbort) {
+          final (retryDelay, completeEarly) = _delayOr(_retryDelay);
+          onAbort.whenComplete(completeEarly);
+          _checkpointState.waitForCheckpointWaiter().whenComplete(
+            completeEarly,
+          );
 
-        await retryDelay;
+          return retryDelay;
+        });
       }
     }
   }
@@ -594,6 +597,7 @@ final class _ActiveRustStreamingIteration {
     const defaultResult = (immediateRestart: false);
     return _abortController.scoped((onAbort) async {
       Stream<SyncEvent>? events;
+      AbortController? checkpointSeed;
 
       for (final startInstruction in await _startCommand()) {
         switch (startInstruction) {
@@ -604,7 +608,9 @@ final class _ActiveRustStreamingIteration {
             );
 
             if (checkpointRequest != null) {
-              _seedCheckpointRequests(checkpointRequest, onAbort);
+              final nested = checkpointSeed = AbortController();
+
+              _seedCheckpointRequests(checkpointRequest, nested);
             }
           case CloseSyncStream():
             return defaultResult;
@@ -617,6 +623,9 @@ final class _ActiveRustStreamingIteration {
       try {
         return await _handleLines(events);
       } finally {
+        await checkpointSeed?.abort();
+
+        sync._checkpointState.downloadIterationEnded();
         await _stop();
       }
     });
@@ -640,27 +649,31 @@ final class _ActiveRustStreamingIteration {
 
   void _seedCheckpointRequests(
     CheckpointRequestPayload payload,
-    Future<void> abortTrigger,
+    AbortController abort,
   ) async {
     try {
-      await sync._checkpointState.markCheckpointsReady(
-        Future(() async {
-          final seed = await sync._requestCheckpointFromService(
-            checkpointRequest: payload.checkpointRequestId,
-            abortTrigger: abortTrigger,
-            clientId: payload.clientId,
-          );
-
-          sync.adapter.writeTransaction(
-            (tx) => tx.seedCheckpointRequestId(seed),
-            onAbort: abortTrigger,
-          );
-        }),
+      final seed = await sync._requestCheckpointFromService(
+        checkpointRequest: payload.checkpointRequestId,
+        abortTrigger: abort.onAbort,
+        clientId: payload.clientId,
       );
+
+      sync.adapter.writeTransaction(
+        (tx) => tx.seedCheckpointRequestId(seed),
+        onAbort: abort.onAbort,
+      );
+
+      sync._checkpointState.markCheckpointsReady();
     } catch (e, s) {
       if (!_aborted) {
         sync._nonLineSyncEvents.add(CheckpointSeedFailed(e, s));
+
+        // If this was aborted, syncIteration() is about to reset the state
+        // anyway.
+        sync._checkpointState.markCheckpointsFailed(e, s);
       }
+    } finally {
+      abort.completeAbort();
     }
   }
 

--- a/packages/powersync/lib/src/sync/streaming_sync.dart
+++ b/packages/powersync/lib/src/sync/streaming_sync.dart
@@ -14,8 +14,11 @@ import 'package:sqlite_async/sqlite_async.dart';
 
 import '../connector.dart';
 import '../crud.dart';
+import '../platform_specific/int64.dart';
 import '../platform_specific/platform_specific.dart';
 import 'bucket_storage.dart';
+import 'checkpoint_request.dart' as checkpoint;
+import 'checkpoint_state.dart';
 import 'instruction.dart';
 import 'internal_connector.dart';
 import 'mutable_sync_status.dart';
@@ -54,6 +57,7 @@ class StreamingSyncImplementation implements StreamingSync {
   final http.Client _client;
 
   final SyncStatusStateStream _state = SyncStatusStateStream();
+  final CheckpointStateSignals _checkpointState = CheckpointStateSignals();
 
   AbortController? _abort;
 
@@ -62,7 +66,7 @@ class StreamingSyncImplementation implements StreamingSync {
       StreamController.broadcast();
 
   final Map<String, String> _userAgentHeaders;
-  String? clientId;
+  String? _clientId;
 
   StreamingSyncImplementation({
     required this.schemaJson,
@@ -131,7 +135,7 @@ class StreamingSyncImplementation implements StreamingSync {
     final abort = _abort = AbortController();
 
     try {
-      clientId = await adapter.getClientId();
+      await _resolveClientId();
 
       final crudLoop = _crudLoop(abort).onError((
         Object error,
@@ -142,10 +146,19 @@ class StreamingSyncImplementation implements StreamingSync {
         logger.warning('Error in crud upload loop', error, stackTrace);
       });
 
-      await (crudLoop, _downloadLoop(abort)).wait;
+      await (
+        crudLoop,
+        _downloadLoop(abort),
+        _repostUnacknowledgedCheckpointRequests(abort),
+      ).wait;
     } finally {
+      _checkpointState.disconnect();
       abort.completeAbort();
     }
+  }
+
+  Future<String> _resolveClientId() async {
+    return (_clientId ??= await adapter.getClientId());
   }
 
   Future<void> _downloadLoop(AbortController abort) async {
@@ -175,7 +188,12 @@ class StreamingSyncImplementation implements StreamingSync {
       // On error, wait a little before retrying
       // When aborting, don't wait
       if (!abort.aborted && delayNextIteration) {
-        await _delayRetry(abort);
+        final (retryDelay, completeEarly) = _delayOr(_retryDelay);
+        _checkpointState.waitForCheckpointWaiter().whenComplete(() {
+          completeEarly();
+        });
+
+        await retryDelay;
       }
     }
   }
@@ -227,9 +245,13 @@ class StreamingSyncImplementation implements StreamingSync {
           _state.updateStatus((s) => s.uploadError = null);
         } else {
           // Uploading is completed
-          didCompleteUpload = await adapter.updateTargetCheckpointRequest(
-            () => getWriteCheckpoint(abort),
-          );
+          didCompleteUpload = await adapter.updateTargetCheckpointRequest(() {
+            if (options.checkpointMode is LegacyCheckpointMode) {
+              return _getLegacyWriteCheckpoint(abort);
+            } else {
+              return _requestNextCheckpointFromService(abort);
+            }
+          });
           break;
         }
       } catch (e, stacktrace) {
@@ -269,13 +291,79 @@ class StreamingSyncImplementation implements StreamingSync {
     request.headers.addAll(_userAgentHeaders);
   }
 
-  Future<String> getWriteCheckpoint(AbortController abort) async {
+  Future<String> _requestNextCheckpointFromService(AbortController abort) {
+    return abort.scoped((abortTrigger) async {
+      await _checkpointState.waitForCheckpointRequestsReady(
+        abort: abortTrigger,
+      );
+
+      final nextCheckpointRequestId = await adapter.writeTransaction(
+        onAbort: abortTrigger,
+        (tx) => tx.nextCheckpointRequestId(),
+      );
+      return await _requestCheckpointFromService(
+        checkpointRequest: nextCheckpointRequestId!,
+        abortTrigger: abortTrigger,
+      );
+    });
+  }
+
+  Future<String> _requestCheckpointFromService({
+    required String checkpointRequest,
+    required Future<void> abortTrigger,
+    String? clientId,
+  }) async {
+    clientId ??= await _resolveClientId();
+
+    // First, check if we can use a custom checkpoint request implementation.
+    if (await connector.postCheckpointRequest(clientId, checkpointRequest)
+        case final customResponse?) {
+      return customResponse;
+    }
+
+    final credentials = await connector.getCredentialsCached();
+    if (credentials == null) {
+      throw CredentialsException("Not logged in");
+    }
+    final uri = credentials.endpointUri('sync/checkpoint-request');
+
+    final request = http.AbortableRequest(
+      'POST',
+      uri,
+      abortTrigger: abortTrigger,
+    );
+    request.body = convert.jsonEncode({
+      'client_id': clientId,
+      'checkpoint_request_id': checkpointRequest,
+    });
+    _applyCommonHeaders(request, credentials);
+    request.headers['Accept'] = 'application/json';
+    request.headers['Content-Type'] = 'application/json';
+    final response = await http.Response.fromStream(
+      await _client.send(request),
+    );
+
+    if (response.statusCode == 401) {
+      await connector.prefetchCredentials(invalidate: true);
+    }
+    if (response.statusCode == 404) {
+      throw checkpoint.instanceNotSupported;
+    }
+    if (response.statusCode != 200) {
+      throw SyncResponseException.fromResponse(response);
+    }
+
+    final body = convert.jsonDecode(response.body);
+    return body['data']['checkpoint_request_id'] as String;
+  }
+
+  Future<String> _getLegacyWriteCheckpoint(AbortController abort) async {
     final credentials = await connector.getCredentialsCached();
     if (credentials == null) {
       throw CredentialsException("Not logged in");
     }
     final uri = credentials.endpointUri(
-      'write-checkpoint2.json?client_id=$clientId',
+      'write-checkpoint2.json?client_id=${await _resolveClientId()}',
     );
 
     final response = await abort.scoped((onAbort) async {
@@ -343,28 +431,119 @@ class StreamingSyncImplementation implements StreamingSync {
     return res;
   }
 
+  /// Watches the current checkpoint request i to re-request it if we take too
+  /// long to receive it.
+  ///
+  /// This does not require navigator locks: It waits for checkpoints to be
+  /// seeded, which can only happen in the context of a download loop.
+  ///
+  /// Note that requesting checkpoints with ids the service has already seen is
+  /// a cheap no-op.
+  Future<void> _repostUnacknowledgedCheckpointRequests(
+    AbortController abort,
+  ) async {
+    final Duration retryDelay;
+    switch (options.checkpointMode) {
+      case RequestsCheckpointMode(retryDelay: final delay):
+        retryDelay = delay;
+      default:
+        return;
+    }
+
+    while (!abort.aborted) {
+      try {
+        await abort.scoped((abortSignal) {
+          return _repostCurrentCheckpointRequestAfterDelay(
+            retryDelay,
+            abortSignal,
+          );
+        });
+      } on Exception catch (e, s) {
+        if (abort.aborted) return;
+
+        logger.warning('Error retrying checkpoint request', e, s);
+        await _delayRetry(abort, retryDelay);
+      }
+    }
+  }
+
+  Future<void> _repostCurrentCheckpointRequestAfterDelay(
+    Duration retryDelay,
+    Future<void> abortSignal,
+  ) async {
+    Future<Int64?> currentCheckpointRequestId() {
+      return adapter.writeTransaction(onAbort: abortSignal, (tx) async {
+        final textRequestId = await tx.currentCheckpointRequestId();
+        return textRequestId == null ? null : Int64.parse(textRequestId);
+      });
+    }
+
+    await _checkpointState.waitForCheckpointRequestsReady(
+      abort: abortSignal,
+      wakeDownloadLoop: false,
+    );
+
+    final requestId = await currentCheckpointRequestId();
+    // Give the request some time to sync.
+    {
+      final (delay, complete) = _delayOr(retryDelay);
+      abortSignal.whenComplete(complete);
+      await delay;
+    }
+
+    // If a new request was made, reset the timer.
+    if (requestId == null || requestId != await currentCheckpointRequestId()) {
+      return;
+    }
+
+    // If the request was applied, we don't need to retry.
+    if (_state.status.lastAppliedCheckpointRequestId case final lastApplied?
+        when lastApplied >= requestId) {
+      return;
+    }
+
+    // Make sure we're online and ready before making the request.
+    await _checkpointState.waitForCheckpointRequestsReady(
+      abort: abortSignal,
+      wakeDownloadLoop: false,
+    );
+
+    // It's safe if this request races with a new one. The service will
+    // reject it.
+    logger.fine('Retry checkpoint request $requestId');
+    await _requestCheckpointFromService(
+      checkpointRequest: requestId.toString(),
+      abortTrigger: abortSignal,
+    );
+  }
+
   /// Delays for [duration] or [_retryDelay], but exits early if an abort has
   /// been requested.
   Future<void> _delayRetry(AbortController abort, [Duration? duration]) {
     return abort.scoped((onAbort) {
-      // Don't use Future.delayed here! Its timer can't be cancelled, which
-      // keeps sync isolates alive for longer than necessary.
-      final completer = Completer<void>.sync();
-      Timer? timer;
-
-      void complete() {
-        if (!completer.isCompleted) {
-          timer?.cancel();
-          timer = null;
-          completer.complete();
-        }
-      }
-
-      timer = Timer(duration ?? _retryDelay, complete);
+      final (future, complete) = _delayOr(duration ?? _retryDelay);
       onAbort.whenComplete(complete);
-      return completer.future;
+      return future;
     });
   }
+}
+
+/// Returns a future that completes after the [delay] or when the returned
+/// function is called.
+(Future<void>, void Function()) _delayOr(Duration delay) {
+  final completer = Completer<void>.sync();
+  Timer? timer;
+
+  void complete() {
+    if (!completer.isCompleted) {
+      timer?.cancel();
+      timer = null;
+      completer.complete();
+    }
+  }
+
+  timer = Timer(delay, complete);
+  return (completer.future, complete);
 }
 
 /// Attempt to give a basic summary of the error for cases where the full error
@@ -418,11 +597,15 @@ final class _ActiveRustStreamingIteration {
 
       for (final startInstruction in await _startCommand()) {
         switch (startInstruction) {
-          case EstablishSyncStream(:final request):
+          case EstablishSyncStream(:final request, :final checkpointRequest):
             events = addBroadcast(
               _receiveLines(request, onAbort),
               sync._nonLineSyncEvents.stream,
             );
+
+            if (checkpointRequest != null) {
+              _seedCheckpointRequests(checkpointRequest, onAbort);
+            }
           case CloseSyncStream():
             return defaultResult;
           case final NonInterruptingInstruction other:
@@ -448,8 +631,37 @@ final class _ActiveRustStreamingIteration {
         'schema': convert.json.decode(sync.schemaJson),
         'include_defaults': sync.options.includeDefaultStreams,
         'active_streams': _encodeSubscriptions(sync._activeSubscriptions),
+        'checkpoint_mode': sync.options.checkpointMode is RequestsCheckpointMode
+            ? 'requests'
+            : 'legacy',
       }),
     );
+  }
+
+  void _seedCheckpointRequests(
+    CheckpointRequestPayload payload,
+    Future<void> abortTrigger,
+  ) async {
+    try {
+      await sync._checkpointState.markCheckpointsReady(
+        Future(() async {
+          final seed = await sync._requestCheckpointFromService(
+            checkpointRequest: payload.checkpointRequestId,
+            abortTrigger: abortTrigger,
+            clientId: payload.clientId,
+          );
+
+          sync.adapter.writeTransaction(
+            (tx) => tx.seedCheckpointRequestId(seed),
+            onAbort: abortTrigger,
+          );
+        }),
+      );
+    } catch (e, s) {
+      if (!_aborted) {
+        sync._nonLineSyncEvents.add(CheckpointSeedFailed(e, s));
+      }
+    }
   }
 
   Stream<SyncEvent> _receiveLines(Object? data, Future<void> onAbort) {
@@ -497,6 +709,8 @@ final class _ActiveRustStreamingIteration {
               'update_subscriptions',
               convert.json.encode(_encodeSubscriptions(currentSubscriptions)),
             );
+          case CheckpointSeedFailed(:final error, :final trace):
+            Error.throwWithStackTrace(error, trace);
         }
 
         for (final instruction in instructions) {
@@ -619,6 +833,13 @@ final class HandleChangedSubscriptions implements SyncEvent {
   final List<SubscribedStream> currentSubscriptions;
 
   HandleChangedSubscriptions(this.currentSubscriptions);
+}
+
+final class CheckpointSeedFailed implements SyncEvent {
+  final Object error;
+  final StackTrace trace;
+
+  CheckpointSeedFailed(this.error, this.trace);
 }
 
 extension on AbortController {

--- a/packages/powersync/lib/src/sync/streaming_sync.dart
+++ b/packages/powersync/lib/src/sync/streaming_sync.dart
@@ -461,7 +461,7 @@ class StreamingSyncImplementation implements StreamingSync {
             abortSignal,
           );
         });
-      } on Exception catch (e, s) {
+      } catch (e, s) {
         if (abort.aborted) return;
 
         logger.warning('Error retrying checkpoint request', e, s);

--- a/packages/powersync/lib/src/sync/streaming_sync.dart
+++ b/packages/powersync/lib/src/sync/streaming_sync.dart
@@ -305,7 +305,7 @@ class StreamingSyncImplementation implements StreamingSync {
         (tx) => tx.nextCheckpointRequestId(),
       );
       return await _requestCheckpointFromService(
-        checkpointRequest: nextCheckpointRequestId!,
+        checkpointRequest: nextCheckpointRequestId,
         abortTrigger: abortTrigger,
       );
     });
@@ -667,7 +667,7 @@ final class _ActiveRustStreamingIteration {
     } catch (e, s) {
       // If this was aborted, syncIteration() is about to reset the state
       // anyway.
-      if (!_aborted) {
+      if (!abort.aborted) {
         sync._nonLineSyncEvents.add(CheckpointSeedFailed(e, s));
 
         sync._checkpointState.markCheckpointsFailed(e, s);

--- a/packages/powersync/lib/src/sync/streaming_sync.dart
+++ b/packages/powersync/lib/src/sync/streaming_sync.dart
@@ -665,11 +665,11 @@ final class _ActiveRustStreamingIteration {
 
       sync._checkpointState.markCheckpointsReady();
     } catch (e, s) {
+      // If this was aborted, syncIteration() is about to reset the state
+      // anyway.
       if (!_aborted) {
         sync._nonLineSyncEvents.add(CheckpointSeedFailed(e, s));
 
-        // If this was aborted, syncIteration() is about to reset the state
-        // anyway.
         sync._checkpointState.markCheckpointsFailed(e, s);
       }
     } finally {

--- a/packages/powersync/lib/src/web/sync_controller.dart
+++ b/packages/powersync/lib/src/web/sync_controller.dart
@@ -71,6 +71,18 @@ class SyncWorkerHandle implements StreamingSync {
                   : null,
               null,
             );
+          case SyncWorkerMessageType.customCheckpointRequest:
+            if (connector case final CustomCheckpointRequestConnector custom) {
+              final request = payload as CustomCheckpointRequest;
+              final resolved = await custom.postCheckpointRequest(
+                request.clientId,
+                request.requestId,
+              );
+
+              return (resolved.toJS, null);
+            } else {
+              return (null, null);
+            }
           default:
             throw StateError('Unexpected message type $type');
         }

--- a/packages/powersync/lib/src/web/sync_worker.dart
+++ b/packages/powersync/lib/src/web/sync_worker.dart
@@ -91,6 +91,12 @@ class ConnectedClient {
               httpClient: request.customHttpClient == true
                   ? () => RemoteHttpClient(channel)
                   : null,
+              checkpointMode: switch (request.retryDelayMs) {
+                null => const CheckpointMode.legacy(),
+                final delay => CheckpointMode.requests(
+                  retryDelay: Duration(microseconds: delay),
+                ),
+              },
             );
 
             _runner = _worker._referenceSyncTask(

--- a/packages/powersync/lib/src/web/sync_worker.dart
+++ b/packages/powersync/lib/src/web/sync_worker.dart
@@ -93,8 +93,8 @@ class ConnectedClient {
                   : null,
               checkpointMode: switch (request.checkpointModeRequestsDelay) {
                 null => const CheckpointMode.legacy(),
-                final delay => CheckpointMode.requests(
-                  retryDelay: Duration(microseconds: delay),
+                final delay => RequestsCheckpointMode.unverifiedDuration(
+                  Duration(microseconds: delay),
                 ),
               },
             );

--- a/packages/powersync/lib/src/web/sync_worker.dart
+++ b/packages/powersync/lib/src/web/sync_worker.dart
@@ -91,7 +91,7 @@ class ConnectedClient {
               httpClient: request.customHttpClient == true
                   ? () => RemoteHttpClient(channel)
                   : null,
-              checkpointMode: switch (request.retryDelayMs) {
+              checkpointMode: switch (request.checkpointModeRequestsDelay) {
                 null => const CheckpointMode.legacy(),
                 final delay => CheckpointMode.requests(
                   retryDelay: Duration(microseconds: delay),
@@ -335,6 +335,12 @@ class SyncRunner {
           return await client.channel.invalidCredentialsCallback();
         },
         uploadCrud: client.channel.uploadCrud,
+        postCheckpointRequests: (clientId, requestId) async {
+          return await client.channel.customCheckpointRequest(
+            clientId,
+            requestId,
+          );
+        },
       ),
       crudUpdateTriggerStream: crudStream,
       options: options,

--- a/packages/powersync/lib/src/web/sync_worker_protocol.dart
+++ b/packages/powersync/lib/src/web/sync_worker_protocol.dart
@@ -50,6 +50,12 @@ enum SyncWorkerMessageType {
   /// The response sends either a [SerializedCredentials] object or an empty
   /// object for uploads.
   uploadCrud,
+
+  /// Invoke [CustomCheckpointRequestConnector.postCheckpointRequest].
+  ///
+  /// For requests, the payload is a [CustomCheckpointRequest]. The response is
+  /// a nullable string.
+  customCheckpointRequest,
   invalidCredentialsCallback,
   credentialsCallback,
 
@@ -381,6 +387,19 @@ extension type SerializedSyncStatus._(JSObject _) implements JSObject {
   }
 }
 
+@anonymous
+extension type CustomCheckpointRequest._(JSObject _) implements JSObject {
+  external factory CustomCheckpointRequest({
+    required JSNumber req,
+    required String clientId,
+    required String requestId,
+  });
+
+  external JSNumber req;
+  external String get clientId;
+  external String get requestId;
+}
+
 final class WorkerCommunicationChannel {
   final Map<int, Completer<JSAny?>> _pendingRequests = {};
   final Completer<void> _closed = Completer();
@@ -450,6 +469,9 @@ final class WorkerCommunicationChannel {
             case SyncWorkerMessageType.invalidCredentialsCallback:
             case SyncWorkerMessageType.uploadCrud:
               requestId = (message.payload as JSNumber).toDartInt;
+            case SyncWorkerMessageType.customCheckpointRequest:
+              requestId =
+                  (message.payload as CustomCheckpointRequest).req.toDartInt;
             case SyncWorkerMessageType.sendHttpRequest:
               final request = message.payload as HttpRequest;
               return _respond(
@@ -650,6 +672,26 @@ final class WorkerCommunicationChannel {
 
   Future<void> uploadCrud() async {
     await _numericRequest(SyncWorkerMessageType.uploadCrud);
+  }
+
+  Future<String?> customCheckpointRequest(
+    String clientId,
+    String requestId,
+  ) async {
+    final (id, completion) = _newRequest();
+    port.postMessage(
+      SyncWorkerMessage(
+        payload: CustomCheckpointRequest(
+          req: id.toJS,
+          clientId: clientId,
+          requestId: requestId,
+        ),
+        type: SyncWorkerMessageType.customCheckpointRequest.name,
+      ),
+    );
+
+    final response = await completion;
+    return (response as JSString?)?.toDart;
   }
 
   Future<HttpResponse> sendHttpRequest(HttpRequest request) async {

--- a/packages/powersync/lib/src/web/sync_worker_protocol.dart
+++ b/packages/powersync/lib/src/web/sync_worker_protocol.dart
@@ -107,6 +107,7 @@ extension type StartSynchronization._(JSObject _) implements JSObject {
     UpdateSubscriptions? subscriptions,
     String? appMetadataEncoded,
     bool? customHttpClient,
+    int? checkpointModeRequestsDelay,
   });
 
   external String get databaseName;
@@ -120,6 +121,7 @@ extension type StartSynchronization._(JSObject _) implements JSObject {
   external String? get appMetadataEncoded;
   external String get lockName;
   external bool? get customHttpClient;
+  external int? checkpointModeRequestsDelay;
 }
 
 @anonymous
@@ -598,6 +600,11 @@ final class WorkerCommunicationChannel {
           },
           lockName: await lockName,
           customHttpClient: customHttpClient,
+          checkpointModeRequestsDelay: switch (options.checkpointMode) {
+            RequestsCheckpointMode(:final retryDelay) =>
+              retryDelay.inMicroseconds,
+            _ => null,
+          },
         ),
       ),
     );

--- a/packages/powersync/test/server/sync_server/in_memory_sync_server.dart
+++ b/packages/powersync/test/server/sync_server/in_memory_sync_server.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:bson/bson.dart';
@@ -20,6 +21,13 @@ final class MockSyncService {
       'data': {'write_checkpoint': '10'},
     };
   };
+
+  var checkpointRequestsSupported = true;
+  var lastCheckpointRequest = 0;
+  var amountOfCheckpointRequests = 0;
+  Future<void> Function()? beforeCheckpointRequestResponse;
+
+  final _checkpointRequests = StreamController<void>.broadcast();
 
   MockSyncService({this.useBson = false}) {
     router
@@ -58,10 +66,39 @@ final class MockSyncService {
           json.encode(await writeCheckpoint()),
           headers: {'Content-Type': 'application/json'},
         );
+      })
+      ..post('/sync/checkpoint-request', (Request request) async {
+        if (!checkpointRequestsSupported) {
+          return Response.notFound('');
+        }
+
+        final body = jsonDecode(await request.readAsString());
+        final requestId = lastCheckpointRequest = max(
+          lastCheckpointRequest,
+          int.parse(body['checkpoint_request_id'] as String),
+        );
+
+        await beforeCheckpointRequestResponse?.call();
+        amountOfCheckpointRequests++;
+        _checkpointRequests.add(null);
+
+        return Response.ok(
+          jsonEncode({
+            'data': {'checkpoint_request_id': '$requestId'},
+          }),
+        );
       });
   }
 
   Future<Request> get waitForListener => _listener.future;
+
+  Future<void> waitForCheckpointRequest(bool Function() check) async {
+    if (check()) return;
+
+    await for (final _ in _checkpointRequests.stream) {
+      if (check()) return;
+    }
+  }
 
   // Queue events which will be sent to connected clients.
   void addRawEvent(Object data) {

--- a/packages/powersync/test/sync/checkpoint_state_test.dart
+++ b/packages/powersync/test/sync/checkpoint_state_test.dart
@@ -1,0 +1,98 @@
+import 'dart:async';
+
+import 'package:powersync/src/abort_controller.dart';
+import 'package:powersync/src/sync/checkpoint_request.dart';
+import 'package:powersync/src/sync/checkpoint_state.dart';
+import 'package:sqlite_async/sqlite_async.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final neverAbort = Completer<void>().future;
+
+  group('CheckpointStateSignals', () {
+    group('waitForCheckpointrequestsReady', () {
+      test('resolves immediately when already ready', () async {
+        final signals = CheckpointStateSignals();
+        signals.markCheckpointsReady(Future.syncValue(null));
+        await signals.waitForCheckpointRequestsReady(abort: neverAbort);
+      });
+
+      test('rejects when disconnected', () async {
+        final signals = CheckpointStateSignals();
+        signals.disconnect();
+
+        await expectLater(
+          signals.waitForCheckpointRequestsReady(abort: neverAbort),
+          throwsA(disconnected),
+        );
+      });
+
+      test('rejects with the error', () async {
+        final signals = CheckpointStateSignals();
+        final error = Exception('expected init error');
+        signals.markCheckpointsReady(Future.error(error)).ignore();
+
+        await expectLater(
+          signals.waitForCheckpointRequestsReady(abort: neverAbort),
+          throwsA(error),
+        );
+      });
+
+      test('can be aborted', () {
+        final signals = CheckpointStateSignals();
+        final abort = AbortController();
+
+        final pending = signals.waitForCheckpointRequestsReady(
+          abort: abort.onAbort,
+        );
+        abort.abort();
+
+        expect(pending, throwsA(isA<AbortException>()));
+      });
+
+      test('supports concurrent waiters', () {
+        final signals = CheckpointStateSignals();
+
+        final first = signals.waitForCheckpointRequestsReady(abort: neverAbort);
+        final second = signals.waitForCheckpointRequestsReady(
+          abort: neverAbort,
+        );
+
+        signals.markCheckpointsReady(Future.syncValue(null));
+        expect(first, completes);
+        expect(second, completes);
+      });
+    });
+
+    test(
+      'waitForCheckpointWaiter is notified when a caller starts waiting while pending',
+      () async {
+        final signals = CheckpointStateSignals();
+
+        final waiterNotified = signals.waitForCheckpointWaiter();
+        signals.waitForCheckpointRequestsReady(abort: neverAbort);
+
+        expect(waiterNotified, completes);
+      },
+    );
+
+    test(
+      'does not notify waitForCheckpointWaiter when wakeDownloadLoop is false',
+      () async {
+        final signals = CheckpointStateSignals();
+        var didComplete = false;
+
+        signals.waitForCheckpointWaiter().whenComplete(
+          () => didComplete = true,
+        );
+        signals.waitForCheckpointRequestsReady(
+          abort: neverAbort,
+          wakeDownloadLoop: false,
+        );
+
+        await pumpEventQueue();
+        expect(didComplete, isFalse);
+      },
+    );
+  });
+}

--- a/packages/powersync/test/sync/checkpoint_state_test.dart
+++ b/packages/powersync/test/sync/checkpoint_state_test.dart
@@ -13,7 +13,7 @@ void main() {
     group('waitForCheckpointrequestsReady', () {
       test('resolves immediately when already ready', () async {
         final signals = CheckpointStateSignals();
-        signals.markCheckpointsReady(Future.syncValue(null));
+        signals.markCheckpointsReady();
         await signals.waitForCheckpointRequestsReady(abort: neverAbort);
       });
 
@@ -30,7 +30,7 @@ void main() {
       test('rejects with the error', () async {
         final signals = CheckpointStateSignals();
         final error = Exception('expected init error');
-        signals.markCheckpointsReady(Future.error(error)).ignore();
+        signals.markCheckpointsFailed(error, StackTrace.current);
 
         await expectLater(
           signals.waitForCheckpointRequestsReady(abort: neverAbort),
@@ -58,7 +58,7 @@ void main() {
           abort: neverAbort,
         );
 
-        signals.markCheckpointsReady(Future.syncValue(null));
+        signals.markCheckpointsReady();
         expect(first, completes);
         expect(second, completes);
       });

--- a/packages/powersync/test/sync/in_memory_sync_test.dart
+++ b/packages/powersync/test/sync/in_memory_sync_test.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:async/async.dart';
 import 'package:logging/logging.dart';
 import 'package:powersync/powersync.dart';
+import 'package:powersync/src/sync/options.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf_router/shelf_router.dart';
 import 'package:test/test.dart';
@@ -17,22 +18,16 @@ import 'utils.dart';
 
 void main() {
   group('sync client', () {
-    _declareTests(
-      'json',
-      SyncOptions(retryDelay: Duration(milliseconds: 200)),
-      false,
-    );
+    _declareTests('json', false);
 
-    _declareTests(
-      'bson',
-      SyncOptions(retryDelay: Duration(milliseconds: 200)),
-      true,
-    );
+    _declareTests('bson', true);
   });
 }
 
-void _declareTests(String name, SyncOptions options, bool bson) {
+void _declareTests(String name, bool bson) {
   final ignoredLogger = Logger.detached('powersync.test')..level = Level.OFF;
+  const retryDelay = Duration(milliseconds: 200);
+  const defaultOptions = SyncOptions(retryDelay: retryDelay);
 
   group(name, () {
     late final testUtils = TestUtils();
@@ -40,25 +35,37 @@ void _declareTests(String name, SyncOptions options, bool bson) {
     late TestDatabase database;
     late MockSyncService syncService;
     late Logger logger;
+    late Server mockServer;
 
     var credentialsCallbackCount = 0;
     Future<void> Function(PowerSyncDatabase) uploadData = (db) async {};
 
-    Future<void> connect() async {
+    Future<PowerSyncCredentials> credentialsCallback() async {
+      credentialsCallbackCount++;
+      return PowerSyncCredentials(
+        endpoint: mockServer.url.toString(),
+        token: 'token$credentialsCallbackCount',
+        expiresAt: DateTime.now(),
+      );
+    }
+
+    Future<void> connect({
+      PowerSyncBackendConnector? connector,
+      SyncOptions? options,
+    }) async {
       final (client, server) = inMemoryServer();
       server.mount((req) => syncService.router(req));
+      mockServer = server;
 
       database.httpClient = client;
       await database.connect(
-        connector: TestConnector(() async {
-          credentialsCallbackCount++;
-          return PowerSyncCredentials(
-            endpoint: server.url.toString(),
-            token: 'token$credentialsCallbackCount',
-            expiresAt: DateTime.now(),
-          );
-        }, uploadData: (db) => uploadData(db)),
-        options: options,
+        connector:
+            connector ??
+            TestConnector(
+              credentialsCallback,
+              uploadData: (db) => uploadData(db),
+            ),
+        options: options ?? defaultOptions,
       );
     }
 
@@ -67,7 +74,7 @@ void _declareTests(String name, SyncOptions options, bool bson) {
       credentialsCallbackCount = 0;
       syncService = MockSyncService(useBson: bson);
 
-      (_, database) = await testUtils.openInMemoryDatabase();
+      (_, database) = await testUtils.openInMemoryDatabase(logger: logger);
       await database.initialize();
     });
 
@@ -77,6 +84,8 @@ void _declareTests(String name, SyncOptions options, bool bson) {
     });
 
     Future<StreamQueue<SyncStatus>> waitForConnection({
+      PowerSyncBackendConnector? connector,
+      SyncOptions? options,
       bool expectNoWarnings = true,
       bool addKeepLive = true,
     }) async {
@@ -87,7 +96,7 @@ void _declareTests(String name, SyncOptions options, bool bson) {
           }
         });
       }
-      await connect();
+      await connect(connector: connector, options: options);
       await syncService.waitForListener;
 
       expect(database.currentStatus.lastSyncedAt, isNull);
@@ -976,6 +985,235 @@ void _declareTests(String name, SyncOptions options, bool bson) {
         });
 
       expect(await query.next, 'from server');
+    });
+
+    group('checkpoint requests', () {
+      final options = SyncOptions(
+        checkpointMode: CheckpointMode.requests(),
+        retryDelay: retryDelay,
+      );
+
+      test(
+        'warns for custom connectors without requests being enabled',
+        () async {
+          final records = <LogRecord>[];
+          logger.onRecord.listen(records.add);
+
+          await waitForConnection(
+            connector: TestCustomCheckpointConnector(
+              credentialsCallback,
+              postCheckpointRequest: (_, _) async {
+                return 'stub';
+              },
+            ),
+            expectNoWarnings: false,
+          );
+
+          expect(
+            records,
+            contains(
+              isA<LogRecord>().having(
+                (e) => e.message,
+                'message',
+                contains(
+                  'CustomCheckpointRequestConnector was used with legacy checkpoints',
+                ),
+              ),
+            ),
+          );
+        },
+      );
+
+      test('requests checkpoints for updates', () async {
+        await waitForConnection(options: options);
+        await syncService.waitForCheckpointRequest(
+          () => syncService.lastCheckpointRequest == 1,
+        );
+        uploadData = (db) async {
+          if (await db.getCrudBatch() case final batch?) {
+            await batch.complete();
+          }
+        };
+
+        await database.execute(
+          'INSERT INTO customers (id, name, email) VALUES (?, uuid(), uuid())',
+          ['id'],
+        );
+        final customers = StreamQueue(
+          database.watch('SELECT * FROM customers'),
+        );
+        await expectLater(customers, emits(hasLength(1)));
+
+        // The local write should eventually be uploaded.
+        await syncService.waitForCheckpointRequest(
+          () => syncService.lastCheckpointRequest == 2,
+        );
+
+        syncService
+          ..addLine(
+            checkpoint(
+              lastOpId: 1,
+              writeCheckpoint: '2',
+              buckets: [bucketDescription('a')],
+            ),
+          )
+          ..addLine({
+            'data': {
+              'bucket': 'a',
+              'data': [
+                {
+                  'checksum': 0,
+                  'op': 'REMOVE',
+                  'op_id': '1',
+                  'object_id': 'id',
+                  'object_type': 'customers',
+                },
+              ],
+            },
+          })
+          ..addLine(checkpointComplete(lastOpId: '1'));
+        await expectLater(customers, emits(isEmpty));
+      });
+
+      test(
+        'reports download error when requesting checkpoints fails',
+        () async {
+          syncService.checkpointRequestsSupported = false;
+          final status = StreamQueue(database.statusStream);
+          addTearDown(status.cancel);
+
+          await connect(options: options);
+          await expectLater(
+            database.statusStream,
+            emitsThrough(isSyncStatus(downloadError: isNotNull)),
+          );
+        },
+      );
+
+      test('reposts current checkpoint until applied', () async {
+        await waitForConnection(
+          options: SyncOptions(
+            retryDelay: retryDelay,
+            checkpointMode: RequestsCheckpointMode.unverifiedDuration(
+              Duration(milliseconds: 50),
+            ),
+          ),
+        );
+
+        // Because we didn't include the checkpoint in a sync response, it
+        // should keep getting requested.
+        await syncService.waitForCheckpointRequest(
+          () => syncService.amountOfCheckpointRequests == 10,
+        );
+
+        // Finally, include the checkpoint.
+        syncService.addLine(checkpoint(lastOpId: 0, writeCheckpoint: '1'));
+        syncService.addLine(checkpointComplete(lastOpId: '0'));
+        await database.waitForFirstSync();
+
+        final requestsBefore = syncService.amountOfCheckpointRequests;
+        await Future<void>.delayed(Duration(seconds: 1));
+        expect(
+          syncService.amountOfCheckpointRequests,
+          requestsBefore,
+          reason: 'Should not keep posting checkpoint requests',
+        );
+      });
+
+      test('download is retried on checkpoint request', () async {
+        final status = await waitForConnection(
+          options: SyncOptions(
+            retryDelay: Duration(seconds: 10),
+            checkpointMode: CheckpointMode.requests(),
+          ),
+          expectNoWarnings: false,
+        );
+        uploadData = (db) async {
+          if (await db.getCrudBatch() case final batch?) {
+            await batch.complete();
+          }
+        };
+
+        // Destroy the initial connection by sending a bogus line.
+        final sw = Stopwatch();
+        syncService.addLine(
+          checkpoint(lastOpId: 1, writeCheckpoint: 'invalid line'),
+        );
+        await expectLater(
+          status,
+          emitsThrough(isSyncStatus(downloadError: isNotNull)),
+        );
+        syncService.endCurrentListener();
+
+        // Trigger an upload here. Because the upload needs a seeded sync
+        // iteration, we should reconnect immediately instead of after the
+        // configured 10s delay.
+        await database.execute(
+          'INSERT INTO customers (id, email, name) VALUES (uuid(), uuid(), uuid())',
+        );
+        await expectLater(status, emitsThrough(isSyncStatus(connected: true)));
+        final elapsed = sw.elapsed;
+
+        expect(elapsed, lessThan(Duration(seconds: 5)));
+      });
+
+      test('can use checkpoint method from connector', () async {
+        final didRequestCheckpoint = Completer<void>();
+        await waitForConnection(
+          connector: TestCustomCheckpointConnector(
+            credentialsCallback,
+            postCheckpointRequest: (clientId, requestId) async {
+              expect(requestId, '1');
+              didRequestCheckpoint.complete();
+              return requestId;
+            },
+          ),
+          options: options,
+        );
+
+        await didRequestCheckpoint.future;
+      });
+
+      test('reconciles checkpoint state on token expiry', () async {
+        syncService.lastCheckpointRequest = 100;
+        await waitForConnection(options: options);
+        await syncService.waitForCheckpointRequest(
+          () => syncService.amountOfCheckpointRequests == 1,
+        );
+        await pumpEventQueue();
+
+        // Simulate what would happen if we suddenly switched users after the
+        // old token expired. The client expects a checkpoint of 100, for
+        // another user the service wouldn't have that counter yet. The client
+        // must request a checkpoint with the existing id, allowing the service
+        // to recognize that this device + user combo needs higher checkpoint
+        // ids.
+        syncService.lastCheckpointRequest = 0;
+        syncService.addKeepAlive(0);
+        syncService.endCurrentListener();
+
+        await syncService.waitForCheckpointRequest(
+          () => syncService.amountOfCheckpointRequests == 2,
+        );
+        expect(syncService.lastCheckpointRequest, 100);
+      });
+
+      test('reads sync lines before checkpoint requests are ready', () async {
+        final hasInitialRequest = Completer<void>();
+        final completeInitialRequest = Completer<void>();
+        syncService.beforeCheckpointRequestResponse = () {
+          hasInitialRequest.complete();
+          return completeInitialRequest.future;
+        };
+
+        final status = await waitForConnection(options: options);
+        await hasInitialRequest.future;
+
+        syncService.addLine(checkpoint(lastOpId: 0));
+        await expectLater(status, emits(isSyncStatus(downloading: true)));
+
+        completeInitialRequest.complete();
+      });
     });
 
     test('checkpoint request can be aborted', () async {

--- a/packages/powersync/test/sync/in_memory_sync_test.dart
+++ b/packages/powersync/test/sync/in_memory_sync_test.dart
@@ -1029,6 +1029,8 @@ void _declareTests(String name, bool bson) {
         await syncService.waitForCheckpointRequest(
           () => syncService.lastCheckpointRequest == 1,
         );
+        await pumpEventQueue();
+
         uploadData = (db) async {
           if (await db.getCrudBatch() case final batch?) {
             await batch.complete();
@@ -1135,7 +1137,7 @@ void _declareTests(String name, bool bson) {
         };
 
         // Destroy the initial connection by sending a bogus line.
-        final sw = Stopwatch();
+        final sw = Stopwatch()..start();
         syncService.addLine(
           checkpoint(lastOpId: 1, writeCheckpoint: 'invalid line'),
         );

--- a/packages/powersync/test/sync/streaming_sync_test.dart
+++ b/packages/powersync/test/sync/streaming_sync_test.dart
@@ -280,6 +280,27 @@ void main() {
 
       expect(pdb.currentStatus.downloadError, exception);
     });
+
+    test('can use custom checkpoint requests', () async {
+      final hadRequest = Completer<void>();
+      final pdb = await testUtils.setupPowerSync(path: path);
+      final server = await createServer();
+      final connector = TestCustomCheckpointConnector(
+        () async =>
+            PowerSyncCredentials(endpoint: server.endpoint, token: 'token'),
+        postCheckpointRequest: (clientId, requestId) async {
+          expect(requestId, '1');
+          hadRequest.complete();
+          return requestId;
+        },
+      );
+
+      await pdb.connect(
+        connector: connector,
+        options: SyncOptions(checkpointMode: CheckpointMode.requests()),
+      );
+      await hadRequest.future;
+    });
   });
 }
 

--- a/packages/powersync/test/sync/utils.dart
+++ b/packages/powersync/test/sync/utils.dart
@@ -10,6 +10,7 @@ TypeMatcher<SyncStatus> isSyncStatus({
   Object? hasSynced,
   Object? downloadProgress,
   Object? syncStreams,
+  Object? downloadError,
 }) {
   var matcher = isA<SyncStatus>();
   if (downloading != null) {
@@ -33,6 +34,13 @@ TypeMatcher<SyncStatus> isSyncStatus({
   }
   if (syncStreams != null) {
     matcher = matcher.having((e) => e.syncStreams, 'syncStreams', syncStreams);
+  }
+  if (downloadError != null) {
+    matcher = matcher.having(
+      (e) => e.downloadError,
+      'downloadError',
+      downloadError,
+    );
   }
 
   return matcher;
@@ -114,7 +122,7 @@ Object checkpoint({
   return {
     'checkpoint': {
       'last_op_id': '$lastOpId',
-      'write_checkpoint': null,
+      'write_checkpoint': writeCheckpoint,
       'buckets': buckets,
       'streams': streams,
     },

--- a/packages/powersync/test/utils/abstract_test_utils.dart
+++ b/packages/powersync/test/utils/abstract_test_utils.dart
@@ -154,6 +154,21 @@ class TestConnector extends PowerSyncBackendConnector {
   }
 }
 
+final class TestCustomCheckpointConnector extends TestConnector
+    with CustomCheckpointRequestConnector {
+  final Future<String> Function(String, String) _postCheckpointRequest;
+
+  TestCustomCheckpointConnector(
+    super.fetchCredentialsCallback, {
+    required Future<String> Function(String, String) postCheckpointRequest,
+  }) : _postCheckpointRequest = postCheckpointRequest;
+
+  @override
+  Future<String> postCheckpointRequest(String clientId, String requestId) {
+    return _postCheckpointRequest(clientId, requestId);
+  }
+}
+
 /// A [PowerSyncDatabase] implemented by a single in-memory database connection
 /// and a mock-HTTP sync client.
 ///

--- a/packages/powersync/test/web/sync_worker_test.dart
+++ b/packages/powersync/test/web/sync_worker_test.dart
@@ -22,6 +22,8 @@ void main() {
   late SyncWorker syncWorker;
   late PowerSyncDatabase db;
 
+  var dbId = 0;
+
   setUpAll(() async {
     utils = TestUtils();
   });
@@ -29,7 +31,10 @@ void main() {
   setUp(() async {
     syncWorker = SyncWorker();
 
-    db = await utils.setupPowerSync(logger: Logger.detached('test_logger'));
+    db = await utils.setupPowerSync(
+      path: 'sync-worker-test-${dbId++}',
+      logger: Logger.detached('test_logger'),
+    );
     await db.initialize();
   });
 
@@ -154,6 +159,7 @@ void main() {
     service.waitForCheckpointRequest(
       () => service.amountOfCheckpointRequests > 0,
     );
+    await handle.abort();
   });
 
   test('can use custom checkpoint connector', () async {
@@ -181,6 +187,7 @@ void main() {
     );
     await handle.streamingSync();
     await didRequestCheckpoint.future;
+    await handle.abort();
   });
 }
 

--- a/packages/powersync/test/web/sync_worker_test.dart
+++ b/packages/powersync/test/web/sync_worker_test.dart
@@ -131,6 +131,57 @@ void main() {
     await handle.streamingSync();
     await db.waitForFirstSync();
   });
+
+  test('can use requests mode', () async {
+    final (client, server) = inMemoryServer();
+    final service = MockSyncService();
+    server.mount((r) => service.router(r));
+
+    final handle = createWorkerHandle(
+      connector: TestConnector(
+        () async => PowerSyncCredentials(
+          endpoint: 'http://test.powersync.example.org',
+          token: 'token',
+        ),
+      ),
+      options: SyncOptions(
+        httpClient: () => client,
+        checkpointMode: CheckpointMode.requests(),
+      ),
+    );
+    await handle.streamingSync();
+
+    service.waitForCheckpointRequest(
+      () => service.amountOfCheckpointRequests > 0,
+    );
+  });
+
+  test('can use custom checkpoint connector', () async {
+    final (client, server) = inMemoryServer();
+    final service = MockSyncService();
+    server.mount((r) => service.router(r));
+    final didRequestCheckpoint = Completer<void>();
+
+    final handle = createWorkerHandle(
+      connector: TestCustomCheckpointConnector(
+        () async => PowerSyncCredentials(
+          endpoint: 'http://test.powersync.example.org',
+          token: 'token',
+        ),
+        postCheckpointRequest: (clientId, checkpoint) async {
+          expect(checkpoint, '1');
+          didRequestCheckpoint.complete();
+          return checkpoint;
+        },
+      ),
+      options: SyncOptions(
+        httpClient: () => client,
+        checkpointMode: CheckpointMode.requests(),
+      ),
+    );
+    await handle.streamingSync();
+    await didRequestCheckpoint.future;
+  });
 }
 
 final class _ThrowingBackendConnector extends PowerSyncBackendConnector {


### PR DESCRIPTION
This adds support for the new checkpoint request protocol. The implementation is mostly a port from the [JavaScript](https://github.com/powersync-ja/powersync-js/pull/1072) and [Kotlin](https://github.com/powersync-ja/powersync-kotlin/pull/371) PRs.

Dart-specific work in this PR is mostly related to the explicit RPC protocol used to expose custom checkpoint connectors to the sync isolate and sync worker, and the lack of a consistent 64-bit integer type across platforms.

Closes https://github.com/powersync-ja/powersync.dart/issues/464

AI use: Reviewed with Claude Code.