### PR TITLE
Prepare 2.4.0 release

### DIFF
--- a/packages/js-assets/package.json
+++ b/packages/js-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powersync/dart-wasm-bundles",
-  "version": "2.3.3",
+  "version": "2.4.0",
   "description": "Pre-compiled PowerSync Dart SDK assets.",
   "type": "module",
   "publishConfig": {

--- a/packages/powersync/CHANGELOG.md
+++ b/packages/powersync/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.4.0 (unreleased)
+## 2.4.0
 
 - Add `SyncOptions.checkpointMode`, which can be used to replace a legacy implementation for write checkpoints
   with a newer and more efficient endpoint.

--- a/packages/powersync/lib/src/version.dart
+++ b/packages/powersync/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String libraryVersion = '2.3.3';
+const String libraryVersion = '2.4.0';

--- a/packages/powersync/pubspec.yaml
+++ b/packages/powersync/pubspec.yaml
@@ -1,5 +1,5 @@
 name: powersync
-version: 2.3.3
+version: 2.4.0
 homepage: https://powersync.com
 repository: https://github.com/powersync-ja/powersync.dart
 description: PowerSync Dart and Flutter SDK. Sync Postgres, MongoDB, MySQL or SQL Server with SQLite in your app


### PR DESCRIPTION
Update version numbers to 2.4.0 to prepare the release. This version adds support for checkpoint requests, reduces log noise from the attachments implementation and fixes unsendable errors (e.g. from dio) disrupting the sync isolate. 